### PR TITLE
Add logger aspect to the mixer.

### DIFF
--- a/pkg/aspect/logger/BUILD
+++ b/pkg/aspect/logger/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "logger.go",
+    ],
+    deps = [
+        "//pkg/aspect:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -1,0 +1,48 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"github.com/golang/protobuf/proto"
+	"istio.io/mixer/pkg/aspect"
+)
+
+type (
+	// Aspect is the interface for adapters that will handle logs data
+	// within the mixer.
+	Aspect interface {
+		aspect.Aspect
+
+		// Log directs a backend adapter to process a batch of
+		// log entries derived from potentially several Report() calls.
+		Log([]Entry) error
+	}
+
+	// Entry is a set of key-value pairs of attributes that together
+	// constitute the data for log entry. The key
+	// is the attribute name, and the value is a typed value for the
+	// named attribute.
+	Entry map[string]interface{}
+
+	// Adapter is the interface for building Aspect instances for
+	// mixer logging backends.
+	Adapter interface {
+		aspect.Adapter
+
+		// NewAspect returns a new Logger implementation, based
+		// on the supplied Aspect configuration for the backend.
+		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+	}
+)

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -31,18 +31,17 @@ type (
 	}
 
 	// Entry is a set of key-value pairs of attributes that together
-	// constitute the data for log entry. The key
-	// is the attribute name, and the value is a typed value for the
-	// named attribute.
+	// constitute the data for log entry. The key is the attribute name,
+	// and the value is a typed value for the named attribute.
 	Entry map[string]interface{}
 
-	// Adapter is the interface for building Aspect instances for
-	// mixer logging backends.
+	// Adapter is the interface for building Aspect instances for mixer
+	// logging backends.
 	Adapter interface {
 		aspect.Adapter
 
-		// NewAspect returns a new Logger implementation, based
-		// on the supplied Aspect configuration for the backend.
+		// NewAspect returns a new Logger implementation, based on the
+		// supplied Aspect configuration for the backend.
 		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
 	}
 )

--- a/pkg/aspectsupport/logger/BUILD
+++ b/pkg/aspectsupport/logger/BUILD
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "manager.go",
+    ],
+    deps = [
+        "//pkg/aspect:go_default_library",
+        "//pkg/aspect/logger:go_default_library",
+        "//pkg/aspectsupport:go_default_library",
+        "//pkg/attribute:go_default_library",
+        "//pkg/expr:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
+        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
+        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
+    ],
+)
+
+go_test(
+    name = "logger_manager_test",
+    size = "small",
+    srcs = ["manager_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "@com_github_golang_protobuf//jsonpb/jsonpb_test_proto:go_default_library",
+        "@com_github_istio_api//:istio/config/v1",
+    ],
+)

