### PR TITLE
Simplify adapter implementations a bit.

### DIFF
--- a/adapter/denyChecker/adapter.go
+++ b/adapter/denyChecker/adapter.go
@@ -15,8 +15,6 @@
 package denyChecker
 
 import (
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/rpc/code"
 
@@ -24,50 +22,22 @@ import (
 	"istio.io/mixer/pkg/aspectsupport"
 )
 
-const (
-	// ImplName is the canonical name of this implementation
-	ImplName = "istio/denyChecker"
-)
-
-// Register records the existence of this adapter
 func Register(r aspectsupport.Registry) error {
 	return r.RegisterDeny(newAdapter())
 }
 
 type adapterState struct{}
 
-func newAdapter() denyChecker.Adapter {
-	return &adapterState{}
-}
-
-func (a *adapterState) Name() string {
-	return ImplName
-}
-
-func (a *adapterState) Description() string {
-	return "Deny every check request"
-}
+func newAdapter() denyChecker.Adapter                          { return &adapterState{} }
+func (a *adapterState) Name() string                           { return "istio/denyChecker" }
+func (a *adapterState) Description() string                    { return "Deny every check request" }
+func (a *adapterState) Close() error                           { return nil }
+func (a *adapterState) ValidateConfig(cfg proto.Message) error { return nil }
 
 func (a *adapterState) DefaultConfig() proto.Message {
 	return &Config{ErrorCode: int32(code.Code_FAILED_PRECONDITION)}
 }
 
-func (a *adapterState) ValidateConfig(cfg proto.Message) (err error) {
-	_, ok := cfg.(*Config)
-	if !ok {
-		return fmt.Errorf("Invalid message type %#v", cfg)
-	}
-	return nil
-}
-
-func (a *adapterState) Close() error {
-	return nil
-}
-
 func (a *adapterState) NewAspect(cfg proto.Message) (denyChecker.Aspect, error) {
-	if err := a.ValidateConfig(cfg); err != nil {
-		return nil, err
-	}
-
 	return newAspect(cfg.(*Config))
 }

--- a/adapter/denyChecker/aspect.go
+++ b/adapter/denyChecker/aspect.go
@@ -31,14 +31,5 @@ func newAspect(c *Config) (denyChecker.Aspect, error) {
 	}, nil
 }
 
-func (a *aspectState) ImplName() string {
-	return ImplName
-}
-
-func (a *aspectState) Close() error {
-	return nil
-}
-
-func (a *aspectState) Deny() status.Status {
-	return a.status
-}
+func (a *aspectState) Close() error        { return nil }
+func (a *aspectState) Deny() status.Status { return a.status }

--- a/adapter/genericListChecker/adapter.go
+++ b/adapter/genericListChecker/adapter.go
@@ -15,17 +15,10 @@
 package genericListChecker
 
 import (
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
 
 	"istio.io/mixer/pkg/aspect/listChecker"
 	"istio.io/mixer/pkg/aspectsupport"
-)
-
-const (
-	// ImplName is the canonical name of this implementation
-	ImplName = "istio/genericListChecker"
 )
 
 // Register records the existence of this adapter
