### PR TITLE
Update Makefile to gen *.pb.go inline (instead of in vendor/).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,36 +32,36 @@ PROTOC = bin/protoc.$(shell uname)
 VENDOR = vendor
 
 API_SRC = $(wildcard api/v1/*.proto)
-API_OUTDIR_GO = $(VENDOR)/istio.io/mixer/api/v1
-API_OUTDIR_CPP = api/v1/cpp
-API_OUTPUTS = $(API_SRC:api/v1/%.proto=$(API_OUTDIR_GO)/%.pb.go) $(API_SRC:api/v1/%.proto=$(API_OUTDIR_CPP)/%.pb.cc) $(API_SRC:api/v1/%.proto=$(API_OUTDIR_CPP)/%.pb.h)
+API_OUTDIR_BASE = $(CURDIR)
+API_OUTDIR_FULL = $(API_OUTDIR_BASE)/api/v1
+API_OUTPUTS = $(API_SRC:api/v1/%.proto=$(API_OUTDIR_FULL)/%.pb.go)
 
-$(API_OUTDIR_GO)/%.pb.go $(API_OUTDIR_CPP)/%.pb.cc $(API_OUTDIR_CPP)/%.pb.h: api/v1/%.proto
+$(API_OUTDIR_FULL)/%.pb.go: api/v1/%.proto
 	@echo "Building API protos"
-	@mkdir -p $(API_OUTDIR_GO) $(API_OUTDIR_CPP)
-	@$(PROTOC) --proto_path=api/v1 --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --cpp_out=$(API_OUTDIR_CPP) --go_out=plugins=grpc:$(VENDOR) $(API_SRC)
+	@mkdir -p $(API_OUTDIR_FULL)
+	@$(PROTOC) --proto_path=. --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --go_out=plugins=grpc:$(API_OUTDIR_BASE) $(API_SRC)
 
 build_api: $(API_OUTPUTS)
 
 clean_api:
-	@rm -fr $(API_OUTDIR_GO) $(API_OUTDIR_CPP)
+	@rm -fr $(API_OUTDIR_FULL)/*.pb.go
 
 ## Config Targets
 
 CONFIG_SRC = $(wildcard config/v1/*.proto)
-CONFIG_OUTDIR_GO = $(VENDOR)/istio.io/mixer
-CONFIG_OUTDIR_CPP = config/v1/cpp
-CONFIG_OUTPUTS = $(CONFIG_SRC:config/v1/%.proto=$(CONFIG_OUTDIR_GO)/%.pb.go) $(CONFIG_SRC:config/v1/%.proto=$(CONFIG_OUTDIR_CPP)/%.pb.cc) $(CONFIG_SRC:config/v1/%.proto=$(CONFIG_OUTDIR_CPP)/%.pb.h)
+CONFIG_OUTDIR_BASE = $(CURDIR)
+CONFIG_OUTDIR_FULL = $(CONFIG_OUTDIR_BASE)/config/v1
+CONFIG_OUTPUTS = $(CONFIG_SRC:config/v1/%.proto=$(CONFIG_OUTDIR_FULL)/%.pb.go)
 
-$(CONFIG_OUTDIR_GO)/%.pb.go $(CONFIG_OUTDIR_CPP)/%.pb.cc $(CONFIG_OUTDIR_CPP)/%.pb.h: config/v1/%.proto
+$(CONFIG_OUTDIR_FULL)/%.pb.go: config/v1/%.proto
 	@echo "Building config protos"
-	@mkdir -p $(CONFIG_OUTDIR_GO) $(CONFIG_OUTDIR_CPP)
-	@$(PROTOC) --proto_path=. --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --cpp_out=$(CONFIG_OUTDIR_CPP) --go_out=plugins=grpc:$(CONFIG_OUTDIR_GO) $(CONFIG_SRC)
+	@mkdir -p $(CONFIG_OUTDIR_FULL)
+	@$(PROTOC) --proto_path=. --proto_path=vendor/github.com/googleapis/googleapis --proto_path=vendor/github.com/google/protobuf/src --go_out=plugins=grpc:$(CONFIG_OUTDIR_BASE) $(CONFIG_SRC)
 
 build_config: $(CONFIG_OUTPUTS)
 
 clean_config:
-	@rm -fr $(CONFIG_OUTDIR_GO) $(CONFIG_OUTDIR_CPP)
+	@rm -fr $(CONFIG_OUTDIR_FULL)/*.pb.go
 
 ## Server targets
 

--- a/api/v1/check.proto
+++ b/api/v1/check.proto
@@ -14,9 +14,7 @@
 
 syntax = "proto3";
 
-package istio.mixer.v1;
-
-option go_package="istio.io/mixer/api/v1;mixerpb";
+package api.v1;
 
 import "google/rpc/status.proto";
 

--- a/api/v1/quota.proto
+++ b/api/v1/quota.proto
@@ -14,9 +14,7 @@
 
 syntax = "proto3";
 
-package istio.mixer.v1;
-
-option go_package="istio.io/mixer/api/v1;mixerpb";
+package api.v1;
 
 import "google/rpc/status.proto";
 

--- a/api/v1/report.proto
+++ b/api/v1/report.proto
@@ -14,9 +14,7 @@
 
 syntax = "proto3";
 
-package istio.mixer.v1;
-
-option go_package="istio.io/mixer/api/v1;mixerpb";
+package api.v1;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";

--- a/api/v1/service.proto
+++ b/api/v1/service.proto
@@ -14,13 +14,11 @@
 
 syntax = "proto3";
 
-package istio.mixer.v1;
+package api.v1;
 
-option go_package="istio.io/mixer/api/v1;mixerpb";
-
-import "check.proto";
-import "report.proto";
-import "quota.proto";
+import "api/v1/check.proto";
+import "api/v1/report.proto";
+import "api/v1/quota.proto";
 
 // The Istio Mixer API
 service Mixer {

--- a/example/client/cmd/check.go
+++ b/example/client/cmd/check.go
@@ -28,9 +28,9 @@ var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Invokes the mixer's Check API.",
 	Run: func(cmd *cobra.Command, args []string) {
-		cs, err := createAPIClient(mixerAddress)
+		cs, err := createAPIClient(MixerAddress)
 		if err != nil {
-			errorf("Unable to establish connection to %s", mixerAddress)
+			errorf("Unable to establish connection to %s", MixerAddress)
 			return
 		}
 		defer deleteAPIClient(cs)
@@ -42,7 +42,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		var attrs map[string]string
-		if attrs, err = parseAttributes(attributes); err != nil {
+		if attrs, err = parseAttributes(Attributes); err != nil {
 			errorf(err.Error())
 			return
 		}

--- a/example/client/cmd/root.go
+++ b/example/client/cmd/root.go
@@ -20,8 +20,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var attributes string
-var mixerAddress string
+// Attributes is the list of name/value pairs of attributes that will be sent with requests.
+var Attributes string
+
+// MixerAddress is the full address (including port) of a mixer instance to call.
+var MixerAddress string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{

--- a/example/client/cmd/util.go
+++ b/example/client/cmd/util.go
@@ -21,7 +21,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"istio.io/mixer/api/v1"
+	mixerpb "istio.io/mixer/api/v1"
 )
 
 type clientState struct {

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
 hash: e656a3c4d739d645abd37e646e6aaac61cf01675397448f022004a266c30a3bf
-updated: 2016-12-09T09:00:18.499703569-08:00
+updated: 2016-12-09T18:40:50.158839884-08:00
 imports:
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:
   - proto
   - ptypes/any
@@ -12,9 +12,9 @@ imports:
   - ptypes/timestamp
   - ptypes/wrappers
 - name: github.com/google/protobuf
-  version: 39f9b43219bc5718b659ed72a2130a7b2ce66108
+  version: 277a8b65805aceeefc1764947616430994e05bdf
 - name: github.com/googleapis/googleapis
-  version: 1e43683baaf049720b4bd5e2995304c430c749bd
+  version: 15282fdb98e08a2c4345e2a6649b2b09df86f5da
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/spf13/cobra
@@ -24,7 +24,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: golang.org/x/net
-  version: 4971afdc2f162e82d185353533d3cf16188a9f4e
+  version: b1a2d6e8c8b5fc8f601ead62536f02a8e1b6217d
   subpackages:
   - context
   - http2
@@ -34,12 +34,12 @@ imports:
   - lex/httplex
   - internal/timeseries
 - name: google.golang.org/genproto
-  version: f3350869260a1e80675c8d0e42f1f3a870db2b74
+  version: 08f135d1a31b6ba454287638a3ce23a55adace6f
   subpackages:
   - googleapis/rpc/code
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: eca2ad68af4d7bf894ada6bd263133f069a441d5
+  version: 8712952b7d646dbbbc6fb73a782174f3115060f3
   subpackages:
   - credentials
   - codes

--- a/server/apiHandlers.go
+++ b/server/apiHandlers.go
@@ -21,7 +21,8 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 
 	"istio.io/mixer/adapters"
-	"istio.io/mixer/api/v1"
+
+	mixerpb "istio.io/mixer/api/v1"
 )
 
 // APIHandlers holds pointers to the functions that implement

--- a/server/apiServer.go
+++ b/server/apiServer.go
@@ -33,9 +33,9 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"istio.io/mixer/adapters"
-	"istio.io/mixer/api/v1"
 
 	proto "github.com/golang/protobuf/proto"
+	mixerpb "istio.io/mixer/api/v1"
 )
 
 // APIServerOptions controls the behavior of a gRPC server.


### PR DESCRIPTION
This CL alters the approach towards proto gen to use the
local directories for the protos, instead of vendor/. As
a result of the changes, some of the packages for various
proto files are updated (and golang options removed). This
should make it easier for bazel.build to be overlayed.

Additionally, the generation of c++ code from protos was removed.
This functionality can be restored at a later date when needed.
Generating them in the same dir as the protos causes compilation
issues, and pushing them into a special cpp/ directory feels less
than ideal. They aren't needed at the moment, so we can defer
this design bit until later. Bazel.build may make the this bit
obsolete anyhow.

This also updates some of the example code that was preventing
make from completing properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/51)
<!-- Reviewable:end -->
