### PR TITLE
Add go_package option to protos.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,15 @@ test: test_server
 ## API Targets
 
 PROTOC = bin/protoc.$(shell uname)
-API_OUTDIR_GO = api/v1/go
+VENDOR = vendor
+API_OUTDIR_GO = $(VENDOR)/istio.io/mixer/api/v1
 API_OUTDIR_CPP = api/v1/cpp
 API_SRC = api/v1/service.proto api/v1/check.proto api/v1/report.proto api/v1/quota.proto
 
 $(API_OUTDIR_GO)/%.pb.go $(API_OUTDIR_CPP)/%.pb.cc: api/v1/%.proto
 	@echo "Building API protos"
 	@mkdir -p $(API_OUTDIR_GO) $(API_OUTDIR_CPP)
-	@$(PROTOC) --proto_path=api/v1 --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --cpp_out=$(API_OUTDIR_CPP) --go_out=plugins=grpc:$(API_OUTDIR_GO) $(API_SRC)
+	@$(PROTOC) --proto_path=api/v1 --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --cpp_out=$(API_OUTDIR_CPP) --go_out=plugins=grpc:$(VENDOR) $(API_SRC)
 
 build_api: $(API_OUTDIR_GO)/service.pb.go
 

--- a/api/v1/check.proto
+++ b/api/v1/check.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+option go_package="istio.io/mixer/api/v1;mixer";
+
 import "google/rpc/status.proto";
 
 // Used to verify preconditions before performing an action.

--- a/api/v1/quota.proto
+++ b/api/v1/quota.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+option go_package="istio.io/mixer/api/v1;mixer";
+
 import "google/rpc/status.proto";
 
 message QuotaRequest {

--- a/api/v1/report.proto
+++ b/api/v1/report.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+option go_package="istio.io/mixer/api/v1;mixer";
+
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/any.proto";

--- a/api/v1/service.proto
+++ b/api/v1/service.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+option go_package="istio.io/mixer/api/v1;mixer";
+
 import "check.proto";
 import "report.proto";
 import "quota.proto";

--- a/server/apiHandlers.go
+++ b/server/apiHandlers.go
@@ -21,8 +21,7 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 
 	"istio.io/mixer/adapters"
-
-	mixpb "istio.io/mixer/api/v1/go"
+	"istio.io/mixer/api/v1"
 )
 
 // APIHandlers holds pointers to the functions that implement
