### PR TITLE
Format BUILD files with buildifier

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,12 +124,12 @@ new_git_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
     commit = "1d9417f607be5503eee95fdb109c0d906fe6b5f5",
-    remote = "https://github.com/istio/api.git"
+    remote = "https://github.com/istio/api.git",
 )
 
-# use with --define istio=local invocation 
+# use with --define istio=local invocation
 new_local_repository(
     name = "local_istio_api",
     build_file = "BUILD.api",
-    path = "../api"
+    path = "../api",
 )

--- a/adapter/denyChecker/BUILD
+++ b/adapter/denyChecker/BUILD
@@ -8,15 +8,13 @@ go_library(
         "adapter.go",
         "builder.go",
     ],
-    deps = [
-        "//pkg/adapter:go_default_library",
-    ],
+    deps = ["//pkg/adapter:go_default_library"],
 )
 
 go_test(
     name = "deny_checker_test",
-    srcs = [ "builder_test.go" ],
     size = "small",
-    deps = [ "//pkg/adaptertesting:go_default_library" ],
+    srcs = ["builder_test.go"],
     library = ":go_default_library",
+    deps = ["//pkg/adaptertesting:go_default_library"],
 )

--- a/adapter/genericListChecker/BUILD
+++ b/adapter/genericListChecker/BUILD
@@ -8,15 +8,13 @@ go_library(
         "adapter.go",
         "builder.go",
     ],
-    deps = [
-        "//pkg/adapter:go_default_library",
-    ],
+    deps = ["//pkg/adapter:go_default_library"],
 )
 
 go_test(
     name = "generic_list_checker_test",
-    srcs = [ "builder_test.go" ],
     size = "small",
-    deps = [ "//pkg/adaptertesting:go_default_library" ],
+    srcs = ["builder_test.go"],
     library = ":go_default_library",
+    deps = ["//pkg/adaptertesting:go_default_library"],
 )

--- a/adapter/ipListChecker/BUILD
+++ b/adapter/ipListChecker/BUILD
@@ -9,16 +9,16 @@ go_library(
         "builder.go",
     ],
     deps = [
-        "//pkg/adapter:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
+        "//pkg/adapter:go_default_library",
     ],
 )
 
 go_test(
     name = "ip_list_checker_test",
-    srcs = [ "builder_test.go" ],
     size = "small",
-    deps = [ "//pkg/adaptertesting:go_default_library" ],
+    srcs = ["builder_test.go"],
     library = ":go_default_library",
+    deps = ["//pkg/adaptertesting:go_default_library"],
 )

--- a/adapter/jsonLogger/BUILD
+++ b/adapter/jsonLogger/BUILD
@@ -6,18 +6,16 @@ go_library(
     name = "go_default_library",
     srcs = [
         "adapter.go",
-        "config.go",
         "builder.go",
+        "config.go",
     ],
-    deps = [
-        "//pkg/adapter:go_default_library",
-    ],
+    deps = ["//pkg/adapter:go_default_library"],
 )
 
 go_test(
     name = "json_logger_test",
-    srcs = [ "jsonLogger_test.go" ],
     size = "small",
-    deps = [ "//pkg/adaptertesting:go_default_library" ],
+    srcs = ["jsonLogger_test.go"],
     library = ":go_default_library",
+    deps = ["//pkg/adaptertesting:go_default_library"],
 )

--- a/cmd/client/BUILD
+++ b/cmd/client/BUILD
@@ -2,32 +2,36 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
-SRCS = [
-    "check.go",
-    "main.go",
-    "quota.go",
-    "report.go",
-    "util.go",
-]
-
-DEPS = [
-    "@com_github_istio_api//:go_default_library",
-    "@com_github_golang_glog//:go_default_library",
-    "@com_github_golang_protobuf//ptypes:go_default_library",
-    "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-    "@com_github_spf13_cobra//:go_default_library",
-    "@org_golang_google_grpc//:go_default_library",
-]
-
-go_binary(
-    name = "mixc",
-    srcs = SRCS,
-    deps = DEPS,
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "check.go",
+        "main.go",
+        "quota.go",
+        "report.go",
+        "util.go",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_istio_api//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
 )
 
 go_test(
     name = "util_test",
-    srcs = SRCS + ["util_test.go"],
-    deps = DEPS,
     size = "small",
+    srcs = ["util_test.go"],
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "mixc",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
 )

