### PR TITLE
Add initial travis-CI build config for bazel.build.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+test --test_output=errors
+test --test_size_filters=-large,-enormous

--- a/.bazelrc.travis
+++ b/.bazelrc.travis
@@ -1,0 +1,19 @@
+# This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
+startup --host_jvm_args=-Xmx2500m
+startup --host_jvm_args=-Xms2500m
+startup --batch
+test --ram_utilization_factor=10
+
+# This is so we understand failures better
+build --verbose_failures
+
+# This is so we don't use sandboxed execution. Sandboxed execution
+# runs stuff in a container, and since Travis already runs its script
+# in a container (unless you require sudo in your .travis.yml) this
+# fails to run tests.
+build --spawn_strategy=standalone --genrule_strategy=standalone
+test --test_strategy=standalone
+
+# Below this line, .travis.yml will cat the default bazelrc.
+# This is needed so Bazel starts with the base workspace in its
+# package path.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+dist: xenial
+
+lang: go
+
+go:
+  - 1.7.x
+
+jdk:
+  - oraclejdk8
+
+env:
+  - BAZEL_VERSION=0.4.2
+
+addons:
+  apt:
+    packages:
+      - wget
+
+cache:
+  directories:
+    - $HOME/bazel/install
+    - $HOME/bazel/outbase
+
+before_install:
+  - mkdir -p ${HOME}/bazel/install
+  - cd ${HOME}/bazel/install
+  - wget --no-clobber "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" 
+  - chmod +x bazel_${BAZEL_VERSION}-linux-x86_64.deb
+  - sudo dpkg -i bazel_${BAZEL_VERSION}-linux-x86_64.deb
+  - cd ${TRAVIS_BUILD_DIR}
+  - mv .bazelrc .bazelrc.orig
+  - cat .bazelrc.travis .bazelrc.orig > .bazelrc
+
+script:
+  - bazel --output_base=${HOME}/bazel/outbase test //...


### PR DESCRIPTION
This does not attempt to provide any coverage information. It does attempt to use caching of directories to improve test performance.

There is a lot of room for improvement here, but it should establish the basic ability to run tests with our bazel.build and see the status of those tests via travis-ci. Hopefully, this can be improved with subsequent updates.

This is meant to address issues #2 and #32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/56)
<!-- Reviewable:end -->