@@ -35,38 +28,13 @@ func Register(r aspectsupport.Registry) error {
 
 type adapterState struct{}
 
-func newAdapter() listChecker.Adapter {
-	return &adapterState{}
-}
-
-func (a *adapterState) Name() string {
-	return ImplName
-}
-
-func (a *adapterState) Description() string {
-	return "Checks whether a string is present in a list."
-}
-
-func (a *adapterState) DefaultConfig() proto.Message {
-	return &Config{}
-}
-
-func (a *adapterState) ValidateConfig(cfg proto.Message) (err error) {
-	_, ok := cfg.(*Config)
-	if !ok {
-		return fmt.Errorf("Invalid message type %#v", cfg)
-	}
-	return nil
-}
-
-func (a *adapterState) Close() error {
-	return nil
-}
+func newAdapter() listChecker.Adapter                          { return &adapterState{} }
+func (a *adapterState) Name() string                           { return "istio/genericListChecker" }
+func (a *adapterState) Description() string                    { return "Checks whether a string is present in a list." }
+func (a *adapterState) Close() error                           { return nil }
+func (a *adapterState) ValidateConfig(cfg proto.Message) error { return nil }
+func (a *adapterState) DefaultConfig() proto.Message           { return &Config{} }
 
 func (a *adapterState) NewAspect(cfg proto.Message) (listChecker.Aspect, error) {
-	if err := a.ValidateConfig(cfg); err != nil {
-		return nil, err
-	}
-
 	return newAspect(cfg.(*Config))
 }

--- a/adapter/genericListChecker/aspect.go
+++ b/adapter/genericListChecker/aspect.go
@@ -31,10 +31,6 @@ func newAspect(c *Config) (listChecker.Aspect, error) {
 	return &aspectState{entries: entries}, nil
 }
 
-func (a *aspectState) ImplName() string {
-	return ImplName
-}
-
 func (a *aspectState) Close() error {
 	a.entries = nil
 	return nil

--- a/adapter/ipListChecker/aspect.go
+++ b/adapter/ipListChecker/aspect.go
@@ -67,10 +67,6 @@ func newAspect(c *Config) (listChecker.Aspect, error) {
 	return &aa, nil
 }
 
-func (a *aspectState) ImplName() string {
-	return ImplName
-}
-
 func (a *aspectState) Close() error {
 	close(a.closing)
 	return nil

--- a/pkg/aspect/aspect.go
+++ b/pkg/aspect/aspect.go
@@ -36,8 +36,6 @@ type (
 	// ex: //adapter/ipListChecker aspectState implements the listChecker.Aspect.
 	Aspect interface {
 		io.Closer
-		// ImplName returns the official name of adapter implementation ex. "istio/statsd"
-		ImplName() string
 	}
 
 	// Adapter represents an Aspect Builder that constructs instances a specific aspect.

--- a/pkg/aspect/denyChecker/manager.go
+++ b/pkg/aspect/denyChecker/manager.go
@@ -31,7 +31,8 @@ type (
 	manager struct{}
 
 	aspectWrapper struct {
-		aspect Aspect
+		adapter Adapter
+		aspect  Aspect
 	}
 )
 
@@ -58,15 +59,20 @@ func (m *manager) NewAspect(cfg *aspect.CombinedConfig, ga aspect.Adapter) (aspe
 	}
 
 	return &aspectWrapper{
-		aspect: asp,
+		adapter: aa,
+		aspect:  asp,
 	}, nil
+}
+
+func (*manager) Kind() string {
+	return kind
+}
+
+func (a *aspectWrapper) AdapterName() string {
+	return a.adapter.Name()
 }
 
 func (a *aspectWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspect.Output, error) {
 	status := a.aspect.Deny()
 	return &aspect.Output{Code: code.Code(status.Code)}, nil
-}
-
-func (*manager) Kind() string {
-	return kind
 }

--- a/pkg/aspect/listChecker/manager.go
+++ b/pkg/aspect/listChecker/manager.go
@@ -33,6 +33,7 @@ type (
 
 	aspectWrapper struct {
 		cfg          *aspect.CombinedConfig
+		adapter      Adapter
 		aspect       Aspect
 		aspectConfig *listcheckerpb.Config
 	}
@@ -63,9 +64,18 @@ func (m *manager) NewAspect(cfg *aspect.CombinedConfig, ga aspect.Adapter) (aspe
 
 	return &aspectWrapper{
 		cfg:          cfg,
+		adapter:      aa,
 		aspect:       asp,
 		aspectConfig: aspectConfig,
 	}, nil
+}
+
+func (*manager) Kind() string {
+	return kind
+}
+
+func (a *aspectWrapper) AdapterName() string {
+	return a.adapter.Name()
 }
 
 func (a *aspectWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspect.Output, error) {
@@ -96,8 +106,4 @@ func (a *aspectWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*as
 	}
 
 	return &aspect.Output{Code: rCode}, nil
-}
-
-func (*manager) Kind() string {
-	return kind
 }


### PR DESCRIPTION
A proposal to simplify adapter implementations a bit:

- Remove aspect.ImplName, this can be handled by AspectWrapper.

- We can guarantee that the configs passed to ValidateConfig are of the right type, so each adapter doesn't need to check.

- We can guarantee that NewAspect is only ever called with validated configs, so each adapter doesn't need to check.

- Reformat for higher-density.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/123)
<!-- Reviewable:end -->
