### PR TITLE
Add bazel.build support to config/v1 package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,14 @@ clean_api:
 ## Config Targets
 
 CONFIG_SRC = $(wildcard config/v1/*.proto)
-CONFIG_OUTDIR_GO = config/v1/go
+CONFIG_OUTDIR_GO = $(VENDOR)/istio.io/mixer
 CONFIG_OUTDIR_CPP = config/v1/cpp
 CONFIG_OUTPUTS = $(CONFIG_SRC:config/v1/%.proto=$(CONFIG_OUTDIR_GO)/%.pb.go) $(CONFIG_SRC:config/v1/%.proto=$(CONFIG_OUTDIR_CPP)/%.pb.cc) $(CONFIG_SRC:config/v1/%.proto=$(CONFIG_OUTDIR_CPP)/%.pb.h)
 
 $(CONFIG_OUTDIR_GO)/%.pb.go $(CONFIG_OUTDIR_CPP)/%.pb.cc $(CONFIG_OUTDIR_CPP)/%.pb.h: config/v1/%.proto
 	@echo "Building config protos"
 	@mkdir -p $(CONFIG_OUTDIR_GO) $(CONFIG_OUTDIR_CPP)
-	@$(PROTOC) --proto_path=config/v1 --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --cpp_out=$(CONFIG_OUTDIR_CPP) --go_out=plugins=grpc:$(CONFIG_OUTDIR_GO) $(CONFIG_SRC)
+	@$(PROTOC) --proto_path=. --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --cpp_out=$(CONFIG_OUTDIR_CPP) --go_out=plugins=grpc:$(CONFIG_OUTDIR_GO) $(CONFIG_SRC)
 
 build_config: $(CONFIG_OUTPUTS)
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,8 +5,11 @@ git_repository(
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
 
 go_repositories()
+
+go_proto_repositories()
 
 new_go_repository(
     name = "com_github_golang_glog",

--- a/config/v1/BUILD
+++ b/config/v1/BUILD
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "lib_proto",
+    srcs = [ 
+        "label_descriptor.proto",
+        "log_entry_descriptor.proto",
+        "metric_descriptor.proto",
+        "monitored_resource_descriptor.proto",
+        "principal_descriptor.proto",
+        "quota_descriptor.proto",
+    ],
+)

--- a/config/v1/log_entry_descriptor.proto
+++ b/config/v1/log_entry_descriptor.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package config.v1;
 
-import "label_descriptor.proto";
+import "config/v1/label_descriptor.proto";
 
 // Defines the format of a single log entry.
 //

--- a/config/v1/metric_descriptor.proto
+++ b/config/v1/metric_descriptor.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package config.v1;
 
-import "label_descriptor.proto";
+import "config/v1/label_descriptor.proto";
 
 // Defines a metric type and its schema.
 //

--- a/config/v1/monitored_resource_descriptor.proto
+++ b/config/v1/monitored_resource_descriptor.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package config.v1;
 
-import "label_descriptor.proto";
+import "config/v1/label_descriptor.proto";
 
 // An object that describes the schema of a 'MonitoredResource'
 // using a name and a set of labels.

--- a/config/v1/principal_descriptor.proto
+++ b/config/v1/principal_descriptor.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package config.v1;
 
-import "label_descriptor.proto";
+import "config/v1/label_descriptor.proto";
 
 // Defines a a security principal.
 //

--- a/config/v1/quota_descriptor.proto
+++ b/config/v1/quota_descriptor.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package config.v1;
 
-import "label_descriptor.proto";
+import "config/v1/label_descriptor.proto";
 
 // Configuration state for a particular quota.
 //


### PR DESCRIPTION
This CL adds basic bazel.build support for the config protos. To
achieve this, it creates a single proto library in config/v1 and
alters the imports the proto files themselves to reflect full
package path from repo root. The Makefile is updated to accommodate
the changes.

To build, from repo root: `bazel build config/...`

This CL is continuing the effort to address issue #32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/48)
<!-- Reviewable:end -->
