### PR TITLE
Add ConfigValidator interface

### DIFF
--- a/pkg/aspect/aspect.go
+++ b/pkg/aspect/aspect.go
@@ -41,6 +41,11 @@ type (
 		Name() string
 		// Description returns a user-friendly description of this adapter.
 		Description() string
+
+		ConfigValidater
+
+	}
+	ConfigValidater interface {
 		// DefaultConfig returns a default configuration struct for this
 		// adapter. This will be used by the configuration system to establish
 		// the shape of the block of configuration state passed to the NewAspect method.

--- a/pkg/aspectsupport/denyChecker/manager.go
+++ b/pkg/aspectsupport/denyChecker/manager.go
@@ -17,12 +17,14 @@ package denyChecker
 import (
 	"fmt"
 
+	denycheckerpb "istio.io/api/istio/config/v1/aspect/denyChecker"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/aspect/denyChecker"
 	"istio.io/mixer/pkg/aspectsupport"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
+	"github.com/golang/protobuf/proto"
 )
 
 const (
@@ -69,6 +71,15 @@ func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter
 func (*manager) Kind() string {
 	return kind
 }
+
+func (*manager) DefaultConfig() proto.Message {
+	return &denycheckerpb.Config{}
+}
+
+func (*manager) ValidateConfig(implConfig proto.Message) (ce *aspect.ConfigErrors){
+	return 
+}
+
 
 func (a *aspectWrapper) AdapterName() string {
 	return a.adapter.Name()

--- a/pkg/aspectsupport/listChecker/manager.go
+++ b/pkg/aspectsupport/listChecker/manager.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/mixer/pkg/aspectsupport"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
+	"github.com/golang/protobuf/proto"
 )
 
 const (
@@ -74,6 +75,20 @@ func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter
 
 func (*manager) Kind() string {
 	return kind
+}
+
+func (*manager) DefaultConfig() proto.Message {
+	return &listcheckerpb.Config{
+		CheckAttribute: "src.ip",
+	}
+}
+
+func (*manager) ValidateConfig(implConfig proto.Message) (ce *aspect.ConfigErrors){
+	lc := implConfig.(*listcheckerpb.Config)
+	if lc.CheckAttribute == "" {
+		ce.Appendf("check_attribute", "Missing")
+	}
+	return
 }
 
 func (a *aspectWrapper) AdapterName() string {

--- a/pkg/aspectsupport/manager.go
+++ b/pkg/aspectsupport/manager.go
@@ -47,6 +47,8 @@ type (
 		NewAspect(cfg *CombinedConfig, adapter aspect.Adapter) (AspectWrapper, error)
 		// Kind return the kind of aspect
 		Kind() string
+
+		aspect.ConfigValidater
 	}
 
 	AspectWrapper interface {


### PR DESCRIPTION
ConfigValidator is implemented by
1. Adapter
2. AspectManager

This ensures that 2 freeform configs are processed in the same way

It enables CombinedConfig to be fully preprocessed and pre-validated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/137)
<!-- Reviewable:end -->
