### PR TITLE
Add BUILD rules for istio/api repo.

### DIFF
--- a/BUILD.api
+++ b/BUILD.api
@@ -1,3 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+
+# Desired effect: import "istio.io/mixer/api/v1"
+go_prefix("istio.io")
+
 load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
 
 go_proto_library(
@@ -7,14 +14,15 @@ go_proto_library(
         "google/rpc/status.proto": "google.golang.org/genproto/googleapis/rpc/status",
     },
     imports = [
-        "external/com_github_google_protobuf/src",
-        "external/com_github_googleapis_googleapis"
+        "../../external/com_github_google_protobuf/src",
+        "../../external/com_github_googleapis_googleapis"
     ],
-    protos = [ 
-        "check.proto",
-        "report.proto",
-        "quota.proto",
-        "service.proto",
+    protos = [
+        "mixer/api/v1/attributes.proto",
+        "mixer/api/v1/check.proto",
+        "mixer/api/v1/report.proto",
+        "mixer/api/v1/quota.proto",
+        "mixer/api/v1/service.proto",
     ],
     deps = [
         "@com_github_googleapis_googleapis//:go_status_proto",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "com_github_istio_mixer")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "4c73b9cb84c1f8e32e7df3c26e237439699d5d8c",
+    commit = "2c6fa767100b95799043451aa3ee221d9a9bbb55",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
@@ -24,6 +24,7 @@ load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_repositories")
 load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
 
 cpp_proto_repositories()
+
 go_proto_repositories()
 
 new_go_repository(
@@ -65,19 +66,6 @@ go_proto_library(
     ],
     verbose = 0,
 )
-
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cc_proto_library")
-
-cc_proto_library(
-    name = "cc_status_proto",
-    protos = [
-        "google/rpc/status.proto",
-    ],
-    imports = [
-        "../../external/com_github_google_protobuf/src",
-    ],
-    verbose = 0,
-)
 """
 
 new_git_repository(
@@ -109,4 +97,11 @@ new_go_repository(
     name = "com_github_spf13_pflag",
     commit = "5ccb023bc27df288a957c5e994cd44fd19619465",
     importpath = "github.com/spf13/pflag",
+)
+
+new_git_repository(
+    name = "com_github_istio_api",
+    build_file = "BUILD.api",
+    commit = "81854bc61abf2753aaf8adc1d114cc61ee960da7",
+    remote = "https://github.com/istio/api.git",
 )


### PR DESCRIPTION
I haven't been able to validate this BUILD yet, as the PR for the istio/api repo files is still in review.

Submitting now, however, so that @geeknoid can potentially use this as a patch to validate the istio/api PR and work to switch over mixer to the new API surface. It will need tweaking depending on the packages and paths of the committed protos in that repo, etc.

@geeknoid: One thing that will absolutely have to change is the commit listed for the com_github_istio_api git repository in the WORKSPACE file. It will need to match whatever commit contains the final result of your inflight PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/79)
<!-- Reviewable:end -->
