### PR TITLE
Add flags to .bazelrc to disable the sandbox.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 test --test_output=errors
 test --test_size_filters=-large,-enormous
+# Disable the sandbox so that protos can build; see https://github.com/istio/mixer/issues/69
 build --genrule_strategy=standalone
 build --spawn_strategy=standalone

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,4 @@
 test --test_output=errors
 test --test_size_filters=-large,-enormous
+build --genrule_strategy=standalone
+build --spawn_strategy=standalone


### PR DESCRIPTION
At head bazel build has a race condition retrieving imported sources. Forcing bazel to not use a sandbox removes this race, making builds work again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/70)
<!-- Reviewable:end -->
