### PR TITLE
Renaming request_id to request_index for clarity.

### DIFF
--- a/api/v1/check.proto
+++ b/api/v1/check.proto
@@ -22,8 +22,8 @@ import "google/rpc/status.proto";
 
 // Used to verify preconditions before performing an action.
 message CheckRequest {
-  // Uniquely identifies this request, used to match to responses
-  int64 request_id = 1;
+  // Index within the stream for this request, used to match to responses
+  int64 request_index = 1;
 
   // The set of discovered facts associated with this request. This value
   // represents a delta relative to the facts currently known to the mixer
@@ -32,8 +32,8 @@ message CheckRequest {
 }
 
 message CheckResponse {
-  // Identifies the request this response is associated with
-  int64 request_id = 1;
+  // Index of the request this response is associated with
+  int64 request_index = 1;
 
   // Indicates whether or not the preconditions succeeded
   google.rpc.Status result = 2;

--- a/api/v1/quota.proto
+++ b/api/v1/quota.proto
@@ -21,8 +21,8 @@ option go_package="istio.io/mixer/api/v1;mixerpb";
 import "google/rpc/status.proto";
 
 message QuotaRequest {
-  // Uniquely identifies this request, used to match to responses
-  int64 request_id = 1;
+  // Index within the stream for this request, used to match to responses
+  int64 request_index = 1;
 
   // The set of discovered facts associated with this request. This value
   // represents a delta relative to the facts currently known to the mixer
@@ -66,8 +66,8 @@ message QuotaRequest {
 // Quotas can also be used to impose upper limits on the number of specific
 // resources exposed by a service to its consumers.
 message QuotaResponse {
-  // Identifies the request this response is associated with
-  int64 request_id = 1;
+  // Index of the request this response is associated with
+  int64 request_index = 1;
 
   // Results, one for each operation in the request.
   // This map is indexed by the quota_operation_id of the individual quota operations.

--- a/api/v1/report.proto
+++ b/api/v1/report.proto
@@ -25,8 +25,8 @@ import "google/rpc/status.proto";
 
 // Used to report telemetry after performing an action.
 message ReportRequest {
-  // Uniquely identifies this request, used to match to responses
-  int64 request_id = 1;
+  // Index within the stream for this request, used to match to responses
+  int64 request_index = 1;
 
   // The set of discovered facts associated with this request. This value
   // represents a delta relative to the facts currently known to the mixer
@@ -146,8 +146,8 @@ message LogEntry {
 }
 
 message ReportResponse {
-  // Identifies the request this response is associated with
-  int64 request_id = 1;
+  // Index of the request this response is associated with
+  int64 request_index = 1;
 
   // Indicates whether the report was processed or not
   google.rpc.Status result = 2;


### PR DESCRIPTION
Tried to make it every so slightly more obvious that this is the index within the stream and not the id of the request being processed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/35)
<!-- Reviewable:end -->
