### PR TITLE
Enable build against local istio repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,5 +124,12 @@ new_git_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
     commit = "1d9417f607be5503eee95fdb109c0d906fe6b5f5",
-    remote = "https://github.com/istio/api.git",
+    remote = "https://github.com/istio/api.git"
+)
+
+# use with --define istio=local invocation 
+new_local_repository(
+    name = "local_istio_api",
+    build_file = "BUILD.api",
+    path = "../api"
 )

--- a/server/BUILD
+++ b/server/BUILD
@@ -2,6 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
+config_setting(
+    name = "local",
+    values = { "define": "istio=local" }
+)
+
 DEPS = [
     "//:go_default_library",
     "//adapters:go_default_library",
@@ -11,7 +16,6 @@ DEPS = [
     "//adapters/ipListChecker:go_default_library",
     "//adapters/jsonLogger:go_default_library",
     "//config/listChecker:go_default_library",
-    "@com_github_istio_api//:go_default_library",
     "@com_github_golang_glog//:go_default_library",
     "@com_github_golang_protobuf//proto:go_default_library",
     "@com_github_golang_protobuf//ptypes:go_default_library",
@@ -19,7 +23,10 @@ DEPS = [
     "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
     "@org_golang_google_grpc//:go_default_library",
     "@org_golang_google_grpc//credentials:go_default_library",
-]
+] + select ({
+    ":local": ["@local_istio_api//:go_default_library"],
+    "//conditions:default": ["@com_github_istio_api//:go_default_library"]
+	})
 
 go_binary(
     name = "server",


### PR DESCRIPTION
```
bazel build //server:server --define istio=local
```
Will build against the standard expected place of istio.io api per go conventions.

$GOPATH/src/istio.io/api

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/84)
<!-- Reviewable:end -->
