### PR TITLE
Update the BUILD rules for istio/api in the mixer repo.

### DIFF
--- a/BUILD.api
+++ b/BUILD.api
@@ -17,6 +17,10 @@ go_proto_library(
         "../../external/com_github_google_protobuf/src",
         "../../external/com_github_googleapis_googleapis"
     ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_googleapis_googleapis//:status_proto",
+    ],
     protos = [
         "mixer/api/v1/attributes.proto",
         "mixer/api/v1/check.proto",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,6 +123,6 @@ new_go_repository(
 new_git_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
-    commit = "81854bc61abf2753aaf8adc1d114cc61ee960da7",
+    commit = "cf7f8a4dde9504eaed44eb43c55133e65ff6e67e",
     remote = "https://github.com/istio/api.git",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,6 +123,6 @@ new_go_repository(
 new_git_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
-    commit = "cf7f8a4dde9504eaed44eb43c55133e65ff6e67e",
+    commit = "78eee435367ffe5f179395ee9a49e2d309e9d1d6",
     remote = "https://github.com/istio/api.git",
 )


### PR DESCRIPTION
NOTE: Trying to build the istio/api repo still fails as several protos reference 'attribute.proto' instead of 'attributes.proto'.

```
$ bazel build @com_github_istio_api//:go_default_library
INFO: Found 1 target...
ERROR: /private/var/tmp/_bazel_dougreid/5a64d675d9770ab00ead2cf89d1223e3/external/com_github_istio_api/BUILD:10:1: error executing shell command: 'cd external/com_github_istio_api && ../../bazel-out/host/bin/external/com_github_google_protobuf/protoc --descriptor_set_out=../../bazel-out/local-fastbuild/genfiles/external/com_github_istio_api/g...' failed: bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped): com.google.devtools.build.lib.shell.BadExitStatusException: Process exited with status 1.
mixer/api/v1/attribute.proto: File not found.
mixer/api/v1/check.proto: Import "mixer/api/v1/attribute.proto" was not found or had errors.
mixer/api/v1/check.proto:28:3: "istio.mixer.v1.Attributes" seems to be defined in "mixer/api/v1/attributes.proto", which is not imported by "mixer/api/v1/check.proto".  To use it here, please add the necessary import.
Target @com_github_istio_api//:go_default_library failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.252s, Critical Path: 0.03s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/81)
<!-- Reviewable:end -->