@@ -31,17 +30,17 @@ type APIHandlers interface {
 	// Check performs the configured set of precondition checks.
 	// Note that the request parameter is immutable, while the response parameter is where
 	// results are specified
-	Check(adapters.FactTracker, *mixpb.CheckRequest, *mixpb.CheckResponse)
+	Check(adapters.FactTracker, *mixer.CheckRequest, *mixer.CheckResponse)
 
 	// Report performs the requested set of reporting operations.
 	// Note that the request parameter is immutable, while the response parameter is where
 	// results are specified
-	Report(adapters.FactTracker, *mixpb.ReportRequest, *mixpb.ReportResponse)
+	Report(adapters.FactTracker, *mixer.ReportRequest, *mixer.ReportResponse)
 
 	// Quota increments, decrements, or queries the specified quotas.
 	// Note that the request parameter is immutable, while the response parameter is where
 	// results are specified
-	Quota(adapters.FactTracker, *mixpb.QuotaRequest, *mixpb.QuotaResponse)
+	Quota(adapters.FactTracker, *mixer.QuotaRequest, *mixer.QuotaResponse)
 }
 
 type apiHandlers struct {
@@ -51,8 +50,8 @@ func newStatus(c code.Code) *status.Status {
 	return &status.Status{Code: int32(c)}
 }
 
-func newQuotaError(c code.Code) *mixpb.QuotaResponse_Error {
-	return &mixpb.QuotaResponse_Error{Error: newStatus(c)}
+func newQuotaError(c code.Code) *mixer.QuotaResponse_Error {
+	return &mixer.QuotaResponse_Error{Error: newStatus(c)}
 }
 
 // NewAPIHandlers returns a canonical APIHandlers that implements all of the mixer's API surface
@@ -60,19 +59,19 @@ func NewAPIHandlers() APIHandlers {
 	return &apiHandlers{}
 }
 
-func (h *apiHandlers) Check(tracker adapters.FactTracker, request *mixpb.CheckRequest, response *mixpb.CheckResponse) {
+func (h *apiHandlers) Check(tracker adapters.FactTracker, request *mixer.CheckRequest, response *mixer.CheckResponse) {
 	tracker.UpdateFacts(request.GetFacts())
 	response.RequestId = request.RequestId
 	response.Result = newStatus(code.Code_UNIMPLEMENTED)
 }
 
-func (h *apiHandlers) Report(tracker adapters.FactTracker, request *mixpb.ReportRequest, response *mixpb.ReportResponse) {
+func (h *apiHandlers) Report(tracker adapters.FactTracker, request *mixer.ReportRequest, response *mixer.ReportResponse) {
 	tracker.UpdateFacts(request.GetFacts())
 	response.RequestId = request.RequestId
 	response.Result = newStatus(code.Code_UNIMPLEMENTED)
 }
 
-func (h *apiHandlers) Quota(tracker adapters.FactTracker, request *mixpb.QuotaRequest, response *mixpb.QuotaResponse) {
+func (h *apiHandlers) Quota(tracker adapters.FactTracker, request *mixer.QuotaRequest, response *mixer.QuotaResponse) {
 	tracker.UpdateFacts(request.GetFacts())
 	response.RequestId = request.RequestId
 	response.Result = newQuotaError(code.Code_UNIMPLEMENTED)

--- a/server/apiServer.go
+++ b/server/apiServer.go
@@ -33,9 +33,9 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"istio.io/mixer/adapters"
+	"istio.io/mixer/api/v1"
 
 	proto "github.com/golang/protobuf/proto"
-	mixpb "istio.io/mixer/api/v1/go"
 )
 
 // APIServerOptions controls the behavior of a gRPC server.
@@ -118,7 +118,7 @@ func NewAPIServer(options *APIServerOptions) (*APIServer, error) {
 	// get everything wired up
 	grpcServer := grpc.NewServer(grpcOptions...)
 	apiServer := &APIServer{grpcServer, listener, options.Handlers, options.FactConverter}
-	mixpb.RegisterMixerServer(grpcServer, apiServer)
+	mixer.RegisterMixerServer(grpcServer, apiServer)
 	return apiServer, nil
 }
 
@@ -162,31 +162,31 @@ func (s *APIServer) streamLoop(stream grpc.ServerStream, request proto.Message, 
 }
 
 // Check is the entry point for the external Check method
-func (s *APIServer) Check(stream mixpb.Mixer_CheckServer) error {
+func (s *APIServer) Check(stream mixer.Mixer_CheckServer) error {
 	return s.streamLoop(stream,
-		new(mixpb.CheckRequest),
-		new(mixpb.CheckResponse),
+		new(mixer.CheckRequest),
+		new(mixer.CheckResponse),
 		func(tracker adapters.FactTracker, request proto.Message, response proto.Message) {
-			s.handler.Check(tracker, request.(*mixpb.CheckRequest), response.(*mixpb.CheckResponse))
+			s.handler.Check(tracker, request.(*mixer.CheckRequest), response.(*mixer.CheckResponse))
 		})
 }
 
 // Report is the entry point for the external Report method
-func (s *APIServer) Report(stream mixpb.Mixer_ReportServer) error {
+func (s *APIServer) Report(stream mixer.Mixer_ReportServer) error {
 	return s.streamLoop(stream,
-		new(mixpb.ReportRequest),
-		new(mixpb.ReportResponse),
+		new(mixer.ReportRequest),
+		new(mixer.ReportResponse),
 		func(tracker adapters.FactTracker, request proto.Message, response proto.Message) {
-			s.handler.Report(tracker, request.(*mixpb.ReportRequest), response.(*mixpb.ReportResponse))
+			s.handler.Report(tracker, request.(*mixer.ReportRequest), response.(*mixer.ReportResponse))
 		})
 }
 
 // Quota is the entry point for the external Quota method
-func (s *APIServer) Quota(stream mixpb.Mixer_QuotaServer) error {
+func (s *APIServer) Quota(stream mixer.Mixer_QuotaServer) error {
 	return s.streamLoop(stream,
-		new(mixpb.QuotaRequest),
-		new(mixpb.QuotaResponse),
+		new(mixer.QuotaRequest),
+		new(mixer.QuotaResponse),
 		func(tracker adapters.FactTracker, request proto.Message, response proto.Message) {
-			s.handler.Quota(tracker, request.(*mixpb.QuotaRequest), response.(*mixpb.QuotaResponse))
+			s.handler.Quota(tracker, request.(*mixer.QuotaRequest), response.(*mixer.QuotaResponse))
 		})
 }

--- a/server/apiServer_test.go
+++ b/server/apiServer_test.go
@@ -25,8 +25,7 @@ import (
 
 	"istio.io/mixer/adapters"
 	"istio.io/mixer/adapters/factMapper"
-
-	mixpb "istio.io/mixer/api/v1/go"
+	"istio.io/mixer/api/v1"
 )
 
 const (
@@ -37,7 +36,7 @@ const (
 
 type testState struct {
 	apiServer  *APIServer
-	client     mixpb.MixerClient
+	client     mixer.MixerClient
 	connection *grpc.ClientConn
 }
 
@@ -89,7 +88,7 @@ func (ts *testState) createAPIClient() error {
 		return err
 	}
 
-	ts.client = mixpb.NewMixerClient(ts.connection)
+	ts.client = mixer.NewMixerClient(ts.connection)
 	return nil
 }
 
@@ -118,17 +117,17 @@ func (ts *testState) cleanupTestState() {
 	ts.deleteAPIServer()
 }
 
-func (ts *testState) Check(tracker adapters.FactTracker, request *mixpb.CheckRequest, response *mixpb.CheckResponse) {
+func (ts *testState) Check(tracker adapters.FactTracker, request *mixer.CheckRequest, response *mixer.CheckResponse) {
 	response.RequestId = request.RequestId
 	response.Result = newStatus(code.Code_UNIMPLEMENTED)
 }
 
-func (ts *testState) Report(tracker adapters.FactTracker, request *mixpb.ReportRequest, response *mixpb.ReportResponse) {
+func (ts *testState) Report(tracker adapters.FactTracker, request *mixer.ReportRequest, response *mixer.ReportResponse) {
 	response.RequestId = request.RequestId
 	response.Result = newStatus(code.Code_UNIMPLEMENTED)
 }
 
-func (ts *testState) Quota(tracker adapters.FactTracker, request *mixpb.QuotaRequest, response *mixpb.QuotaResponse) {
+func (ts *testState) Quota(tracker adapters.FactTracker, request *mixer.QuotaRequest, response *mixer.QuotaResponse) {
 	response.RequestId = request.RequestId
 	response.Result = newQuotaError(code.Code_UNIMPLEMENTED)
 }
@@ -164,13 +163,13 @@ func TestCheck(t *testing.T) {
 	}()
 
 	// send the first request
-	request := mixpb.CheckRequest{RequestId: testRequestID0}
+	request := mixer.CheckRequest{RequestId: testRequestID0}
 	if err := stream.Send(&request); err != nil {
 		t.Errorf("Failed to send first request: %v", err)
 	}
 
 	// send the second request
-	request = mixpb.CheckRequest{RequestId: testRequestID1}
+	request = mixer.CheckRequest{RequestId: testRequestID1}
 	if err := stream.Send(&request); err != nil {
 		t.Errorf("Failed to send second request: %v", err)
 	}
@@ -221,13 +220,13 @@ func TestReport(t *testing.T) {
 	}()
 
 	// send the first request
-	request := mixpb.ReportRequest{RequestId: testRequestID0}
+	request := mixer.ReportRequest{RequestId: testRequestID0}
 	if err := stream.Send(&request); err != nil {
 		t.Errorf("Failed to send first request: %v", err)
 	}
 
 	// send the second request
-	request = mixpb.ReportRequest{RequestId: testRequestID1}
+	request = mixer.ReportRequest{RequestId: testRequestID1}
 	if err := stream.Send(&request); err != nil {
 		t.Errorf("Failed to send second request: %v", err)
 	}


### PR DESCRIPTION
This refactors the golang code generation bits for the
mixer protos by adding a package option to the protos. Generated
golang code is also now generated in the vendor/ directory,
instead of in a special go/ directory in the api/v1/ directory.

This should make importing and use of the protos a little less
cumbersome in the codebase in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/20)
<!-- Reviewable:end -->
