### PR TITLE
Basic proposal for well-known and strongly typed facts.

### DIFF
--- a/api/v1/attributes.proto
+++ b/api/v1/attributes.proto
@@ -18,45 +18,24 @@ package istio.mixer.v1;
 
 option go_package="istio.io/mixer/api/v1;mixerpb";
 
-// Contains a set of attributes related to an event.
-message Attributes {
-  // Attributes related to the source of an event.
+// A set of attributes reported over a period of time.
+// An instant can be represented by only reporting an end
+// time and no start time.
+message AttributeSpan {
+  // The start of the span being reported.
+  google.protobuf.Timestamp start_time = 1;
 
-  uint32 source_ip = 1;
-  uint32 source_port = 2;
-  string source_name = 3;
-  string source_instance = 4;
-  string source_namespace = 5;
-  string source_user = 6;
-  // ...
+  // The end of the span being reported.
+  google.protobuf.Timestamp end_time = 2;
 
-  // Attributes related to the target of an event.
-  uint32 target_ip = 101;
-  uint32 target_port = 102;
-  string target_service = 103;
-  string target_name = 104;
-  string target_instance = 105;
-  string target_namespace = 106;
-  string target_user = 107;
-  // ...
-
-  // Attributes related to the origin of an event,
-  // if the source of the event is proxying it.
-  uint32 origin_ip = 201;
-  uint32 origin_port = 202;
-  string origin_name = 203;
-  string origin_instance = 204;
-  string origin_namespace = 205;
-  string origin_user = 206;
-  // ...
-
-  // Non predefined attributes go here.
-  repeated Attribute attributes = 1000;
+  // The named values being reported in the span.
+  repeated Attribute attributes = 3;
 }
 
 // An individual attribute, which has a name and a value.
 message Attribute {
-  // The name of the attribute.
+  // The name of the attribute, which is dot-delimited
+  // ascii string, for example "source.device_id"
   string name = 1;
 
   // The value of the attribute.

--- a/api/v1/attributes.proto
+++ b/api/v1/attributes.proto
@@ -1,0 +1,69 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.mixer.v1;
+
+option go_package="istio.io/mixer/api/v1;mixerpb";
+
+// Contains a set of attributes related to an event.
+message Attributes {
+  // Attributes related to the source of an event.
+
+  uint32 source_ip = 1;
+  uint32 source_port = 2;
+  string source_name = 3;
+  string source_instance = 4;
+  string source_namespace = 5;
+  string source_user = 6;
+  // ...
+
+  // Attributes related to the target of an event.
+  uint32 target_ip = 101;
+  uint32 target_port = 102;
+  string target_service = 103;
+  string target_name = 104;
+  string target_instance = 105;
+  string target_namespace = 106;
+  string target_user = 107;
+  // ...
+
+  // Attributes related to the origin of an event,
+  // if the source of the event is proxying it.
+  uint32 origin_ip = 201;
+  uint32 origin_port = 202;
+  string origin_name = 203;
+  string origin_instance = 204;
+  string origin_namespace = 205;
+  string origin_user = 206;
+  // ...
+
+  // Non predefined attributes go here.
+  repeated Attribute attributes = 1000;
+}
+
+// An individual attribute, which has a name and a value.
+message Attribute {
+  // The name of the attribute.
+  string name = 1;
+
+  // The value of the attribute.
+  oneof value {
+    string string_value = 2;
+    bool bool_value = 3;
+    double double_value = 4;
+    int64 int64_value = 5;
+  }
+}

--- a/api/v1/check.proto
+++ b/api/v1/check.proto
@@ -18,6 +18,7 @@ package istio.mixer.v1;
 
 option go_package="istio.io/mixer/api/v1;mixerpb";
 
+import "attributes.proto";
 import "google/rpc/status.proto";
 
 // Used to verify preconditions before performing an action.
@@ -25,10 +26,10 @@ message CheckRequest {
   // Uniquely identifies this request, used to match to responses
   int64 request_id = 1;
 
-  // The set of discovered facts associated with this request. This value
-  // represents a delta relative to the facts currently known to the mixer
+  // The set of discovered attributes associated with this request. This value
+  // represents a delta relative to the attributes currently known to the mixer
   // within the current stream.
-  map<string, string> facts = 2;
+  Attributes attributes = 2;
 }
 
 message CheckResponse {

--- a/api/v1/check.proto
+++ b/api/v1/check.proto
@@ -29,7 +29,7 @@ message CheckRequest {
   // The set of discovered attributes associated with this request. This value
   // represents a delta relative to the attributes currently known to the mixer
   // within the current stream.
-  Attributes attributes = 2;
+  AttributeSpan attributes = 2;
 }
 
 message CheckResponse {

--- a/api/v1/quota.proto
+++ b/api/v1/quota.proto
@@ -28,7 +28,7 @@ message QuotaRequest {
   // The set of discovered attributes associated with this request. This value
   // represents a delta relative to the attributes currently known to the mixer
   // within the current stream.
-  Attributes attributes = 2;
+  AttributeSpan attributes = 2;
 
   // Name of the QuotaDescriptor providing the schema for this quota
   string descriptor_name = 3;

--- a/api/v1/quota.proto
+++ b/api/v1/quota.proto
@@ -18,16 +18,17 @@ package istio.mixer.v1;
 
 option go_package="istio.io/mixer/api/v1;mixerpb";
 
+import "attributes.proto";
 import "google/rpc/status.proto";
 
 message QuotaRequest {
   // Uniquely identifies this request, used to match to responses
   int64 request_id = 1;
 
-  // The set of discovered facts associated with this request. This value
-  // represents a delta relative to the facts currently known to the mixer
+  // The set of discovered attributes associated with this request. This value
+  // represents a delta relative to the attributes currently known to the mixer
   // within the current stream.
-  map<string, string> facts = 2;
+  Attributes attributes = 2;
 
   // Name of the QuotaDescriptor providing the schema for this quota
   string descriptor_name = 3;

--- a/api/v1/report.proto
+++ b/api/v1/report.proto
@@ -26,10 +26,9 @@ message ReportRequest {
   // Uniquely identifies this request, used to match to responses
   int64 request_id = 1;
 
-  // The set of attributes associated with this request. This value represents
-  // a delta relative to the attributes currently known to the mixer within
-  // the current stream.
-  Attributes attributes = 2;
+  // Spans of attributes being reported to the mixer. Only attributes that
+  // have changed in value will be reported within a span.
+  repeated AttributeSpan spans = 2;
 }
 
 message ReportResponse {

--- a/api/v1/report.proto
+++ b/api/v1/report.proto
@@ -18,9 +18,7 @@ package istio.mixer.v1;
 
 option go_package="istio.io/mixer/api/v1;mixerpb";
 
-import "google/protobuf/timestamp.proto";
-import "google/protobuf/struct.proto";
-import "google/protobuf/any.proto";
+import "attributes.proto";
 import "google/rpc/status.proto";
 
 // Used to report telemetry after performing an action.
@@ -28,121 +26,10 @@ message ReportRequest {
   // Uniquely identifies this request, used to match to responses
   int64 request_id = 1;
 
-  // The set of discovered facts associated with this request. This value
-  // represents a delta relative to the facts currently known to the mixer
-  // within the current stream.
-  map<string, string> facts = 2;
-
-  // The monitored resource type associated with this report.
-  string monitored_resource_descriptor_name = 3;
-
-  // Metric values being reported
-  repeated MetricValue metric_values = 4;
-
-  // Log entries being reported
-  repeated LogEntry log_entries = 5;
-}
-
-// Represents a single metric value.
-message MetricValue {
-  // Name of the MetricDescriptor providing the schema for the metric.
-  string descriptor_name = 1;
-
-  // The start of the time period over which this metric value's measurement
-  // applies. The time period has different semantics for different metric
-  // kinds (cumulative, delta, and gauge). See the documentation for the
-  // MetricDescriptor for more information.
-  google.protobuf.Timestamp start_time = 3;
-
-  // The end of the time period over which this metric value's measurement
-  // applies.
-  google.protobuf.Timestamp end_time = 4;
-
-  // The value. The type of value used in the request must
-  // agree with the MetricDescriptor, otherwise
-  // the MetricValue is rejected.
-  oneof value {
-    // A boolean value.
-    bool bool_value = 5;
-
-    // A signed 64-bit integer value.
-    int64 int64_value = 6;
-
-    // A double precision floating point value.
-    double double_value = 7;
-
-    // A text string value.
-    string string_value = 8;
-  }
-}
-
-message LogEntry {
-  // The severity of the event described in a log entry, expressed as one of the
-  // standard severity levels listed below.  For your reference, the levels are
-  // assigned the listed numeric values. The effect of using numeric values other
-  // than those listed is undefined.
-  //
-  // If you are writing log entries, you should map other severity encodings to
-  // one of these standard levels. For example, you might map all of Java's FINE,
-  // FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
-  // original severity level in the log entry payload if you wish.
-  enum LogSeverity {
-    // (0) The log entry has no assigned severity level.
-    DEFAULT = 0;
-
-    // (100) Debug or trace information.
-    DEBUG = 100;
-
-    // (200) Routine information, such as ongoing status or performance.
-    INFO = 200;
-
-    // (300) Normal but significant events, such as start up, shut down, or
-    // a configuration change.
-    NOTICE = 300;
-
-    // (400) Warning events might cause problems.
-    WARNING = 400;
-
-    // (500) Error events are likely to cause problems.
-    ERROR = 500;
-
-    // (600) Critical events cause more severe problems or outages.
-    CRITICAL = 600;
-
-    // (700) A person must take an action immediately.
-    ALERT = 700;
-
-    // (800) One or more systems are unusable.
-    EMERGENCY = 800;
-  }
-
-  // The name of the LogEntryDescriptor providing the schema for this log entry.
-  string descriptor_name = 1;
-
-  // Destination log collection for this entry
-  string log_collection = 2;
-
-  // The time the event described by the log entry occurred.
-  google.protobuf.Timestamp timestamp = 3;
-
-  // The severity of the log entry. The default value is
-  // `LogSeverity.DEFAULT`.
-  LogSeverity severity = 4;
-
-  // The log entry payload, which can be one of multiple types.
-  oneof payload {
-    // The log entry payload, represented as a protocol buffer that is
-    // expressed as a JSON object. You can only pass `protoPayload`
-    // values that belong to a set of approved types.
-    google.protobuf.Any proto_payload = 5;
-
-    // The log entry payload, represented as a Unicode string (UTF-8).
-    string text_payload = 6;
-
-    // The log entry payload, represented as a structure that
-    // is expressed as a JSON object.
-    google.protobuf.Struct struct_payload = 7;
-  }
+  // The set of attributes associated with this request. This value represents
+  // a delta relative to the attributes currently known to the mixer within
+  // the current stream.
+  Attributes attributes = 2;
 }
 
 message ReportResponse {


### PR DESCRIPTION
- Renames fact to attribute, and makes attributes typed (using metric value types)
- Adds well known types to an Attributes object
- Replaces map<string, string> facts with Attributes object
- Removes metric values and log entries from report.
- Removes aggregation, I'd like to add aggregation generically for attributes, rather than just for metric values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/34)
<!-- Reviewable:end -->
