### PR TITLE
Add JSON logger adapter.

### DIFF
--- a/adapters/jsonLogger/adapter.go
+++ b/adapters/jsonLogger/adapter.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonLogger
+
+import (
+	"os"
+
+	"istio.io/mixer/adapters"
+)
+
+type (
+	adapter struct{}
+)
+
+func newLogger(c adapters.AdapterConfig) (adapters.Logger, error) {
+	return &adapter{}, nil
+}
+
+func (a *adapter) Log(l []adapters.LogEntry) error {
+	var logsErr error
+	for _, le := range l {
+		if err := adapters.WriteJSON(os.Stdout, le); err != nil {
+			logsErr = err
+			continue
+		}
+	}
+	return logsErr
+}
+
+func (a *adapter) Close() error { return nil }

--- a/adapters/jsonLogger/builder.go
+++ b/adapters/jsonLogger/builder.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonLogger
+
+import (
+	"istio.io/mixer/adapters"
+)
+
+const (
+	name = "istio.io/mixer/loggers/jsonLogger"
+	desc = "Writes adapters.LogEntrys to os.Stdout with JSON encoding"
+)
+
+type (
+	builder struct{}
+)
+
+// TODO: consider making destination configurable (os.Stdout v os.Stderr)
+
+// NewBuilder returns the builder for the default logging adapter.
+func NewBuilder() adapters.Builder { return &builder{} }
+
+func (b *builder) Close() error { return nil }
+
+func (b builder) Name() string { return name }
+
+func (b builder) Description() string { return desc }
+
+func (b builder) DefaultBuilderConfig() adapters.BuilderConfig { return &struct{}{} }
+
+func (b builder) ValidateBuilderConfig(c adapters.BuilderConfig) error { return nil }
+
+func (b builder) Configure(c adapters.BuilderConfig) error { return nil }
+
+func (b builder) DefaultAdapterConfig() adapters.AdapterConfig { return &struct{}{} }
+
+func (b builder) ValidateAdapterConfig(c adapters.AdapterConfig) error { return nil }
+
+func (b builder) NewAdapter(c adapters.AdapterConfig) (adapters.Adapter, error) {
+	return newLogger(c)
+}

--- a/adapters/jsonLogger/jsonLogger_test.go
+++ b/adapters/jsonLogger/jsonLogger_test.go
@@ -1,0 +1,122 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonLogger
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/mixer/adapters"
+	"istio.io/mixer/adapters/testutil"
+)
+
+var (
+	t, _ = time.Parse("2006-Jan-01", "2016-Dec-06")
+
+	textEntry = adapters.LogEntry{
+		Collection:  "info_log",
+		Timestamp:   t,
+		Severity:    "INFO",
+		TextPayload: "Server start",
+	}
+
+	structEntry = adapters.LogEntry{
+		Collection: "access_log",
+		Timestamp:  t,
+		Severity:   "ERROR",
+		StructPayload: map[string]interface{}{
+			"source_ip":      "10.0.0.1",
+			"source_user":    "tester@test.com",
+			"api_method":     "GetShelves",
+			"response_code":  "404",
+			"response_bytes": 43545,
+		},
+	}
+)
+
+func TestBuilderInvariants(t *testing.T) {
+	b := NewBuilder()
+	testutil.TestBuilderInvariants(b, t)
+}
+
+func TestLog(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   []adapters.LogEntry
+		want      []string
+		expectErr bool
+	}{
+		{
+			name:    "Single Report",
+			entries: []adapters.LogEntry{textEntry},
+			want:    []string{"{\"logsCollection\":\"info_log\",\"timestamp\":\"2016-06-01T00:00:00Z\",\"severity\":\"INFO\",\"textPayload\":\"Server start\"}"},
+		},
+		{
+			name:    "Batch Reports",
+			entries: []adapters.LogEntry{textEntry, structEntry},
+			want: []string{
+				"{\"logsCollection\":\"info_log\",\"timestamp\":\"2016-06-01T00:00:00Z\",\"severity\":\"INFO\",\"textPayload\":\"Server start\"}",
+				"{\"logsCollection\":\"access_log\",\"timestamp\":\"2016-06-01T00:00:00Z\",\"severity\":\"ERROR\",\"structPayload\":{\"api_method\":\"GetShelves\",\"response_bytes\":43545,\"response_code\":\"404\",\"source_ip\":\"10.0.0.1\",\"source_user\":\"tester@test.com\"}}",
+			},
+		},
+	}
+
+	b := NewBuilder()
+
+	for _, v := range tests {
+		a, err := b.NewAdapter(struct{}{})
+		if err != nil {
+			if !v.expectErr {
+				t.Errorf("%s - could not build adapter: %v", v.name, err)
+			}
+			continue
+		}
+		if err == nil && v.expectErr {
+			t.Errorf("%s - expected error building adapter", v.name)
+		}
+
+		l := a.(adapters.Logger)
+
+		old := os.Stdout // for restore
+		r, w, _ := os.Pipe()
+		os.Stdout = w // redirecting
+		// copy over the output from stderr
+		outC := make(chan string)
+		go func() {
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			outC <- buf.String()
+		}()
+
+		l.Log(v.entries)
+
+		// back to normal state
+		w.Close()
+		os.Stdout = old
+		logs := <-outC
+
+		got := strings.Split(strings.TrimSpace(logs), "\n")
+
+		if !reflect.DeepEqual(got, v.want) {
+			t.Errorf("%s - got %s, want %s", v.name, got, v.want)
+		}
+	}
+
+}

--- a/adapters/logger.go
+++ b/adapters/logger.go
@@ -1,0 +1,60 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+type (
+	// Logger is the interface for adapters that will handle logs data within
+	// the mixer.
+	Logger interface {
+		Adapter
+
+		// Log directs a backend adapter to process a batch of LogEntries derived
+		// from potentially several Report() calls.
+		Log([]LogEntry) error
+	}
+
+	// LogEntry is the top-level struct for logs data that will be
+	// exported by logging adapters.
+	LogEntry struct {
+		// Collection identifies the logs target for the LogEntry.
+		Collection string `json:"logsCollection,omitempty"`
+		// Timestamp identifies the event time for the log.
+		Timestamp time.Time `json:"timestamp,omitempty"`
+		// Labels are a set of key-value pairs for non-payload logs data.
+		Labels map[string]string `json:"labels,omitempty"`
+		// Severity indicates the log-level for the entry.
+		Severity string `json:"severity,omitempty"`
+		// ProtoPayload is for providing a protobuf-encoded payload.
+		ProtoPayload string `json:"protoPayload,omitempty"`
+		// TextPayload is for providing a raw text payload.
+		TextPayload string `json:"textPayload,omitempty"`
+		// StructPayload is for providing a structured text payload (JSON).
+		StructPayload map[string]interface{} `json:"structPayload,omitempty"`
+	}
+)
+
+// WriteJSON converts a log entry to json and writes to the supplied io.Writer
+func WriteJSON(w io.Writer, l LogEntry) error {
+	if err := json.NewEncoder(w).Encode(l); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This change adds a default logging adapter that logs to stdout. As
part of this change, a Logging interface is added to the mixer.adapters
package, which is then implemented by the default logger. A FactValues type
is also added to the root package as a placeholder for storing facts to
pass into adapters.

The default logger operates on templates in the golang text/template
style, extracting a map from the FactValues passed in per request. It
supports batching by allowing a list of FactValues to be supplied (as
would happen if reports were batched by a batching adapter in the
mixer itself).

This is meant to address issue #11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/29)
<!-- Reviewable:end -->
