### PR TITLE
Enable 'go vet' linting

### DIFF
--- a/adapter/denyChecker/adapter.go
+++ b/adapter/denyChecker/adapter.go
@@ -42,7 +42,7 @@ func (a *adapterState) Close() error                                            
 func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) { return }
 
 func (a *adapterState) DefaultConfig() proto.Message {
-	return &pb.Config{&status.Status{Code: int32(code.Code_FAILED_PRECONDITION)}}
+	return &pb.Config{Error: &status.Status{Code: int32(code.Code_FAILED_PRECONDITION)}}
 }
 
 func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {

--- a/adapter/denyChecker/adapter_test.go
+++ b/adapter/denyChecker/adapter_test.go
@@ -41,7 +41,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("a.Close failed: %v", err)
 	}
 
-	a, err = b.NewAspect(nil, &pb.Config{&status.Status{Code: int32(code.Code_INVALID_ARGUMENT)}})
+	a, err = b.NewAspect(nil, &pb.Config{Error: &status.Status{Code: int32(code.Code_INVALID_ARGUMENT)}})
 	if err != nil {
 		t.Errorf("Unable to create aspect: %v", err)
 	}

--- a/adapter/ipListChecker/adapter_test.go
+++ b/adapter/ipListChecker/adapter_test.go
@@ -131,7 +131,7 @@ func TestValidateConfig(t *testing.T) {
 	for i, c := range cases {
 		err := b.ValidateConfig(&c.cfg).Multi.Errors[0].(aspect.ConfigError)
 		if err.Field != c.field {
-			t.Error("Case %d: expecting error for field %s, got %s", i, c.field, err.Field)
+			t.Errorf("Case %d: expecting error for field %s, got %s", i, c.field, err.Field)
 		}
 	}
 }

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -29,7 +29,7 @@ run_linters() {
         --enable=goconst\
         --enable=gofmt\
         --enable=goimports\
-        --enable=golint --min-confidence=0 --exclude=.pb.go --exclude="should have a package comment" --exclude="adapter.AdapterConfig"\
+        --enable=golint --min-confidence=0 --exclude=.pb.go --exclude="should have a package comment"\
         --enable=gosimple\
         --enable=ineffassign\
         --enable=interfacer\
@@ -40,6 +40,7 @@ run_linters() {
         --enable=unconvert\
         --enable=unused\
         --enable=varcheck\
+        --enable=vet\
         --enable=vetshadow\
         ./...
 

--- a/pkg/aspectsupport/logger/manager.go
+++ b/pkg/aspectsupport/logger/manager.go
@@ -89,7 +89,7 @@ func (e *executor) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspects
 	if err := e.aspect.Log([]logger.Entry{entry}); err != nil {
 		return nil, err
 	}
-	return &aspectsupport.Output{code.Code_OK}, nil
+	return &aspectsupport.Output{Code: code.Code_OK}, nil
 }
 
 func structToProto(in *structpb.Struct, out proto.Message) error {


### PR DESCRIPTION
I thought this was implied by the vetshadow linter, but it wasn't
and needs to be explicitly controlled.

Fixed a few resulting new warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/155)
<!-- Reviewable:end -->
