### PR TITLE
Disable the Bazel sandbox in our .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
 test --test_output=errors
 test --test_size_filters=-large,-enormous
+# Disable sandbox; see github.com/istio/mixer/issues/69
+build --genrule_strategy=standalone
+build --spawn_strategy=standalone


### PR DESCRIPTION
There is currently a race condition in the bazel build as it imports sources in parallel. By disabling the sandbox we remove this race, making the build work consistently and deterministically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/71)
<!-- Reviewable:end -->
