### PR TITLE
Establish initial contrib docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing guidelines
+
+So, you want to hack on Istio Mixer? Yay!
+
+## Developer Guide
+
+We have a [Developer's Guide](docs/devel/development.md) that outlines everything
+you need to know to contribute. If you find something undocumented or incorrect
+along the way, please feel free to send a Pull Request.
+
+## Filing issues
+
+If you have a question about Istio Mixer or have a problem using it, please
+[file an issue](https://github.com/istio/mixer/issues/new).
+
+[//]: # (TODO: add troubleshooting guide)
+
+## How to become a contributor and submit your own code
+
+### Contributor License Agreements
+
+We'd love to accept your patches! Before we can take them, we have to jump a
+couple of legal hurdles.
+
+Please fill out the Cloud Native Computing Foundation (CNCF) CLA.
+
+CNCF:
+  * To contribute as an individual or as am employee of a signed organization,
+    [go here](https://identity.linuxfoundation.org/projects/cncf).
+  * To sign up as an organization, [go
+    here](https://identity.linuxfoundation.org/node/285/organization-signup).
+
+Once you are CLA'ed, we'll be able to accept your pull requests.
+
+***NOTE***: Only original source code from you and other people that have
+signed the CLA can be accepted into the repository. This policy does not
+apply to [third_party](third_party/) and [vendor](vendor/).
+
+### Finding Things That Need Help
+
+[//]: # (TODO: fill out)
+
+### Contributing A Patch
+
+If you're working on an existing issue, simply respond to the issue and express
+interest in working on it. This helps other people know that the issue is
+active, and hopefully prevents duplicated efforts.
+
+If you want to work on a new idea of relatively small scope:
+
+1. Submit an issue describing your proposed change to the repo in question.
+1. The repo owners will respond to your issue promptly.
+1. If your proposed change is accepted, and you haven't already done so, sign a
+   Contributor License Agreement (see details above).
+1. Fork the repo, develop, and test your changes.
+1. Submit a pull request.
+
+TODO: document how to deal with bigger issues
+
+### Downloading the project
+
+There are a few ways you can download this code. You must download it into a
+GOPATH - see [golang.org](https://golang.org/doc/code.html) for more info on
+how Go works with code. This project expects to be found at the Go package
+`github.com/istio/mixer/`.
+
+1. You can `git clone` the repo. If you do this, you MUST make sure it is in
+   the GOPATH as `github.com/istio/mixer` or it may not build.  E.g.: `git clone
+   https://github.com/kubernetes/kubernetes $GOPATH/src/github.com/istio/mixer`
+1. You can use `go get` to fetch the repo. This will automatically put it into
+   your GOPATH in the right place. E.g.: `go get -d github.com/istio/mixer`
+
+
+### Building the project
+
+There are a few things you need to build and test this project:
+
+1. `make` - the human interface to the Istio Mixer build is `make`, so you must
+   have this tool installed on your machine. We try not to use too many crazy
+   features of `Makefile`s and other tools, so most commonly available versions
+   should work.
+1. `go` - Istio Mixer is written in Go (aka golang), so you need a relatively
+   recent version of the [Go toolchain](https://golang.org/dl/) installed.
+   While Linux is the primary platform for Istio Mixer, it should compile on a
+   Mac, too. Windows is in progress.
+
+To build Istio Mixer, simply type `make`.  This should figure out what it needs
+to do and not need any input from you.
+
+To run basic tests, simply type `make test`.  This will run all of the unit
+tests in the project.
+
+### Protocols for Collaborative Development
+
+Please read [this doc](docs/devel/collab.md) for information on how we're
+running development for the project.  Also take a look at the [development
+guide](docs/devel/development.md) for information on how to set up your
+environment, run tests, manage dependencies, etc.
+
+### Adding dependencies
+
+[//]: # (TODO: add bits on glide here)
+
+### Community Expectations
+
+Please see our [expectations](docs/devel/community-expectations.md) for members
+of the Istio Mixer community.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+## Istio Mixer Community Code of Conduct
+
+Istio Mixer follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/docs/devel/coding-conventions.md
+++ b/docs/devel/coding-conventions.md
@@ -1,0 +1,104 @@
+# Coding Conventions
+
+## Code conventions
+
+  - Go
+
+[//]: # (TODO: Add info about presubmits here when applicable)
+
+    - [Go Code Review
+Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+
+    - [Effective Go](https://golang.org/doc/effective_go.html)
+
+    - Comment your code.
+      - [Go's commenting
+conventions](http://blog.golang.org/godoc-documenting-go-code)
+      - If reviewers ask questions about why the code is the way it is, that's a
+sign that comments might be helpful.
+
+
+    - Command-line flags should use dashes, not underscores
+
+
+    - Naming
+      - Please consider package name when selecting an interface name, and avoid
+redundancy.
+
+          - e.g.: `storage.Interface` is better than `storage.StorageInterface`.
+
+      - Do not use uppercase characters, underscores, or dashes in package
+names.
+      - Please consider parent directory name when choosing a package name.
+
+          - so pkg/controllers/autoscaler/foo.go should say `package autoscaler`
+not `package autoscalercontroller`.
+
+[//]: # (TODO: replace with istio mixer specific example)
+
+          - Unless there's a good reason, the `package foo` line should match
+the name of the directory in which the .go file exists.
+          - Importers can use a different name if they need to disambiguate.
+
+      - Locks should be called `lock` and should never be embedded (always `lock
+sync.Mutex`). When multiple locks are present, give each lock a distinct name
+following Go conventions - `stateLock`, `mapLock` etc.
+
+    - [Logging conventions](logging.md)
+
+## Testing conventions
+
+  - All new packages and most new significant functionality must come with unit
+tests
+
+  - Table-driven tests are preferred for testing multiple scenarios/inputs
+
+[//]: # (TODO: add link to example)
+
+  - Significant features should come with integration (test/integration) and/or
+end-to-end tests
+
+  - Avoid waiting for a short amount of time (or without waiting) and expect an
+asynchronous thing to happen (e.g. wait for 1 seconds and expect a Pod to be
+running). Wait and retry instead.
+
+  - See the [testing guide](testing.md) for additional testing advice.
+
+## Directory and file conventions
+
+  - Avoid package sprawl. Find an appropriate subdirectory for new packages.
+
+    - Libraries with no more appropriate home belong in new package
+subdirectories of pkg/util
+
+  - Avoid general utility packages. Packages called "util" are suspect. Instead,
+derive a name that describes your desired function.
+
+  - All filenames should be lowercase
+
+  - Go source files and directories use underscores, not dashes
+    - Package directories should generally avoid using separators as much as
+possible (when packages are multiple words, they usually should be in nested
+subdirectories).
+
+  - Document directories and filenames should use dashes rather than underscores
+
+  - Contrived examples that illustrate system features belong in
+/docs/user-guide or /docs/admin, depending on whether it is a feature primarily
+intended for users that deploy applications or cluster administrators,
+respectively. Actual application examples belong in /examples.
+
+  - Third-party code
+
+    - Go code for normal third-party dependencies is managed using
+[glide](https://github.com/Masterminds/glide)
+
+    - Third-party code must include licenses
+
+    - This includes modified third-party code and excerpts, as well
+
+## Coding advice
+
+  - Go
+
+    - [Go landmines](https://gist.github.com/lavalamp/4bd23295a9f32706a48f)

--- a/docs/devel/collab.md
+++ b/docs/devel/collab.md
@@ -1,0 +1,82 @@
+# On Collaborative Development
+
+Istio Mixer is open source, but many of the people working on it do so as their
+day job. In order to avoid forcing people to be "at work" effectively 24/7, we
+want to establish some semi-formal protocols around development. Hopefully these
+rules make things go more smoothly. If you find that this is not the case,
+please complain loudly.
+
+## Patches welcome
+
+First and foremost: as a potential contributor, your changes and ideas are
+welcome at any hour of the day or night, weekdays, weekends, and holidays.
+Please do not ever hesitate to ask a question or send a PR.
+
+## Code reviews
+
+All changes must be code reviewed. For non-maintainers this is obvious, since
+you can't commit anyway. But even for maintainers, we want all changes to get at
+least one review, preferably (for non-trivial changes obligatorily) from someone
+who knows the areas the change touches. For non-trivial changes we may want two
+reviewers. The primary reviewer will make this decision and nominate a second
+reviewer, if needed. Except for trivial changes, PRs should not be committed
+until relevant parties (e.g. owners of the subsystem affected by the PR) have
+had a reasonable chance to look at PR in their local business hours.
+
+Most PRs will find reviewers organically. If a maintainer intends to be the
+primary reviewer of a PR they should set themselves as the assignee on GitHub
+and say so in a reply to the PR. Only the primary reviewer of a change should
+actually do the merge, except in rare cases (e.g. they are unavailable in a
+reasonable timeframe).
+
+If a PR has gone 2 work days without an owner emerging, please poke the PR
+thread and ask for a reviewer to be assigned.
+
+Except for rare cases, such as trivial changes (e.g. typos, comments) or
+emergencies (e.g. broken builds), maintainers should not merge their own
+changes.
+
+Expect reviewers to request that you avoid [common go style
+mistakes](https://github.com/golang/go/wiki/CodeReviewComments) in your PRs.
+
+## Assigned reviews
+
+Maintainers can assign reviews to other maintainers, when appropriate. The
+assignee becomes the shepherd for that PR and is responsible for merging the PR
+once they are satisfied with it or else closing it. The assignee might request
+reviews from non-maintainers.
+
+## Merge hours
+
+Maintainers will do merges of appropriately reviewed-and-approved changes during
+their local "business hours" (typically 7:00 am Monday to 5:00 pm (17:00h)
+Friday). PRs that arrive over the weekend or on holidays will only be merged if
+there is a very good reason for it and if the code review requirements have been
+met. Concretely this means that nobody should merge changes immediately before
+going to bed for the night.
+
+There may be discussion an even approvals granted outside of the above hours,
+but merges will generally be deferred.
+
+If a PR is considered complex or controversial, the merge of that PR should be
+delayed to give all interested parties in all timezones the opportunity to
+provide feedback. Concretely, this means that such PRs should be held for 24
+hours before merging. Of course "complex" and "controversial" are left to the
+judgment of the people involved, but we trust that part of being a committer is
+the judgment required to evaluate such things honestly, and not be motivated by
+your desire (or your cube-mate's desire) to get their code merged. Also see
+"Holds" below, any reviewer can issue a "hold" to indicate that the PR is in
+fact complicated or complex and deserves further review.
+
+PRs that are incorrectly judged to be merge-able, may be reverted and subject to
+re-review, if subsequent reviewers believe that they in fact are controversial
+or complex.
+
+
+## Holds
+
+Any maintainer or core contributor who wants to review a PR but does not have
+time immediately may put a hold on a PR simply by saying so on the PR discussion
+and offering an ETA measured in single-digit days at most. Any PR that has a
+hold shall not be merged until the person who requested the hold acks the
+review, withdraws their hold, or is overruled by a preponderance of maintainers.

--- a/docs/devel/community-expectations.md
+++ b/docs/devel/community-expectations.md
@@ -1,0 +1,80 @@
+## Community Expectations
+
+Istio Mixer is a community project. Consequently, it is wholly dependent on
+its community to provide a productive, friendly and collaborative environment.
+
+The first and foremost goal of the Istio Mixer community to develop technology
+that radically simplifies rpc precondition checking and service telemetry.
+However a second, equally important goal is the creation of a community that
+fosters easy, agile development of such systems.
+
+We therefore describe the expectations for members of the Istio Mixer community.
+This document is intended to be a living one that evolves as the community
+evolves via the same PR and code review process that shapes the rest of the
+project. It currently covers the expectations of conduct that govern all members
+of the community as well as the expectations around code review that govern all
+active contributors to Istio Mixer.
+
+### Code of Conduct
+
+The most important expectation of the Istio Mixer community is that all members
+abide by the Istio Mixer [community code of conduct](../../code-of-conduct.md).
+Only by respecting each other can we develop a productive, collaborative
+community.
+
+### Code review
+
+As a community we believe in the [value of code review for all contributions](collab.md).
+Code review increases both the quality and readability of our codebase, which
+in turn produces high quality software.
+
+However, the code review process can also introduce latency for contributors
+and additional work for reviewers that can frustrate both parties.
+
+Consequently, as a community we expect that all active participants in the
+community will also be active reviewers.
+
+We ask that active contributors to the project participate in the code review
+process in areas where that contributor has expertise. Active contributors are
+considered to be anyone who meets any of the following criteria:
+   * Sent more than two pull requests (PRs) in the previous one month, or more
+   than 20 PRs in the previous year.
+   * Filed more than three issues in the previous month, or more than 30 issues
+   in the previous 12 months.
+   * Commented on more than pull requests in the previous month, or
+   more than 50 pull requests in the previous 12 months.
+   * Marked any PR as LGTM in the previous month.
+   * Have *collaborator* permissions in the Istio Mixer github project.
+
+In addition to these community expectations, any community member who wants to
+be an active reviewer can also add their name to an *active reviewer* file
+(location tbd) which will make them an active reviewer for as long as they
+are included in the file.
+
+#### Expectations of reviewers: Review comments
+
+Because reviewers are often the first points of contact between new members of
+the community and can significantly impact the first impression of the
+Istio Mixer community, reviewers are especially important in shaping the
+Istio Mixer community. Reviewers are highly encouraged to review the
+[code of conduct](../../code-of-conduct.md) and are strongly encouraged to go
+above and beyond the code of conduct to promote a collaborative, respectful
+Istio Mixer community.
+
+#### Expectations of reviewers: Review latency
+
+Reviewers are expected to respond in a timely fashion to PRs that are assigned
+to them. Reviewers are expected to respond to an *active* PRs with reasonable
+latency, and if reviewers fail to respond, those PRs may be assigned to other
+reviewers.
+
+*Active* PRs are considered those which have a proper CLA (`cla:yes`) label
+and do not need rebase to be merged.  PRs that do not have a proper CLA, or
+require a rebase are not considered active PRs.
+
+## Thanks
+
+Many thanks in advance to everyone who contributes their time and effort to
+making Istio Mixer both a successful system as well as a successful community.
+The strength of our software shines in the strengths of each individual
+community member.  Thanks!

--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -1,0 +1,163 @@
+# Development Guide
+
+This document is intended to be the canonical source of truth for things like
+supported toolchain versions for building Istio Mixer. If you find a
+requirement that this doc does not capture, please
+[submit an issue](https://github.com/istio/mixer/issues) on github. If
+you find other docs with references to requirements that are not simply links to
+this doc, please [submit an issue](https://github.com/istio/mixer/issues).
+
+This document is intended to be relative to the branch in which it is found.
+It is guaranteed that requirements will change over time for the development
+branch, but release branches of Istio Mixer should not change.
+
+## Building Istio Mixer
+
+Please see our [build docs](../building.md).
+	
+### Go development environment
+
+Istio Mixer is written in the [Go](http://golang.org) programming language.
+To build Istio Mixer, you'll need a Go development environment. Builds for 
+Istio Mixer require Go version 1.7.0. If you haven't set up a Go development
+environment, please follow [these instructions](http://golang.org/doc/code.html)
+to install the go tools.
+
+Set up your GOPATH and add a path entry for go binaries to your PATH. Typically
+added to your ~/.profile:
+
+```sh
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin
+```
+
+### Godep dependency management
+
+Istio Mixer build and test scripts use [glide](https://github.com/Masterminds/glide) to
+manage dependencies.
+
+#### Install glide
+
+To install glide, please follow their [installation guide](https://github.com/Masterminds/glide#install).
+
+### Local build using make
+
+To build Istio Mixer using your local Go development environment (generate linux
+binaries):
+
+```sh
+make
+```
+
+You may pass build options and packages to the script as necessary. For example,
+to build with optimizations disabled for enabling use of source debug tools:
+
+```sh
+make GOGCFLAGS="-N -l"
+```
+
+## Workflow
+
+Below, we outline one of the more common git workflows that core developers use.
+Other git workflows are also valid.
+
+[//]: # (TODO: add visual overview)
+
+### Fork the main repository
+
+1. Go to https://github.com/istio/mixer
+2. Click the "Fork" button (at the top right)
+
+### Clone your fork
+
+The commands below require that you have $GOPATH set ([$GOPATH
+docs](https://golang.org/doc/code.html#GOPATH)). We highly recommend you put
+Istio Mixer' code into your GOPATH. Note: the commands below will not work if
+there is more than one directory in your `$GOPATH`.
+
+```sh
+mkdir -p $GOPATH/src/istio
+cd $GOPATH/src/istio
+# Replace "$YOUR_GITHUB_USERNAME" below with your github username
+git clone https://github.com/$YOUR_GITHUB_USERNAME/mixer.git
+cd mixer
+git remote add upstream 'https://github.com/istio/mixer.git'
+```
+
+### Create a branch and make changes
+
+```sh
+git checkout -b my-feature
+# Make your code changes
+```
+
+### Keeping your development fork in sync
+
+```sh
+git fetch upstream
+git rebase upstream/master
+```
+
+Note: If you have write access to the main repository at
+github.com/istio/mixer, you should modify your git configuration so
+that you can't accidentally push to upstream:
+
+```sh
+git remote set-url --push upstream no_push
+```
+
+### Committing changes to your fork
+
+TODO: iron out and detail pre-commit hooks.
+
+Then you can commit your changes and push them to your fork:
+
+```sh
+git commit
+git push -f origin my-feature
+```
+
+### Creating a pull request
+
+1. Visit https://github.com/$YOUR_GITHUB_USERNAME/mixer
+2. Click the "Compare & pull request" button next to your "my-feature" branch.
+3. Check out the pull request [process](pull-requests.md) for more details
+
+**Note:** If you have write access, please refrain from using the GitHub UI for
+creating PRs, because GitHub will create the PR branch inside the main
+repository rather than inside your fork.
+
+### Getting a code review
+
+Once your pull request has been opened it will be assigned to one or more
+reviewers. Those reviewers will do a thorough code review, looking for
+correctness, bugs, opportunities for improvement, documentation and comments,
+and style.
+
+Very small PRs are easy to review.  Very large PRs are very difficult to
+review. Github has a built-in code review tool, which is what most people use.
+
+[//]: # (TODO: add bits about fast path reviews)
+
+### When to retain commits and when to squash
+
+Upon merge, all git commits should represent meaningful milestones or units of
+work. Use commits to add clarity to the development and review process.
+
+Before merging a PR, squash any "fix review feedback", "typo", and "rebased"
+sorts of commits. It is not imperative that every commit in a PR compile and
+pass tests independently, but it is worth striving for. For mass automated
+fixups (e.g. automated doc formatting), use one or more commits for the
+changes to tooling and a final commit to apply the fixup en masse. This makes
+reviews much easier.
+
+## Testing
+
+```sh
+cd mixer
+make test # Run every unit test
+```
+
+See the [testing guide](testing.md) for additional information and scenarios.
+
+[//]: # (TODO: Add integration/end-to-end testing info)

--- a/docs/devel/logging.md
+++ b/docs/devel/logging.md
@@ -1,0 +1,33 @@
+## Logging Conventions
+
+The following conventions for the glog levels to use.
+[glog](http://godoc.org/github.com/golang/glog) is globally preferred to
+[log](http://golang.org/pkg/log/) for better runtime control.
+
+* glog.Errorf() - Always an error
+
+* glog.Warningf() - Something unexpected, but probably not an error
+
+* glog.Infof() has multiple levels:
+  * glog.V(0) - Generally useful for this to ALWAYS be visible to an operator
+    * Programmer errors
+    * Logging extra info about a panic
+    * CLI argument handling
+  * glog.V(1) - A reasonable default log level if you don't want verbosity.
+    * Information about config (listening on X, watching Y)
+    * Errors that repeat frequently that relate to conditions that can be 
+    corrected
+  * glog.V(2) - Useful steady state information about the service and important 
+  log messages that may correlate to significant changes in the system.  This is
+  the recommended default log level for most systems.
+    * Logging HTTP requests and their exit code
+    * System state changing
+  * glog.V(3) - Extended information about changes
+    * More info about system state changes
+  * glog.V(4) - Debug level verbosity (for now)
+    * Logging in particularly thorny parts of code where you may want to come
+    back later and check it
+
+As per the comments, the practical default level is V(2). Developers and QE
+environments may wish to run at V(3) or V(4). If you wish to change the log
+level, you can pass in `-v=X` where X is the desired maximum level to log.

--- a/docs/devel/testing.md
+++ b/docs/devel/testing.md
@@ -1,0 +1,32 @@
+# Testing guide
+
+This assumes you already read the [development guide](development.md) to
+install go, glide, and configure your git client.  All command examples are
+relative to the `mixer` root directory.
+
+Before sending pull requests you should at least make sure your changes have
+passed both unit and integration tests.
+
+Istio Mixer only merges pull requests when **all** tests are passing.
+
+## Unit tests
+
+* Unit tests should be fully hermetic
+  - Only access resources in the test binary.
+* All packages and any significant files require unit tests.
+* The preferred method of testing multiple scenarios or input is
+  [table driven testing](https://github.com/golang/go/wiki/TableDrivenTests)
+[//]: # (TODO: Add info about presubmits here when applicable)
+* Concurrent unit test runs must pass.
+* See [coding conventions](coding-conventions.md).
+
+### Run all unit tests
+
+`make test` is the entrypoint for running the unit tests that ensures that
+`GOPATH` is set up correctly.  If you have `GOPATH` set up correctly, you can
+also just use `go test` directly.
+
+```sh
+cd mixer
+make test  # Run all unit tests.
+```


### PR DESCRIPTION
These docs borrow heavily from the k8s docs, making only
small changes to remove unneeded parts and/or to replace
kubernetes with istio mixer where appropriate.

A number of TODOs are left in place to indicate areas that
need further attention as our dev story becomes more fleshed
out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/4)
<!-- Reviewable:end -->
