### PR TITLE
Introduce the ConfigError type.

### DIFF
--- a/adapter/denyChecker/BUILD
+++ b/adapter/denyChecker/BUILD
@@ -10,6 +10,7 @@ go_library(
     ],
     deps = [
         ":config_proto",
+        "//pkg/adapter:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/aspect/denyChecker:go_default_library",
         "//pkg/aspectsupport:go_default_library",

--- a/adapter/denyChecker/adapter.go
+++ b/adapter/denyChecker/adapter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/rpc/code"
 
+	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/aspect/denyChecker"
 	"istio.io/mixer/pkg/aspectsupport"
 
@@ -32,11 +33,11 @@ func Register(r aspectsupport.Registry) error {
 
 type adapterState struct{}
 
-func newAdapter() denyChecker.Adapter                          { return &adapterState{} }
-func (a *adapterState) Name() string                           { return "istio/denyChecker" }
-func (a *adapterState) Description() string                    { return "Deny every check request" }
-func (a *adapterState) Close() error                           { return nil }
-func (a *adapterState) ValidateConfig(cfg proto.Message) error { return nil }
+func newAdapter() denyChecker.Adapter                                               { return &adapterState{} }
+func (a *adapterState) Name() string                                                { return "istio/denyChecker" }
+func (a *adapterState) Description() string                                         { return "Deny every check request" }
+func (a *adapterState) Close() error                                                { return nil }
+func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *adapter.ConfigErrors) { return }
 
 func (a *adapterState) DefaultConfig() proto.Message {
 	return &pb.Config{&status.Status{Code: int32(code.Code_FAILED_PRECONDITION)}}

--- a/adapter/genericListChecker/BUILD
+++ b/adapter/genericListChecker/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "//pkg/adapter:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/aspectsupport:go_default_library",
         "//pkg/aspect/listChecker:go_default_library",

--- a/adapter/genericListChecker/adapter.go
+++ b/adapter/genericListChecker/adapter.go
@@ -17,6 +17,7 @@ package genericListChecker
 import (
 	"github.com/golang/protobuf/proto"
 
+	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/aspect/listChecker"
 	"istio.io/mixer/pkg/aspectsupport"
 )
@@ -28,12 +29,12 @@ func Register(r aspectsupport.Registry) error {
 
 type adapterState struct{}
 
-func newAdapter() listChecker.Adapter                          { return &adapterState{} }
-func (a *adapterState) Name() string                           { return "istio/genericListChecker" }
-func (a *adapterState) Description() string                    { return "Checks whether a string is present in a list." }
-func (a *adapterState) Close() error                           { return nil }
-func (a *adapterState) ValidateConfig(cfg proto.Message) error { return nil }
-func (a *adapterState) DefaultConfig() proto.Message           { return &Config{} }
+func newAdapter() listChecker.Adapter                                               { return &adapterState{} }
+func (a *adapterState) Name() string                                                { return "istio/genericListChecker" }
+func (a *adapterState) Description() string                                         { return "Checks whether a string is present in a list." }
+func (a *adapterState) Close() error                                                { return nil }
+func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *adapter.ConfigErrors) { return }
+func (a *adapterState) DefaultConfig() proto.Message                                { return &Config{} }
 
 func (a *adapterState) NewAspect(cfg proto.Message) (listChecker.Aspect, error) {
 	return newAspect(cfg.(*Config))

--- a/adapter/ipListChecker/BUILD
+++ b/adapter/ipListChecker/BUILD
@@ -12,10 +12,11 @@ go_library(
     deps = [
         "@com_github_golang_glog//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
+        "//pkg/adapter:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/aspectsupport:go_default_library",
         "//pkg/aspect/listChecker:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library"
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 

--- a/pkg/adapter/BUILD
+++ b/pkg/adapter/BUILD
@@ -1,14 +1,26 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
         "aspect.go",
         "adapter.go",
+        "configError.go",
         "listChecker.go",
         "logger.go",
         "metricsReporter.go",
     ],
+    deps = [
+        "@com_github_hashicorp_go_multierror//:go_default_library",
+    ],
 )
+
+go_test(
+    name = "config_error_test",
+    size = "small",
+    srcs = ["configError_test.go"],
+    library = ":go_default_library",
+)
+

--- a/pkg/adapter/configError.go
+++ b/pkg/adapter/configError.go
@@ -1,0 +1,81 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"fmt"
+
+	me "github.com/hashicorp/go-multierror"
+)
+
+// A collection of configuration errors
+//
+// The usage pattern for this type is pretty simple:
+//
+// 	func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *adapter.ConfigErrors) {
+//      c := cfg.(*Config)
+//      if c.Url == nil {
+// 			ce = ce.Appendf("Url", "Must have a valid URL")
+//		}
+//		if c.RetryCount < 0 {
+//          ce = ce.Appendf("RetryCount", "Expecting >= 0, got %d", cfg.RetryCount)
+//		}
+//		return
+//  }
+type ConfigErrors struct {
+	// Multi is the accumulator of errors
+	Multi *me.Error
+}
+
+// ConfigError represents an error encountered while validating a block of configuration state.
+type ConfigError struct {
+	Field      string
+	Underlying error
+}
+
+// Appendf adds a ConfigError to a multierror. This function is intended
+// to be used by adapter's ValidateConfig method to report errors
+// in configuration. The field parameter indicates the name of the
+// specific configuration field name that is problematic.
+func (e *ConfigErrors) Appendf(field, format string, args ...interface{}) *ConfigErrors {
+	if e == nil {
+		e = &ConfigErrors{}
+	}
+
+	e.Multi = me.Append(e.Multi, ConfigError{field, fmt.Errorf(format, args...)})
+	return e
+}
+
+// Append adds a ConfigError to a multierror. This function is intended
+// to be used by adapter's ValidateConfig method to report errors
+// in configuration. The field parameter indicates the name of the
+// specific configuration field name that is problematic.
+func (e *ConfigErrors) Append(field string, err error) *ConfigErrors {
+	if e == nil {
+		e = &ConfigErrors{}
+	}
+
+	e.Multi = me.Append(e.Multi, ConfigError{field, err})
+	return e
+}
+
+// Error returns a string representation of the configuration error.
+func (e ConfigError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Underlying)
+}
+
+func (e *ConfigErrors) Error() string {
+	return e.Multi.Error()
+}

--- a/pkg/adapter/configError_test.go
+++ b/pkg/adapter/configError_test.go
@@ -1,0 +1,50 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestConfigErrors(t *testing.T) {
+	cases := []struct {
+		field string
+		underlying string
+		error string
+	}{
+		{"F0", "Format 0", "F0: Format 0"},
+		{"F1", "Format 1", "F1: Format 1"},
+	}
+
+	var ce *ConfigErrors
+	ce = ce.Appendf(cases[0].field, "Format %d", 0)
+	ce = ce.Append(cases[1].field, fmt.Errorf("Format %d", 1))
+
+	for i, c := range cases {
+		err := ce.Multi.Errors[i].(ConfigError)
+		if err.Field != c.field {
+			t.Errorf("Error %d field is '%s', expected '%s'", i, err.Field, c.field)
+		}
+		if err.Underlying.Error() != c.underlying {
+			t.Errorf("Error %d underlying is '%s', expected '%s'", i, err.Underlying.Error(), c.underlying)
+		}
+		if err.Error() != c.error {
+			t.Errorf("Error %d Error() returns '%s', expected '%s'", i, err.Error(), c.error)
+		}
+	}
+
+	t.Log(ce)
+}

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -16,6 +16,7 @@ ISTIO_DEPS = [
 DEPS = [
     "@com_github_golang_protobuf//proto:go_default_library",
     "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
+    "//pkg/adapter:go_default_library",
     "//pkg/attribute:go_default_library",
     "//pkg/expr:go_default_library"] + ["@com_github_istio_api" + d for d in ISTIO_DEPS]
 

--- a/pkg/aspect/aspect.go
+++ b/pkg/aspect/aspect.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/rpc/code"
 
+	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 
@@ -52,7 +53,7 @@ type (
 		// the shape of the block of configuration state passed to the NewAspect method.
 		DefaultConfig() (implConfig proto.Message)
 		// ValidateConfig determines whether the given configuration meets all correctness requirements.
-		ValidateConfig(implConfig proto.Message) error
+		ValidateConfig(implConfig proto.Message) *adapter.ConfigErrors
 	}
 
 	// CombinedConfig combines all configuration related to an aspect


### PR DESCRIPTION
ConfigError is intended to be used alongside multierrors. It provides a way for adapters to returned slightly structured errors from the ValidateConfig method. At a higher level, we can extract ConfigError objects and recover the field name against which the error was declared. That should be sufficient for us to point the user to a particular line of input code where the problem originated from.

The use of multierror also makes it so we encourage implementations of ValidateConfig to return all config errors in one shot, as opposed to failing fast after the first error is encountered. This will deliver a better experience for the operator as they'll get all the errors at once instead of playing whack-a-mole.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/128)
<!-- Reviewable:end -->
