### PR TITLE
Add initial bazel.build support for adapters package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ dep-prep
 __pycache__/*
 .cache
 .cover/*
+bazel-*
+

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+
+go_prefix("istio.io/mixer")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,21 @@
+git_repository(
+    name = "io_bazel_rules_go",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    tag = "0.3.1",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
+
+go_repositories()
+
+new_go_repository(
+    name = "com_github_golang_glog",
+    commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
+    importpath = "github.com/golang/glog",
+)
+
+new_go_repository(
+    name = "in_gopkg_yaml_v2",
+    commit = "a5b47d31c556af34a302ce5d659e6fea44d90de0",
+    importpath = "gopkg.in/yaml.v2",
+)

--- a/adapters/BUILD
+++ b/adapters/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+  name = "go_default_library",
+  srcs = [
+    "adapter.go",
+    "builder.go",
+    "factConverter.go",
+    "listChecker.go",
+    "logger.go",
+  ],
+)

--- a/adapters/denyChecker/BUILD
+++ b/adapters/denyChecker/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "adapter.go",
+        "builder.go",
+    ],
+    deps = [
+        "//adapters:go_default_library",
+    ],
+)
+
+go_test(
+    name = "deny_checker_test",
+    srcs = [ "builder_test.go" ],
+    size = "small",
+    deps = [ "//adapters/testutil:go_default_library" ],
+    library = ":go_default_library",
+)

--- a/adapters/factMapper/BUILD
+++ b/adapters/factMapper/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "adapter.go",
+        "builder.go",
+        "tracker.go",
+    ],
+    deps = [
+        "//adapters:go_default_library",
+    ],
+)
+
+go_test(
+    name = "fact_mapper_test",
+    srcs = [ "builder_test.go" ],
+    size = "small",
+    deps = [ "//adapters/testutil:go_default_library" ],
+    library = ":go_default_library",
+)

--- a/adapters/genericListChecker/BUILD
+++ b/adapters/genericListChecker/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "adapter.go",
+        "builder.go",
+    ],
+    deps = [
+        "//adapters:go_default_library",
+    ],
+)
+
+go_test(
+    name = "generic_list_checker_test",
+    srcs = [ "builder_test.go" ],
+    size = "small",
+    deps = [ "//adapters/testutil:go_default_library" ],
+    library = ":go_default_library",
+)

--- a/adapters/ipListChecker/BUILD
+++ b/adapters/ipListChecker/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "adapter.go",
+        "builder.go",
+    ],
+    deps = [
+        "//adapters:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "ip_list_checker_test",
+    srcs = [ "builder_test.go" ],
+    size = "small",
+    deps = [ "//adapters/testutil:go_default_library" ],
+    library = ":go_default_library",
+)

--- a/adapters/jsonLogger/BUILD
+++ b/adapters/jsonLogger/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "adapter.go",
+        "builder.go",
+    ],
+    deps = [
+        "//adapters:go_default_library",
+    ],
+)
+
+go_test(
+    name = "json_logger_test",
+    srcs = [ "jsonLogger_test.go" ],
+    size = "small",
+    deps = [ "//adapters/testutil:go_default_library" ],
+    library = ":go_default_library",
+)

--- a/adapters/testutil/BUILD
+++ b/adapters/testutil/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "builders.go",
+    ],
+    deps = [
+        "//adapters:go_default_library",
+    ],
+)


### PR DESCRIPTION
This adds basic bazel.build support to the mixer/adapter package. The top-level build is not functional with this CL.

To use, from mixer/adapters:

- Build with: `bazel build ...`
- Run all tests with: `bazel test ...`

This is the first in a series of CLs needed to address issue #32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/46)
<!-- Reviewable:end -->
