### PR TITLE
Add bazel.build support for api/v1 and server/.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,26 @@
+workspace(name = "com_github_istio_mixer")
+
 git_repository(
     name = "io_bazel_rules_go",
+    commit = "4c73b9cb84c1f8e32e7df3c26e237439699d5d8c",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.3.1",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
-load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
 
 go_repositories()
+
+git_repository(
+    name = "org_pubref_rules_protobuf",
+    remote = "https://github.com/pubref/rules_protobuf",
+    tag = "v0.7.1",
+)
+
+load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_repositories")
+
+proto_repositories()
+
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_repositories")
 
 go_proto_repositories()
 
@@ -21,4 +34,52 @@ new_go_repository(
     name = "in_gopkg_yaml_v2",
     commit = "a5b47d31c556af34a302ce5d659e6fea44d90de0",
     importpath = "gopkg.in/yaml.v2",
+)
+
+new_go_repository(
+    name = "com_github_golang_protobuf",
+    commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",
+    importpath = "github.com/golang/protobuf",
+)
+
+GOOGLEAPIS_BUILD_FILE = """
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+go_prefix("github.com/googleapis/googleapis")
+
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "go_status_proto",
+    protos = [
+        "google/rpc/status.proto",
+    ],
+    imports = [
+        "../../external/com_github_google_protobuf/src",
+    ],
+    deps = [
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+    ],
+    verbose = 0,
+)
+"""
+
+new_git_repository(
+    name = "com_github_googleapis_googleapis",
+    build_file_content = GOOGLEAPIS_BUILD_FILE,
+    commit = "13ac2436c5e3d568bd0e938f6ed58b77a48aba15",
+    remote = "https://github.com/googleapis/googleapis.git",
+)
+
+new_go_repository(
+    name = "com_github_google_go_genproto",
+    commit = "08f135d1a31b6ba454287638a3ce23a55adace6f",
+    importpath = "google.golang.org/genproto",
+)
+
+new_go_repository(
+    name = "org_golang_google_grpc",
+    commit = "8712952b7d646dbbbc6fb73a782174f3115060f3",
+    importpath = "google.golang.org/grpc",
 )

--- a/api/v1/BUILD
+++ b/api/v1/BUILD
@@ -1,0 +1,37 @@
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+
+go_proto_library(
+    # use go_default_library here to prevent need to append lib name on imports
+    name = "go_default_library",
+    importmap = {
+        "google/rpc/status.proto": "google.golang.org/genproto/googleapis/rpc/status",
+    },
+    imports = [
+        "external/com_github_google_protobuf/src",
+        "external/com_github_googleapis_googleapis"
+    ],
+    protos = [ 
+        "check.proto",
+        "report.proto",
+        "quota.proto",
+        "service.proto",
+    ],
+    deps = [
+        "@com_github_googleapis_googleapis//:go_status_proto",
+        "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/plugin:go_default_library",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
+        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+
+        # needed until org_pubref_rules_protobuf updates to grpc 1.0.4 in deps
+        # issue https://github.com/pubref/rules_protobuf/issues/46 filed.
+        "@org_golang_google_grpc//:go_default_library", 
+    ],
+    verbose = 0,
+    visibility = ["//visibility:public"],
+)

--- a/config/v1/BUILD
+++ b/config/v1/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
 
 go_proto_library(
-    name = "lib_proto",
-    srcs = [ 
+    name = "go_default_library",
+    protos = [ 
         "label_descriptor.proto",
         "log_entry_descriptor.proto",
         "metric_descriptor.proto",

--- a/server/BUILD
+++ b/server/BUILD
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+DEPS = [
+    "//adapters:go_default_library",
+    "//adapters/denyChecker:go_default_library",
+    "//adapters/factMapper:go_default_library",
+    "//adapters/genericListChecker:go_default_library",
+    "//adapters/ipListChecker:go_default_library",
+    "//api/v1:go_default_library",
+    "@com_github_golang_glog//:go_default_library",
+    "@com_github_golang_protobuf//proto:go_default_library",
+    "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
+    "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
+    "@org_golang_google_grpc//:go_default_library",
+    "@org_golang_google_grpc//credentials:go_default_library",
+]
+
+go_binary(
+    name = "server",
+    srcs = [ 
+        "adapterManager.go",
+        "apiHandlers.go",
+        "apiServer.go",
+        "main.go",
+    ],
+    deps = DEPS,
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "adapterManager.go",
+        "apiHandlers.go",
+        "apiServer.go",
+    ],
+    deps = DEPS
+)
+
+go_test(
+    name = "api_server_test",
+    srcs = [ "apiServer_test.go" ],
+    size = "small",
+    deps = [ "//adapters/testutil:go_default_library" ],
+    library = ":go_default_library",
+)

--- a/server/apiServer_test.go
+++ b/server/apiServer_test.go
@@ -25,7 +25,8 @@ import (
 
 	"istio.io/mixer/adapters"
 	"istio.io/mixer/adapters/factMapper"
-	"istio.io/mixer/api/v1"
+
+	mixerpb "istio.io/mixer/api/v1"
 )
 
 const (


### PR DESCRIPTION
This CL establishes a working bazel build for the go_binary for mixer server. In doing so, it also
establishes bazel.build support for the api/v1 package.

Tested with the following from repo root:

1. `bazel clean`
1. `bazel build ...`
1. `bazel test ...`

Output of `bazel test ...`

```
INFO: Found 14 targets and 6 test targets...
INFO: Elapsed time: 0.347s, Critical Path: 0.14s
//adapters/denyChecker:deny_checker_test                                 PASSED in 0.1s
//adapters/factMapper:fact_mapper_test                                   PASSED in 0.1s
//adapters/genericListChecker:generic_list_checker_test                  PASSED in 0.1s
//adapters/ipListChecker:ip_list_checker_test                            PASSED in 0.1s
//adapters/jsonLogger:json_logger_test                                   PASSED in 0.1s
//server:api_server_test                                                 PASSED in 0.1s
```

Addresses issue #32 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/54)
<!-- Reviewable:end -->
