### PR TITLE
Adding configManager and implementing the higher level Check logic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ __pycache__/*
 .cover/*
 bazel-*
 
+.idea/
+*.iml

--- a/config/listChecker/bindingConfig.go
+++ b/config/listChecker/bindingConfig.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listChecker
+
+// BindingConfig is the structure that holds the configuration for input bindings of an adapter.
+type BindingConfig struct {
+}

--- a/config/listChecker/bindingEvaluator.go
+++ b/config/listChecker/bindingEvaluator.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listChecker
+
+// BindingEvaluator calculates the input binding values for invoking an adapter function.
+type BindingEvaluator interface {
+	// EvaluateSymbolBinding evaluates the value of the symbol binding for the CheckList call.
+	EvaluateSymbolBinding(values map[string]string) (string, error)
+}
+
+// NewBindingEvaluator instantiates and returns a new BindingEvaluator, based on the given configuration.
+func NewBindingEvaluator(config BindingConfig) BindingEvaluator {
+	// TODO: Construct a new BindingEvaluator
+	return nil
+}

--- a/config/listChecker/configBlock.go
+++ b/config/listChecker/configBlock.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listChecker
+
+import (
+	"istio.io/mixer/adapters"
+)
+
+// ConfigBlock is a tuple of AdapterConfig for an adapter and a BindingEvaluator that can calculate
+// the input bindings for that adapter.
+type ConfigBlock struct {
+	AdapterConfig *adapters.AdapterConfig
+	Evaluator     BindingEvaluator
+}

--- a/dispatchKey.go
+++ b/dispatchKey.go
@@ -1,0 +1,52 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mixer
+
+import (
+	"fmt"
+)
+
+const (
+	// ServiceName is a well-known name of a fact that is passed by the caller to specify
+	// the particular config that should be used when handling a request.
+	ServiceName = "serviceName"
+
+	// PeerID is a well-known name of a fact that is passed by the caller to specify
+	// the id of the client.
+	PeerID = "peerId"
+)
+
+// DispatchKey is a structure that is used as an internal key within Mixer, based on well-known facts.
+type DispatchKey struct {
+	ServiceName string
+	PeerID      string
+}
+
+// NewDispatchKey constructs and returns a new DispatchKey based on the incoming facts.
+func NewDispatchKey(facts map[string]string) (DispatchKey, error) {
+	serviceName, found := facts[ServiceName]
+	if !found {
+		return DispatchKey{}, fmt.Errorf("required fact not found: %s", ServiceName)
+	}
+	peerID, found := facts[PeerID]
+	if !found {
+		return DispatchKey{}, fmt.Errorf("required fact not found: %s", PeerID)
+	}
+
+	return DispatchKey{
+		ServiceName: serviceName,
+		PeerID:      peerID,
+	}, nil
+}

--- a/server/adapterManager.go
+++ b/server/adapterManager.go
@@ -17,8 +17,8 @@ package main
 import (
 	"errors"
 
+	"istio.io/mixer"
 	"istio.io/mixer/adapters"
-
 	"istio.io/mixer/adapters/denyChecker"
 	"istio.io/mixer/adapters/factMapper"
 	"istio.io/mixer/adapters/genericListChecker"
@@ -52,8 +52,14 @@ type AdapterManager struct {
 	ListCheckers map[string]adapters.Builder
 }
 
-// TODO: this implementation needs to be driven from external config instead of being
-// hardcoded
+// GetListCheckerAdapter returns a matching adapter for the given dispatchKey. If there is no existing adapter,
+// it instantiates one, based on the provided adapter config.
+func (mgr *AdapterManager) GetListCheckerAdapter(dispatchKey mixer.DispatchKey, config *adapters.AdapterConfig) (adapters.ListChecker, error) {
+	// TODO: instantiation & caching of the adapters.
+	return nil, errors.New("NYI")
+}
+
+// TODO: this implementation needs to be driven from external config instead of being hardcoded
 func prepBuilders(l []adapters.Builder) (map[string]adapters.Builder, error) {
 	m := make(map[string]adapters.Builder, len(l))
 

--- a/server/configManager.go
+++ b/server/configManager.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"istio.io/mixer"
+	"istio.io/mixer/config/listChecker"
+)
+
+// ConfigManager keeps track of the total configuration state of the mixer. It is responsible for containing the parsed
+// configuration for both the adapters themselves, as well as the bindings of the adapters inputs to the set of incoming
+// facts.
+type ConfigManager struct {
+}
+
+// NewConfigManager returns a new ConfigManager instance
+func NewConfigManager() (*ConfigManager, error) {
+	var mgr = ConfigManager{}
+	return &mgr, nil
+}
+
+// GetListCheckerConfigBlocks returns a list of ListCheckerConfigBlocks for the given serverID/peerID values.
+func (manager *ConfigManager) GetListCheckerConfigBlocks(dispatchKey mixer.DispatchKey) ([]*listChecker.ConfigBlock, error) {
+	// TODO: return an empty list for now, until we have support for configuration reading/evaluating.
+	return make([]*listChecker.ConfigBlock, 0), nil
+}

--- a/server/main.go
+++ b/server/main.go
@@ -76,6 +76,11 @@ func main() {
 		glog.Exitf("Unable to initialize adapters: %v", err)
 	}
 
+	var configMgr *ConfigManager
+	if configMgr, err = NewConfigManager(); err != nil {
+		glog.Exitf("Unable to initialize configuration: %v", err)
+	}
+
 	// TODO: hackily create a fact mapper builder & adapter.
 	// This necessarily needs to be discovered & created through normal
 	// adapter config goo, but that doesn't exist yet
@@ -96,7 +101,7 @@ func main() {
 		CompressedPayload:    *compressedPayload,
 		ServerCertificate:    serverCert,
 		ClientCertificates:   clientCerts,
-		Handlers:             NewAPIHandlers(),
+		Handlers:             NewAPIHandlers(adapterMgr, configMgr),
 		FactConverter:        factConverter,
 	}
 


### PR DESCRIPTION

This CL introduces a new component, ConfigManager, which is responsible for managing the configuration.

In addition, the higher-level of the check call is implemented: When a request comes in, the Check logic extracts well known serverName and peerId facts, finds the associated ListChecker configurations, obtains adapter instances with the appropriate fact checkers and applies them in sequence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/41)
<!-- Reviewable:end -->