--- a/pkg/aspectsupport/logger/BUILD
+++ b/pkg/aspectsupport/logger/BUILD
@@ -22,7 +22,7 @@ go_library(
 )
 
 go_test(
-    name = "logger_manager_test",
+    name = "manager_test",
     size = "small",
     srcs = ["manager_test.go"],
     library = ":go_default_library",

--- a/pkg/aspectsupport/logger/manager.go
+++ b/pkg/aspectsupport/logger/manager.go
@@ -47,14 +47,14 @@ func (m *manager) NewAspect(c *aspectsupport.CombinedConfig, a aspect.Adapter, e
 	// cast to logger.Adapter from aspect.Adapter
 	logAdapter, ok := a.(logger.Adapter)
 	if !ok {
-		return nil, fmt.Errorf("Adapter of incorrect type. Expected logger.Adapter got %#v %T", a, a)
+		return nil, fmt.Errorf("adapter of incorrect type. Expected logger.Adapter got %#v %T", a, a)
 	}
 
 	// TODO: replace when c.Adapter.TypedParams is ready
 	cpb := logAdapter.DefaultConfig()
 	if c.Adapter.Params != nil {
 		if err := structToProto(c.Adapter.Params, cpb); err != nil {
-			return nil, fmt.Errorf("Could not parse adapter config: %v", err)
+			return nil, fmt.Errorf("could not parse adapter config: %v", err)
 		}
 	}
 

--- a/pkg/aspectsupport/logger/manager.go
+++ b/pkg/aspectsupport/logger/manager.go
@@ -1,0 +1,102 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/golang/protobuf/ptypes/struct"
+	"google.golang.org/genproto/googleapis/rpc/code"
+	"istio.io/mixer/pkg/aspect"
+	"istio.io/mixer/pkg/aspect/logger"
+	"istio.io/mixer/pkg/aspectsupport"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/expr"
+)
+
+type (
+	manager struct{}
+
+	executor struct {
+		inputs map[string]string
+		aspect logger.Aspect
+	}
+)
+
+// NewManager returns an aspect manager for the logger aspect.
+func NewManager() aspectsupport.Manager {
+	return &manager{}
+}
+
+func (m *manager) NewAspect(c *aspectsupport.CombinedConfig, a aspect.Adapter, env aspect.Env) (aspectsupport.AspectWrapper, error) {
+	// cast to logger.Adapter from aspect.Adapter
+	logAdapter, ok := a.(logger.Adapter)
+	if !ok {
+		return nil, fmt.Errorf("Adapter of incorrect type. Expected logger.Adapter got %#v %T", a, a)
+	}
+
+	// TODO: replace when c.Adapter.TypedParams is ready
+	cpb := logAdapter.DefaultConfig()
+	if c.Adapter.Params != nil {
+		if err := structToProto(c.Adapter.Params, cpb); err != nil {
+			return nil, fmt.Errorf("Could not parse adapter config: %v", err)
+		}
+	}
+
+	aspectImpl, err := logAdapter.NewAspect(env, cpb)
+	if err != nil {
+		return nil, err
+	}
+
+	var inputs map[string]string
+	if c.Aspect != nil && c.Aspect.Inputs != nil {
+		inputs = c.Aspect.Inputs
+	}
+
+	return &executor{inputs, aspectImpl}, nil
+}
+
+func (*manager) Kind() string                                                      { return "istio/logger" }
+func (*manager) DefaultConfig() proto.Message                                      { return &empty.Empty{} }
+func (*manager) ValidateConfig(implConfig proto.Message) (ce *aspect.ConfigErrors) { return }
+
+func (a *executor) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspectsupport.Output, error) {
+	entry := make(logger.Entry)
+	for attr, expr := range a.inputs {
+		if val, err := mapper.Eval(expr, attrs); err == nil {
+			entry[attr] = val
+		}
+		// TODO: define error-handling bits (is mapping failure a
+		//       total failure, or should we just not pass the attr
+		//       and let adapter impls decide if that is an error
+		//       condition?)
+	}
+	if err := a.aspect.Log([]logger.Entry{entry}); err != nil {
+		return nil, err
+	}
+	return &aspectsupport.Output{code.Code(code.Code_OK)}, nil
+}
+
+func structToProto(in *structpb.Struct, out proto.Message) error {
+	mm := &jsonpb.Marshaler{}
+	str, err := mm.MarshalToString(in)
+	if err != nil {
+		return fmt.Errorf("failed to marshal to string: %v", err)
+	}
+	return jsonpb.UnmarshalString(str, out)
+}

--- a/pkg/aspectsupport/logger/manager.go
+++ b/pkg/aspectsupport/logger/manager.go
@@ -75,9 +75,9 @@ func (*manager) Kind() string                                                   
 func (*manager) DefaultConfig() proto.Message                                      { return &empty.Empty{} }
 func (*manager) ValidateConfig(implConfig proto.Message) (ce *aspect.ConfigErrors) { return }
 
