### PR TITLE
Add support for aspect environments.

### DIFF
--- a/adapter/denyChecker/adapter.go
+++ b/adapter/denyChecker/adapter.go
@@ -43,6 +43,6 @@ func (a *adapterState) DefaultConfig() proto.Message {
 	return &pb.Config{&status.Status{Code: int32(code.Code_FAILED_PRECONDITION)}}
 }
 
-func (a *adapterState) NewAspect(cfg proto.Message) (denyChecker.Aspect, error) {
+func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {
 	return newAspect(cfg.(*pb.Config))
 }

--- a/adapter/denyChecker/adapter_test.go
+++ b/adapter/denyChecker/adapter_test.go
@@ -26,7 +26,7 @@ import (
 func TestAll(t *testing.T) {
 	b := newAdapter()
 
-	a, err := b.NewAspect(b.DefaultConfig())
+	a, err := b.NewAspect(nil, b.DefaultConfig())
 	if err != nil {
 		t.Errorf("Unable to create aspect: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("a.Close failed: %v", err)
 	}
 
-	a, err = b.NewAspect(&pb.Config{&status.Status{Code: int32(code.Code_INVALID_ARGUMENT)}})
+	a, err = b.NewAspect(nil, &pb.Config{&status.Status{Code: int32(code.Code_INVALID_ARGUMENT)}})
 	if err != nil {
 		t.Errorf("Unable to create aspect: %v", err)
 	}

--- a/adapter/genericListChecker/adapter.go
+++ b/adapter/genericListChecker/adapter.go
@@ -36,6 +36,6 @@ func (a *adapterState) Close() error                                            
 func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) { return }
 func (a *adapterState) DefaultConfig() proto.Message                               { return &Config{} }
 
-func (a *adapterState) NewAspect(cfg proto.Message) (listChecker.Aspect, error) {
+func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
 	return newAspect(cfg.(*Config))
 }

--- a/adapter/genericListChecker/adapter_test.go
+++ b/adapter/genericListChecker/adapter_test.go
@@ -42,7 +42,7 @@ func TestAll(t *testing.T) {
 	for _, c := range cases {
 		b := newAdapter()
 
-		a, err := b.NewAspect(&c.ac)
+		a, err := b.NewAspect(nil, &c.ac)
 		if err != nil {
 			t.Errorf("Unable to create adapter: %v", err)
 		}

--- a/adapter/ipListChecker/BUILD
+++ b/adapter/ipListChecker/BUILD
@@ -10,7 +10,6 @@ go_library(
         "cfg.pb.go",
     ],
     deps = [
-        "@com_github_golang_glog//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/aspect/listChecker:go_default_library",

--- a/adapter/ipListChecker/adapter.go
+++ b/adapter/ipListChecker/adapter.go
@@ -62,6 +62,6 @@ func (a *adapterState) DefaultConfig() proto.Message {
 	}
 }
 
-func (a *adapterState) NewAspect(cfg proto.Message) (listChecker.Aspect, error) {
-	return newAspect(cfg.(*Config))
+func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
+	return newAspect(env, cfg.(*Config))
 }

--- a/adapter/ipListChecker/adapter_test.go
+++ b/adapter/ipListChecker/adapter_test.go
@@ -15,16 +15,27 @@
 package ipListChecker
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"gopkg.in/yaml.v2"
+
+	"istio.io/mixer/pkg/aspect"
 )
 
 // TODO: this test suite needs to be beefed up considerably.
 // Should be testing more edge cases, testing refresh behavior with and without errors,
 // testing TTL handling, testing malformed input, etc.
+
+type env struct {}
+func (e *env) Logger() aspect.Logger {return &logger{} }
+
+type logger struct {}
+func (l *logger) Infof(format string, args ...interface{}) {}
+func (l *logger) Warningf(format string, args ...interface{}) {}
+func (l *logger) Errorf(format string, args ...interface{}) error {return fmt.Errorf(format, args)}
 
 func TestBasic(t *testing.T) {
 	lp := listPayload{
@@ -53,7 +64,7 @@ func TestBasic(t *testing.T) {
 		Ttl:             10,
 	}
 
-	a, err := b.NewAspect(&config)
+	a, err := b.NewAspect(&env{}, &config)
 	if err != nil {
 		t.Errorf("Unable to create adapter: %v", err)
 	}

--- a/pkg/aspect/aspect.go
+++ b/pkg/aspect/aspect.go
@@ -53,4 +53,33 @@ type (
 		// ValidateConfig determines whether the given configuration meets all correctness requirements.
 		ValidateConfig(implConfig proto.Message) *ConfigErrors
 	}
+
+	// The environment in which an aspect executes.
+	Env interface {
+		// Logger returns the logger for the aspect to use at runtime.
+		Logger() Logger
+
+		// Possible other things:
+		// Return how much time remains until the mixer considers the aspect call having timed out and kills it
+		// Return true/false to indicate this is a 'recovery mode' execution following a prior crash of the aspect
+		// ?
+	}
+
+	// The logger used at runtime by aspects.
+	//
+	// This log information is funneled to the mixer which
+	// augments it with desirable metadata and then routes it
+	// to the right place.
+	Logger interface {
+		// Infof logs optional information.
+		Infof(format string, args ...interface{})
+
+		// Warningsf logs suspect situations and recovrable errors
+		Warningf(format string, args ...interface{})
+
+		// Errorf logs error conditions.
+		// In addition to generating a log record for the error, this also returns
+		// an error instance for convenience.
+		Errorf(format string, args ...interface{}) error
+	}
 )

--- a/pkg/aspect/configError.go
+++ b/pkg/aspect/configError.go
@@ -26,7 +26,7 @@ import (
 //
 //  	func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *adapter.ConfigErrors) {
 //  		c := cfg.(*Config)
-//      	if c.Url == nil {
+// 			if c.Url == nil {
 //  			ce = ce.Appendf("Url", "Must have a valid URL")
 //  		}
 //  		if c.RetryCount < 0 {

--- a/pkg/aspect/configError_test.go
+++ b/pkg/aspect/configError_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestConfigErrors(t *testing.T) {
 	cases := []struct {
-		field string
+		field      string
 		underlying string
-		error string
+		error      string
 	}{
 		{"F0", "Format 0", "F0: Format 0"},
 		{"F1", "Format 1", "F1: Format 1"},

--- a/pkg/aspect/denyChecker/denyChecker.go
+++ b/pkg/aspect/denyChecker/denyChecker.go
@@ -32,6 +32,6 @@ type (
 	Adapter interface {
 		aspect.Adapter
 		// NewAspect returns a new DenyChecker
-		NewAspect(cfg proto.Message) (Aspect, error)
+		NewAspect(env aspect.Env, cfg proto.Message) (Aspect, error)
 	}
 )

--- a/pkg/aspectsupport/denyChecker/manager.go
+++ b/pkg/aspectsupport/denyChecker/manager.go
@@ -46,7 +46,7 @@ func NewManager() aspectsupport.Manager {
 }
 
 // NewAspect creates a denyChecker aspect. Implements aspect.Manager#NewAspect()
-func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter) (aspectsupport.AspectWrapper, error) {
+func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter, env aspect.Env) (aspectsupport.AspectWrapper, error) {
 	aa, ok := ga.(denyChecker.Adapter)
 	if !ok {
 		return nil, fmt.Errorf("Adapter of incorrect type. Expected denyChecker.Adapter got %#v %T", ga, ga)
@@ -58,7 +58,7 @@ func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter
 	var asp denyChecker.Aspect
 	var err error
 
-	if asp, err = aa.NewAspect(adapterCfg); err != nil {
+	if asp, err = aa.NewAspect(env, adapterCfg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/aspectsupport/listChecker/manager.go
+++ b/pkg/aspectsupport/listChecker/manager.go
@@ -48,7 +48,7 @@ func NewManager() aspectsupport.Manager {
 }
 
 // NewAspect creates a listChecker aspect. Implements aspect.Manager#NewAspect()
-func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter) (aspectsupport.AspectWrapper, error) {
+func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter, env aspect.Env) (aspectsupport.AspectWrapper, error) {
 	aa, ok := ga.(listChecker.Adapter)
 	if !ok {
 		return nil, fmt.Errorf("Adapter of incorrect type. Expected listChecker.Adapter got %#v %T", ga, ga)
@@ -61,7 +61,7 @@ func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter
 	var asp listChecker.Aspect
 	var err error
 
-	if asp, err = aa.NewAspect(adapterCfg); err != nil {
+	if asp, err = aa.NewAspect(env, adapterCfg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/aspectsupport/manager.go
+++ b/pkg/aspectsupport/manager.go
@@ -40,11 +40,11 @@ type (
 		//context remains immutable during the call
 	}
 
-	// Manager manages a specific aspect and presets a uniform interface
-	// to the rest of system
+	// Manager manages a specific aspect and presents a uniform interface
+	// to the rest of the system
 	Manager interface {
 		// NewAspect creates a new aspect instance given configuration.
-		NewAspect(cfg *CombinedConfig, adapter aspect.Adapter) (AspectWrapper, error)
+		NewAspect(cfg *CombinedConfig, adapter aspect.Adapter, env aspect.Env) (AspectWrapper, error)
 		// Kind return the kind of aspect
 		Kind() string
 

--- a/pkg/aspectsupport/uber/BUILD
+++ b/pkg/aspectsupport/uber/BUILD
@@ -2,7 +2,7 @@ package(default_visibility=["//visibility:public"])
 
 licenses(["notice"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
 
 go_prefix("istio.io/mixer/pkg/aspectsupport")
 
@@ -23,6 +23,7 @@ DEPS = ["//pkg/aspect:go_default_library",
         "//pkg/aspectsupport/denyChecker:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/registry:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
         "//pkg/expr:go_default_library"] + select({
             ":local": ["@local_istio_api" + d for d in ISTIO_DEPS],
             "//conditions:default": ["@com_github_istio_api" + d for d in ISTIO_DEPS]
@@ -35,4 +36,18 @@ go_library(
         exclude=["test_*.go"],
     ),
     deps=DEPS
+)
+
+go_test(
+    name="manager_test",
+    srcs=["manager_test.go"],
+    library = ":go_default_library",
+    size="small",
+)
+
+go_test(
+    name="env_test",
+    srcs=["env_test.go"],
+    library = ":go_default_library",
+    size="small",
 )

--- a/pkg/aspectsupport/uber/env.go
+++ b/pkg/aspectsupport/uber/env.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package listChecker
+package uber
 
 import (
-	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
 )
 
-type (
-	// Aspect listChecker checks given symbol against a list
-	Aspect interface {
-		aspect.Aspect
-		// CheckList verifies whether the given symbol is on the list.
-		CheckList(symbol string) (bool, error)
-	}
+type env struct {
+	logger aspect.Logger
+}
 
-	// Adapter builds the ListChecker Aspect
-	Adapter interface {
-		aspect.Adapter
-		// NewAspect returns a new ListChecker
-		NewAspect(env aspect.Env, cfg proto.Message) (Aspect, error)
-	}
-)
+func newEnv(aspect string) aspect.Env {
+	return &env{logger: newLogger(aspect)}
+}
+
+func (e *env) Logger() aspect.Logger {
+	return e.logger
+}

--- a/pkg/aspectsupport/uber/env_test.go
+++ b/pkg/aspectsupport/uber/env_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package listChecker
+package uber
 
 import (
-	"github.com/golang/protobuf/proto"
-	"istio.io/mixer/pkg/aspect"
+	"testing"
 )
 
-type (
-	// Aspect listChecker checks given symbol against a list
-	Aspect interface {
-		aspect.Aspect
-		// CheckList verifies whether the given symbol is on the list.
-		CheckList(symbol string) (bool, error)
-	}
-
-	// Adapter builds the ListChecker Aspect
-	Adapter interface {
-		aspect.Adapter
-		// NewAspect returns a new ListChecker
-		NewAspect(env aspect.Env, cfg proto.Message) (Aspect, error)
-	}
-)
+func TestEnv(t *testing.T) {
+	// for now, just make sure nothing crashes...
+	env := newEnv("Foo")
+	log := env.Logger()
+	log.Infof("Test%s", "ing")
+	log.Warningf("Test%s", "ing")
+	log.Errorf("Test%s", "ing")
+}

--- a/pkg/aspectsupport/uber/logger.go
+++ b/pkg/aspectsupport/uber/logger.go
@@ -1,0 +1,43 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uber
+
+import (
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+)
+
+type logger struct {
+	aspect string
+}
+
+func newLogger(aspect string) *logger {
+	return &logger{aspect: aspect}
+}
+
+func (l *logger) Infof(format string, args ...interface{}) {
+	glog.InfoDepth(1, l.aspect+":"+fmt.Sprintf(format, args...))
+}
+
+func (l *logger) Warningf(format string, args ...interface{}) {
+	glog.WarningDepth(1, l.aspect+":"+fmt.Sprintf(format, args...))
+}
+
+func (l *logger) Errorf(format string, args ...interface{}) error {
+	s := fmt.Sprintf(format, args...)
+	glog.ErrorDepth(1, l.aspect+":"+s)
+	return errors.New(s)
+}

--- a/pkg/aspectsupport/uber/manager.go
+++ b/pkg/aspectsupport/uber/manager.go
@@ -20,8 +20,8 @@ import (
 
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/aspectsupport"
-	"istio.io/mixer/pkg/aspectsupport/listChecker"
 	"istio.io/mixer/pkg/aspectsupport/denyChecker"
+	"istio.io/mixer/pkg/aspectsupport/listChecker"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 )
@@ -96,6 +96,7 @@ func (m *Manager) Execute(cfg *aspectsupport.CombinedConfig, attrs attribute.Bag
 	if asp, err = m.CacheGet(cfg, mgr, adapter); err != nil {
 		return nil, err
 	}
+
 	// TODO act on aspect.Output
 	return asp.Execute(attrs, mapper)
 }
@@ -115,7 +116,8 @@ func (m *Manager) CacheGet(cfg *aspectsupport.CombinedConfig, mgr aspectsupport.
 	defer m.lock.Unlock()
 	asp, found = m.aspectCache[key]
 	if !found {
-		asp, err = mgr.NewAspect(cfg, adapter)
+		env := newEnv(adapter.Name())
+		asp, err = mgr.NewAspect(cfg, adapter, env)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Introduce adapter.Env to provide generic services to adapters which integrates into the broader mixer world. For starters, this means providing a logger that adapters use instead of any old arbitrary logger they happen to link to. In the future, maybe we use the Env to handle adapter metric pumping, timeout handling, or other global concerns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/135)
<!-- Reviewable:end -->
