### PR TITLE
Add metricReporter interface to adapters package.

### DIFF
--- a/adapters/BUILD
+++ b/adapters/BUILD
@@ -10,5 +10,6 @@ go_library(
     "factConverter.go",
     "listChecker.go",
     "logger.go",
+    "metricsReporter.go",
   ],
 )

--- a/adapters/metricsReporter.go
+++ b/adapters/metricsReporter.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import "time"
+
+type (
+	// MetricsReporter is the interface for adapters that will handle metrics
+	// data within the mixer.
+	MetricsReporter interface {
+		Adapter
+
+		// ReportMetrics directs a backend adapter to process a batch of
+		// MetricValues derived from potentially several Report() calls.
+		ReportMetrics([]MetricValue) error
+	}
+
+	// MetricValue holds the value of a metric, along with dimensional and
+	// other metadata.
+	MetricValue struct {
+		// Name is the unique name for the metric. Name is used to identify
+		// the descriptor for this MetricValue.
+		Name string
+
+		// StartTime identifies the start time of value collection.
+		// An instant can be represented by only reporting an end
+		// time and no start time.
+		StartTime time.Time
+
+		// EndTime identifies the end time of value collection.
+		EndTime time.Time
+
+		// Attributes are a set of key-value pairs for dimensional data.
+		// These correspond directly to the attributes specified in the
+		// schema for this metric value.
+		Attributes map[string]string
+
+		// BoolValue provides a boolean metric value.
+		BoolValue bool
+
+		// Int64Value provides an integer metric value.
+		Int64Value int64
+
+		// Float64Value provides a double-precision floating-point metric
+		// value.
+		Float64Value float64
+
+		// StringValue provides a string-encoded metric value.
+		StringValue string
+	}
+)


### PR DESCRIPTION
Proposal for monitoring interface for adapters that will expose metrics
to various backends. This borrows heavily from the config/v1 descriptor
schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/62)
<!-- Reviewable:end -->