--- a/cmd/server/BUILD
+++ b/cmd/server/BUILD
@@ -1,21 +1,28 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_binary(
-    name = "mixs",
+go_library(
+    name = "go_default_library",
     srcs = [
+        "adapter.go",
         "main.go",
         "server.go",
-        "adapter.go"
     ],
+    visibility = ["//visibility:private"],
     deps = [
-        "//pkg/api:go_default_library",
-        "//pkg/server:go_default_library",
-        "//pkg/adapter:go_default_library",
-        "//pkg/attribute:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/api:go_default_library",
+        "//pkg/attribute:go_default_library",
+        "//pkg/server:go_default_library",
     ],
+)
+
+go_binary(
+    name = "mixs",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
 )

--- a/pkg/adapter/BUILD
+++ b/pkg/adapter/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -10,14 +10,5 @@ go_library(
         "listChecker.go",
         "logger.go",
         "metricsReporter.go",
-    ],
-    deps = [
-        "@com_github_golang_glog//:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
-        "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )

--- a/pkg/adaptertesting/BUILD
+++ b/pkg/adaptertesting/BUILD
@@ -4,10 +4,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "builders.go",
-    ],
-    deps = [
-        "//pkg/adapter:go_default_library",
-    ],
+    srcs = ["builders.go"],
+    deps = ["//pkg/adapter:go_default_library"],
 )

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 config_setting(
     name = "local",
-    values = { "define": "istio=local" }
+    values = {"define": "istio=local"},
 )
 
 DEPS = [
@@ -19,10 +19,10 @@ DEPS = [
     "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
     "@org_golang_google_grpc//:go_default_library",
     "@org_golang_google_grpc//credentials:go_default_library",
-] + select ({
+] + select({
     ":local": ["@local_istio_api//:go_default_library"],
-    "//conditions:default": ["@com_github_istio_api//:go_default_library"]
-    })
+    "//conditions:default": ["@com_github_istio_api//:go_default_library"],
+})
 
 go_library(
     name = "go_default_library",
@@ -30,12 +30,12 @@ go_library(
         "grpcServer.go",
         "methodHandlers.go",
     ],
-    deps = DEPS
+    deps = DEPS,
 )
 
 go_test(
     name = "grpc_server_test",
-    srcs = [ "grpcServer_test.go" ],
     size = "small",
+    srcs = ["grpcServer_test.go"],
     library = ":go_default_library",
 )

--- a/pkg/attribute/BUILD
+++ b/pkg/attribute/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 config_setting(
     name = "local",
-    values = { "define": "istio=local" }
+    values = {"define": "istio=local"},
 )
 
 DEPS = [
@@ -12,32 +12,36 @@ DEPS = [
     "@com_github_golang_protobuf//proto:go_default_library",
     "@com_github_golang_protobuf//ptypes:go_default_library",
     "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-] + select ({
+] + select({
     ":local": ["@local_istio_api//:go_default_library"],
-    "//conditions:default": ["@com_github_istio_api//:go_default_library"]
-    })
+    "//conditions:default": ["@com_github_istio_api//:go_default_library"],
+})
 
 go_library(
     name = "go_default_library",
     srcs = [
-        "manager.go",
         "context.go",
-        "tracker.go",
         "dictionaries.go",
+        "manager.go",
+        "tracker.go",
     ],
-    deps = DEPS
+    deps = [
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_istio_api//:go_default_library",
+    ],
 )
 
 go_test(
     name = "dictionaries_test",
-    srcs = [ "dictionaries_test.go" ],
     size = "small",
+    srcs = ["dictionaries_test.go"],
     library = ":go_default_library",
 )
 
 go_test(
     name = "manager_test",
-    srcs = [ "manager_test.go" ],
     size = "small",
+    srcs = ["manager_test.go"],
     library = ":go_default_library",
+    deps = DEPS,
 )

--- a/pkg/config/listChecker/BUILD
+++ b/pkg/config/listChecker/BUILD
@@ -9,7 +9,5 @@ go_library(
         "bindingEvaluator.go",
         "configBlock.go",
     ],
-    deps = [
-        "//pkg/adapter:go_default_library",
-    ]
+    deps = ["//pkg/adapter:go_default_library"],
 )

--- a/pkg/server/BUILD
+++ b/pkg/server/BUILD
@@ -1,23 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-
-DEPS = [
-    "//adapter/denyChecker:go_default_library",
-    "//adapter/genericListChecker:go_default_library",
-    "//adapter/ipListChecker:go_default_library",
-    "//adapter/jsonLogger:go_default_library",
-    "//pkg/config/listChecker:go_default_library",
-    "//pkg/attribute:go_default_library",
-    "//pkg/adapter:go_default_library",
-    "@com_github_golang_glog//:go_default_library",
-    "@com_github_golang_protobuf//proto:go_default_library",
-    "@com_github_golang_protobuf//ptypes:go_default_library",
-    "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
-    "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
-    "@org_golang_google_grpc//:go_default_library",
-    "@org_golang_google_grpc//credentials:go_default_library",
-]
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -26,5 +9,13 @@ go_library(
         "configManager.go",
         "dispatchKey.go",
     ],
-    deps = DEPS
+    deps = [
+        "//adapter/denyChecker:go_default_library",
+        "//adapter/genericListChecker:go_default_library",
+        "//adapter/ipListChecker:go_default_library",
+        "//adapter/jsonLogger:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/attribute:go_default_library",
+        "//pkg/config/listChecker:go_default_library",
+    ],
 )


### PR DESCRIPTION
I ran the buildifier tool in fix mode over the codebase to see what it would do, and it made the following formatting changes (with minor hand revisions to eliminate SRC and DEPS stuff when appropriate).

Tool: go install github.com/bazelbuild/buildifier/buildifier

Command: $ buildifier -showlog -mode=fix $(find . -iname BUILD -type f)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/97)
<!-- Reviewable:end -->