-func (a *executor) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspectsupport.Output, error) {
+func (e *executor) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspectsupport.Output, error) {
 	entry := make(logger.Entry)
-	for attr, expr := range a.inputs {
+	for attr, expr := range e.inputs {
 		if val, err := mapper.Eval(expr, attrs); err == nil {
 			entry[attr] = val
 		}
@@ -86,7 +86,7 @@ func (a *executor) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspects
 		//       and let adapter impls decide if that is an error
 		//       condition?)
 	}
-	if err := a.aspect.Log([]logger.Entry{entry}); err != nil {
+	if err := e.aspect.Log([]logger.Entry{entry}); err != nil {
 		return nil, err
 	}
 	return &aspectsupport.Output{code.Code(code.Code_OK)}, nil

--- a/pkg/aspectsupport/logger/manager_test.go
+++ b/pkg/aspectsupport/logger/manager_test.go
@@ -1,0 +1,176 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/struct"
+	"istio.io/mixer/pkg/aspect"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/expr"
+
+	jtpb "github.com/golang/protobuf/jsonpb/jsonpb_test_proto"
+	"github.com/golang/protobuf/ptypes/empty"
+	configpb "istio.io/api/istio/config/v1"
+	"istio.io/mixer/pkg/aspect/logger"
+	"istio.io/mixer/pkg/aspectsupport"
+)
+
+func TestNewManager(t *testing.T) {
+	m := NewManager()
+	if m.Kind() != "istio/logger" {
+		t.Error("Wrong kind of adapter")
+	}
+}
+
+func TestNewAspectBadConfig(t *testing.T) {
+
+	newAspectShouldError := []aspectTestCase{
+		{"mismatched protos", widget, statusStruct},
+	}
+
+	m := NewManager()
+
+	for _, v := range newAspectShouldError {
+		c := aspectsupport.CombinedConfig{Adapter: &configpb.Adapter{Params: v.params}}
+		if _, err := m.NewAspect(&c, &testLogger{defaultCfg: v.defaultCfg}, testEnv{}); err == nil {
+			t.Errorf("NewAspect(): expected error for %s", v.name)
+		}
+	}
+}
+
+func TestNewAspectConfig(t *testing.T) {
+
+	newAspectShouldSucceed := []aspectTestCase{
+		{"empty", widget, &structpb.Struct{}},
+		{"nil", widget, nil},
+		{"override", widget, widgetStruct},
+	}
+
+	m := NewManager()
+
+	for _, v := range newAspectShouldSucceed {
+		c := aspectsupport.CombinedConfig{Adapter: &configpb.Adapter{Params: v.params}, Aspect: &configpb.Aspect{Inputs: map[string]string{}}}
+		if _, err := m.NewAspect(&c, &testLogger{defaultCfg: v.defaultCfg}, testEnv{}); err != nil {
+			t.Errorf("NewAspect(): should not have received error for %s (%v)", v.name, err)
+		}
+	}
+}
+
+func TestNewAspectBadAdapter(t *testing.T) {
+	m := NewManager()
+
+	var generic aspect.Adapter
+
+	if _, err := m.NewAspect(&aspectsupport.CombinedConfig{}, generic, testEnv{}); err == nil {
+		t.Error("NewAspect(): expected error for bad adapter")
+	}
+}
+
+func TestExecute(t *testing.T) {
+	executeShouldSucceed := []executeTestCase{
+		{"single attribute", map[string]string{"attr": "val"}, &testBag{}, &testEvaluator{}},
+	}
+
+	for _, v := range executeShouldSucceed {
+		l := &testLogger{}
+		e := &executor{v.inputs, l}
+		if _, err := e.Execute(v.bag, v.mapper); err != nil {
+			t.Errorf("Execute(): should not have received error for %s (%v)", v.name, err)
+		}
+		if l.entryCount != 1 {
+			t.Errorf("Execute(): wanted entry count of 1, got %d", l.entryCount)
+		}
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	m := NewManager()
+	o := m.DefaultConfig()
+	if !proto.Equal(o, &empty.Empty{}) {
+		t.Errorf("DefaultConfig(): wanted empty proto, got %v", o)
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	m := NewManager()
+	if err := m.ValidateConfig(&empty.Empty{}); err != nil {
+		t.Errorf("ValidateConfig(): unexpected error: %v", err)
+	}
+}
+
+type (
+	structMap      map[string]*structpb.Value
+	aspectTestCase struct {
+		name       string
+		defaultCfg proto.Message
+		params     *structpb.Struct
+	}
+	executeTestCase struct {
+		name   string
+		inputs map[string]string
+		bag    attribute.Bag
+		mapper expr.Evaluator
+	}
+	testLogger struct {
+		logger.Adapter
+		logger.Aspect
+
+		defaultCfg proto.Message
+		entryCount int
+	}
+	testEvaluator struct {
+		expr.Evaluator
+	}
+	testBag struct {
+		attribute.Bag
+	}
+	testEnv struct {
+		aspect.Env
+	}
+)
+
+var (
+	widget       = &jtpb.Widget{Color: jtpb.Widget_RED.Enum(), RColor: []jtpb.Widget_Color{jtpb.Widget_GREEN}}
+	statusStruct = newStruct(structMap{"code": newStringVal("Test")})
+	widgetStruct = newStruct(structMap{"color": newStringVal("BLUE"), "simple": newStructVal(structMap{"o_bool": newBoolVal(false)})})
+)
+
+func (t *testLogger) NewAspect(e aspect.Env, m proto.Message) (logger.Aspect, error) { return t, nil }
+func (t *testLogger) DefaultConfig() proto.Message                                   { return t.defaultCfg }
+func (t *testLogger) Log([]logger.Entry) error                                       { t.entryCount++; return nil }
+func (t *testLogger) Close() error                                                   { return nil }
+
+func (t *testEvaluator) Eval(e string, bag attribute.Bag) (interface{}, error) {
+	return e, nil
+}
+
+func newStringVal(s string) *structpb.Value {
+	return &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: s}}
+}
+
+func newBoolVal(b bool) *structpb.Value {
+	return &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: b}}
+}
+
+func newStruct(fields map[string]*structpb.Value) *structpb.Struct {
+	return &structpb.Struct{Fields: fields}
+}
+
+func newStructVal(fields map[string]*structpb.Value) *structpb.Value {
+	return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: newStruct(fields)}}
+}


### PR DESCRIPTION
This adds a basic aspect with a Log([]Entry) interface to be
implemented by various adapters. A simple manager is provided for
downscoping to an Entry from the attribute.Bag based on the
configured Input attributes.

Tested with: pkg/aspectsupport/logger$ bazel test ...
Test coverage: 90%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/140)
<!-- Reviewable:end -->
