### PR TITLE
Remove dynamic adapter instance config updates, that was a bad idea.

### DIFF
--- a/adapters/denyChecker/instance.go
+++ b/adapters/denyChecker/instance.go
@@ -34,10 +34,6 @@ func newInstance(config *InstanceConfig) (adapters.ListChecker, error) {
 func (inst *instance) Delete() {
 }
 
-func (inst *instance) UpdateConfig(config adapters.InstanceConfig) error {
-	return nil
-}
-
 func (inst *instance) CheckList(symbol string) (bool, error) {
 	return false, nil
 }

--- a/adapters/denyChecker/instance_test.go
+++ b/adapters/denyChecker/instance_test.go
@@ -35,9 +35,5 @@ func TestAll(t *testing.T) {
 		t.Error("Expecting to always get false")
 	}
 
-	if err = listChecker.UpdateConfig(&InstanceConfig{}); err != nil {
-		t.Error("Unable to update config")
-	}
-
 	listChecker.Delete()
 }

--- a/adapters/factMapper/instance.go
+++ b/adapters/factMapper/instance.go
@@ -93,20 +93,6 @@ func (inst *instance) Delete() {
 	inst.tables = nil
 }
 
-func (inst *instance) UpdateConfig(config adapters.InstanceConfig) error {
-	c := config.(*InstanceConfig)
-
-	tables, err := buildLookupTables(c)
-	if err != nil {
-		return err
-	}
-
-	// atomically update the table pointer such that any new tracker will use the new
-	// config
-	inst.tables = tables
-	return nil
-}
-
 func (inst *instance) NewTracker() adapters.FactTracker {
-	return newTracker(&inst.tables)
+	return newTracker(inst.tables)
 }

--- a/adapters/factMapper/instance_test.go
+++ b/adapters/factMapper/instance_test.go
@@ -177,43 +177,6 @@ func TestAddRemoveFacts(t *testing.T) {
 	tracker.PurgeFacts([]string{"Fact42"})
 }
 
-func TestConfigUpdates(t *testing.T) {
-	rules := make(map[string]string)
-	rules["Lab1"] = "Fact1|Fact2|Fact3"
-	rules["Lab2"] = "Fact3|Fact2|Fact1"
-	var inst adapters.FactConverter
-	var err error
-	if inst, err = newInstance(&InstanceConfig{Rules: rules}); err != nil {
-		t.Error("Expected to be able to create a mapper")
-	}
-
-	tracker := inst.NewTracker()
-
-	// add some actual facts and try again
-	facts := make(map[string]string)
-	facts["Fact1"] = "One"
-	facts["Fact2"] = "Two"
-	facts["Fact4"] = "Four"
-	tracker.UpdateFacts(facts)
-
-	labels := tracker.GetLabels()
-	if len(labels) != 2 || labels["Lab1"] != "One" || labels["Lab2"] != "Two" {
-		t.Error("Got unexpected labels")
-	}
-
-	rules["Lab1"] = "Fact3|Fact2|Fact1"
-	rules["Lab2"] = "Fact1|Fact2|Fact3"
-
-	if err = inst.UpdateConfig(&InstanceConfig{Rules: rules}); err != nil {
-		t.Error("Expected to be able to update the config")
-	}
-
-	labels = tracker.GetLabels()
-	if len(labels) != 2 || labels["Lab1"] != "Two" || labels["Lab2"] != "One" {
-		t.Error("Got unexpected labels")
-	}
-}
-
 func TestReset(t *testing.T) {
 	rules := make(map[string]string)
 	rules["Lab1"] = "Fact1|Fact2|Fact3"

--- a/adapters/instance.go
+++ b/adapters/instance.go
@@ -21,7 +21,4 @@ type InstanceConfig interface{}
 type Instance interface {
 	// Delete is called by the mixer to indicate it is done with a particular adapter instance.
 	Delete()
-
-	// UpdateConfig is used to refresh an adapter instance's live configuration.
-	UpdateConfig(config InstanceConfig) error
 }

--- a/adapters/ipListChecker/instance.go
+++ b/adapters/ipListChecker/instance.go
@@ -89,10 +89,6 @@ func (inst *instance) Delete() {
 	close(inst.closing)
 }
 
-func (inst *instance) UpdateConfig(config adapters.InstanceConfig) error {
-	return errors.New("not implemented")
-}
-
 func (inst *instance) CheckList(symbol string) (bool, error) {
 	ipa := net.ParseIP(symbol)
 	if ipa == nil {


### PR DESCRIPTION
Instead, when config changes the mixer will simply create new instances.
This is considerably simpler for the adapter authors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/8)
<!-- Reviewable:end -->
