### PR TITLE
Update logger aspect manager handling of aspect config.

### DIFF
--- a/BUILD.api
+++ b/BUILD.api
@@ -56,18 +56,17 @@ go_proto_library(
     ],
 )
 
-go_proto_library(
-    name = "mixer/v1/config/aspect",
-    protos = [
-        "mixer/v1/config/aspect/denyChecker_config.proto",
-        "mixer/v1/config/aspect/listChecker_config.proto",
-        "mixer/v1/config/aspect/logger_config.proto",
-        "mixer/v1/config/aspect/quota_config.proto",
-    ],
-    verbose = 0,
-    visibility = ["//visibility:public"],
-    with_grpc = False,
-)
+#go_proto_library(
+#    name = "mixer/v1/config/aspect",
+#    protos = [
+#        "mixer/v1/config/aspect/denyChecker_config.proto",
+#        "mixer/v1/config/aspect/listChecker_config.proto",
+#        "mixer/v1/config/aspect/quota_config.proto",
+#    ],
+#    verbose = 0,
+#    visibility = ["//visibility:public"],
+#    with_grpc = False,
+#)
 
 go_proto_library(
     name = "mixer/v1/config/descriptor",

--- a/BUILD.api
+++ b/BUILD.api
@@ -77,7 +77,7 @@ go_proto_library(
         "mixer/v1/config/descriptor/metric_descriptor.proto",
         "mixer/v1/config/descriptor/monitored_resource_descriptor.proto",
         "mixer/v1/config/descriptor/principal_descriptor.proto",
-        # "mixer/v1/config/descriptor/quota_descriptor.proto",
+        "mixer/v1/config/descriptor/quota_descriptor.proto",
     ],
     verbose = 0,
     visibility = ["//visibility:public"],

--- a/BUILD.api
+++ b/BUILD.api
@@ -56,18 +56,6 @@ go_proto_library(
     ],
 )
 
-#go_proto_library(
-#    name = "mixer/v1/config/aspect",
-#    protos = [
-#        "mixer/v1/config/aspect/denyChecker_config.proto",
-#        "mixer/v1/config/aspect/listChecker_config.proto",
-#        "mixer/v1/config/aspect/quota_config.proto",
-#    ],
-#    verbose = 0,
-#    visibility = ["//visibility:public"],
-#    with_grpc = False,
-#)
-
 go_proto_library(
     name = "mixer/v1/config/descriptor",
     protos = [

--- a/BUILD.api
+++ b/BUILD.api
@@ -61,6 +61,7 @@ go_proto_library(
     protos = [
         "mixer/v1/config/aspect/denyChecker_config.proto",
         "mixer/v1/config/aspect/listChecker_config.proto",
+        "mixer/v1/config/aspect/logger_config.proto",
         "mixer/v1/config/aspect/quota_config.proto",
     ],
     verbose = 0,
@@ -72,11 +73,11 @@ go_proto_library(
     name = "mixer/v1/config/descriptor",
     protos = [
         "mixer/v1/config/descriptor/attribute_descriptor.proto",
-        "mixer/v1/config/descriptor/logEntry_descriptor.proto",
+        "mixer/v1/config/descriptor/log_entry_descriptor.proto",
         "mixer/v1/config/descriptor/metric_descriptor.proto",
         "mixer/v1/config/descriptor/monitored_resource_descriptor.proto",
         "mixer/v1/config/descriptor/principal_descriptor.proto",
-        "mixer/v1/config/descriptor/quota_descriptor.proto",
+        # "mixer/v1/config/descriptor/quota_descriptor.proto",
     ],
     verbose = 0,
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -157,7 +157,7 @@ new_git_or_local_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
     path = "../api",
-    commit = "09b244073037758efdeaed17225c5a75414171f2",
+    commit = "a3e9726dd154657cb0608a3de0fed476553b1fe8",
     remote = "https://github.com/istio/api.git",
     # Change this to True to use ../api directory
     use_local = False,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -157,7 +157,7 @@ new_git_or_local_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
     path = "../api",
-    commit = "e55fd946afe11f7aab49ee5eaf1dc4f9ecd7e61d",
+    commit = "bfe9416e34c2b5f2207f949a2cad5e57dbffdef5",
     remote = "https://github.com/istio/api.git",
     # Change this to True to use ../api directory
     use_local = False,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -157,7 +157,7 @@ new_git_or_local_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
     path = "../api",
-    commit = "a3e9726dd154657cb0608a3de0fed476553b1fe8",
+    commit = "e55fd946afe11f7aab49ee5eaf1dc4f9ecd7e61d",
     remote = "https://github.com/istio/api.git",
     # Change this to True to use ../api directory
     use_local = False,

--- a/adapter/stdioLogger/config/config.proto
+++ b/adapter/stdioLogger/config/config.proto
@@ -48,21 +48,11 @@ message Params {
     // Format of the value of the payload attribute.
     PayloadFormat payload_format = 2;
 
-    // The name of the attribute that will be used to derive log severity.
-    // If this attribute is not found in the set of attributes passed to this
-    // implementation, a default severity of INFO will be used.
-    string severity_attribute = 3;
-
-    // The name of the attribute that will be used to derive the timestamp
-    // for the corresponding log enty. If this attribute is not specified, the
-    // value from time.Now() will be used as the timestamp for the log.
-    string timestamp_attribute = 4;
-
-    // The format of the value of the timestamp_attribute. It is expected that
+    // The format to use when serializing timestamps. It is expected that
     // this format string will follow the conventions of golang's time.Time
     // package and use the reference date as defined in:
     // https://golang.org/pkg/time/#pkg-constants.
     //
-    // Example: "2006-01-02T15:04:05Z07:00"
+    // Default Value: "2006-01-02T15:04:05Z07:00" (RFC3339)
     string timestamp_format = 5;
 }

--- a/adapter/stdioLogger/config/config.proto
+++ b/adapter/stdioLogger/config/config.proto
@@ -31,12 +31,4 @@ message Params {
     // Selects which standard stream to write to for log entries.
     // STDERR is the default Stream.
     Stream log_stream = 1;
-
-    // The format to use when serializing timestamps. It is expected that
-    // this format string will follow the conventions of golang's time.Time
-    // package and use the reference date as defined in:
-    // https://golang.org/pkg/time/#pkg-constants.
-    //
-    // Default Value: "2006-01-02T15:04:05Z07:00" (RFC3339)
-    string timestamp_format = 2;
 }

--- a/adapter/stdioLogger/config/config.proto
+++ b/adapter/stdioLogger/config/config.proto
@@ -38,5 +38,5 @@ message Params {
     // https://golang.org/pkg/time/#pkg-constants.
     //
     // Default Value: "2006-01-02T15:04:05Z07:00" (RFC3339)
-    string timestamp_format = 5;
+    string timestamp_format = 2;
 }

--- a/adapter/stdioLogger/config/config.proto
+++ b/adapter/stdioLogger/config/config.proto
@@ -21,32 +21,16 @@ option go_package = "config";
 message Params {
 
     // Stream is used to select between different logs output sinks.
-    // STDERR is the default Stream.
     enum Stream {
-
         // STDERR refers to os.Stderr.
         STDERR = 0;
-
         // STDOUT refers to os.Stdout.
         STDOUT = 1;
     }
 
     // Selects which standard stream to write to for log entries.
+    // STDERR is the default Stream.
     Stream log_stream = 1;
-
-    // PayloadFormat details the currently supported logging payload formats.
-    // TEXT is the default payload format.
-    enum PayloadFormat {
-
-        // Indicates a payload format of raw text.
-        TEXT = 0;
-
-        // Indicates a structured payload (JSON object).
-        STRUCTURED = 1;
-    }
-
-    // Format of the value of the payload attribute.
-    PayloadFormat payload_format = 2;
 
     // The format to use when serializing timestamps. It is expected that
     // this format string will follow the conventions of golang's time.Time

--- a/adapter/stdioLogger/config/config.proto
+++ b/adapter/stdioLogger/config/config.proto
@@ -34,11 +34,6 @@ message Params {
     // Selects which standard stream to write to for log entries.
     Stream log_stream = 1;
 
-    // Provides a way to identify a collection of related logs within the
-    // single stream. If no log_name is provided, a default value of
-    // "istio_log" will be used.
-    string log_name = 2;
-
     // PayloadFormat details the currently supported logging payload formats.
     // TEXT is the default payload format.
     enum PayloadFormat {
@@ -50,24 +45,18 @@ message Params {
         STRUCTURED = 1;
     }
 
-    // The name of the attribute to treat as the payload of the logs message.
-    // If payload_attribute is not specified, there will be no payload specified
-    // in the log entry written. All provided attributes will be written out
-    // as logging metadata.
-    string payload_attribute = 3;
-
     // Format of the value of the payload attribute.
-    PayloadFormat payload_format = 4;
+    PayloadFormat payload_format = 2;
 
     // The name of the attribute that will be used to derive log severity.
     // If this attribute is not found in the set of attributes passed to this
     // implementation, a default severity of INFO will be used.
-    string severity_attribute = 5;
+    string severity_attribute = 3;
 
     // The name of the attribute that will be used to derive the timestamp
     // for the corresponding log enty. If this attribute is not specified, the
     // value from time.Now() will be used as the timestamp for the log.
-    string timestamp_attribute = 6;
+    string timestamp_attribute = 4;
 
     // The format of the value of the timestamp_attribute. It is expected that
     // this format string will follow the conventions of golang's time.Time
@@ -75,5 +64,5 @@ message Params {
     // https://golang.org/pkg/time/#pkg-constants.
     //
     // Example: "2006-01-02T15:04:05Z07:00"
-    string timestamp_format = 7;
+    string timestamp_format = 5;
 }

--- a/adapter/stdioLogger/stdioLogger.go
+++ b/adapter/stdioLogger/stdioLogger.go
@@ -40,7 +40,7 @@ type (
 
 	logEntry struct {
 		logger.Entry
-		timestampFmt string `json:"-"`
+		timestampFmt string
 	}
 )
 

--- a/adapter/stdioLogger/stdioLogger_test.go
+++ b/adapter/stdioLogger/stdioLogger_test.go
@@ -68,14 +68,16 @@ func TestAspectImpl_Log(t *testing.T) {
 	stamp, _ := time.Parse("2006-Jan-02", "2017-Jan-09")
 	jan10, _ := time.Parse("2006-Jan-02", "2017-Jan-10")
 
-	textPayloadEntry := logger.Entry{LogName: "istio_log", Labels: map[string]interface{}{}, TextPayload: "text payload", Timestamp: stamp, Severity: "INFO"}
-	jsonPayloadEntry := logger.Entry{LogName: "istio_log", Labels: map[string]interface{}{}, StructPayload: map[string]interface{}{"val": 42, "obj": map[string]interface{}{"val": false}}, Timestamp: stamp, Severity: "INFO"}
-	labelEntry := logger.Entry{LogName: "istio_log", Labels: map[string]interface{}{"label": 42}, Timestamp: stamp, Severity: "INFO"}
-	timeOverrideEntry := logger.Entry{LogName: "istio_log", Labels: map[string]interface{}{"label": 42}, Timestamp: jan10, Severity: "INFO"}
+	structPayload := map[string]interface{}{"val": 42, "obj": map[string]interface{}{"val": false}}
 
-	baseLog := `{"timestamp":"2017-01-09T00:00:00Z","logName":"istio_log","labels":{},"severity":"INFO"}`
-	textPayloadLog := `{"timestamp":"2017-01-09T00:00:00Z","logName":"istio_log","labels":{},"severity":"INFO","textPayload":"text payload"}`
-	jsonPayloadLog := `{"timestamp":"2017-01-09T00:00:00Z","logName":"istio_log","labels":{},"severity":"INFO","structPayload":{"obj":{"val":false},"val":42}}`
+	textPayloadEntry := logger.Entry{LogName: "istio_log", TextPayload: "text payload", Timestamp: stamp, Severity: logger.Info}
+	jsonPayloadEntry := logger.Entry{LogName: "istio_log", StructPayload: structPayload, Timestamp: stamp, Severity: logger.Info}
+	labelEntry := logger.Entry{LogName: "istio_log", Labels: map[string]interface{}{"label": 42}, Timestamp: stamp, Severity: logger.Info}
+	timeOverrideEntry := logger.Entry{LogName: "istio_log", Labels: map[string]interface{}{"label": 42}, Timestamp: jan10, Severity: logger.Info}
+
+	baseLog := `{"timestamp":"2017-01-09T00:00:00Z","logName":"istio_log","severity":"INFO"}`
+	textPayloadLog := `{"timestamp":"2017-01-09T00:00:00Z","logName":"istio_log","severity":"INFO","textPayload":"text payload"}`
+	jsonPayloadLog := `{"timestamp":"2017-01-09T00:00:00Z","logName":"istio_log","severity":"INFO","structPayload":{"obj":{"val":false},"val":42}}`
 	labelLog := `{"timestamp":"2017-01-09T00:00:00Z","logName":"istio_log","labels":{"label":42},"severity":"INFO"}`
 	timestampLog := `{"timestamp":"2017-Jan-10","logName":"istio_log","labels":{"label":42},"severity":"INFO"}`
 
@@ -84,7 +86,7 @@ func TestAspectImpl_Log(t *testing.T) {
 
 	tests := []logTests{
 		{baseAspectImpl, []logger.Entry{}, []string{}},
-		{baseAspectImpl, []logger.Entry{{LogName: "istio_log", Labels: map[string]interface{}{}, Timestamp: stamp, Severity: "INFO"}}, []string{baseLog}},
+		{baseAspectImpl, []logger.Entry{{LogName: "istio_log", Labels: map[string]interface{}{}, Timestamp: stamp, Severity: logger.Info}}, []string{baseLog}},
 		{baseAspectImpl, []logger.Entry{textPayloadEntry}, []string{textPayloadLog}},
 		{baseAspectImpl, []logger.Entry{jsonPayloadEntry}, []string{jsonPayloadLog}},
 		{baseAspectImpl, []logger.Entry{labelEntry}, []string{labelLog}},

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -35,19 +35,23 @@ type (
 	// Entry is the set of data that together constitutes a log entry.
 	Entry struct {
 		// LogName is the name of the log in which to record this entry.
-		LogName string
+		LogName string `json:"logName",omitempty`
 		// Labels are a set of metadata associated with this entry.
 		// For instance, Labels can be used to describe the monitored
 		// resource that corresponds to the log entry.
-		Labels map[string]interface{}
-		// Payload is the actual data for which the entry is being
-		// generated.
-		Payload string
+		Labels map[string]interface{} `json:"labels",omitempty`
 		// Timestamp is the time value for the log entry
-		Timestamp time.Time
+		Timestamp time.Time `json:"timestamp,omitempty"`
 		// Severity indicates the log level for the log entry.
 		// Example levels: "INFO", "WARNING", "500"
-		Severity string
+		Severity string `json:"severity",omitempty`
+		// TextPayload is textual logs data for which the entry is being
+		// generated.
+		TextPayload string `json:"textPayload,omitempty"`
+		// StructPayload is a structured set of data, extracted from
+		// a serialized JSON Object, that represent the actual data
+		// for which the entry is being generated.
+		StructPayload map[string]interface{} `json:"structPayload,omitempty"`
 	}
 
 	// Adapter is the interface for building Aspect instances for mixer

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -30,10 +30,16 @@ type (
 		Log([]Entry) error
 	}
 
-	// Entry is a set of key-value pairs of attributes that together
-	// constitute the data for log entry. The key is the attribute name,
-	// and the value is a typed value for the named attribute.
-	Entry map[string]interface{}
+	// Entry is the set of data that together constitutes a log entry.
+	Entry struct {
+		// LogName is the name of the log in which to record this entry.
+		LogName string
+		// Labels are the set of metadata associated with this entry.
+		Labels map[string]interface{}
+		// Payload is the actual data for which the entry is being
+		// generated.
+		Payload string
+	}
 
 	// Adapter is the interface for building Aspect instances for mixer
 	// logging backends.

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -15,6 +15,9 @@
 package logger
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -35,16 +38,15 @@ type (
 	// Entry is the set of data that together constitutes a log entry.
 	Entry struct {
 		// LogName is the name of the log in which to record this entry.
-		LogName string `json:"logName",omitempty`
+		LogName string `json:"logName,omitempty"`
 		// Labels are a set of metadata associated with this entry.
 		// For instance, Labels can be used to describe the monitored
 		// resource that corresponds to the log entry.
-		Labels map[string]interface{} `json:"labels",omitempty`
+		Labels map[string]interface{} `json:"labels,omitempty"`
 		// Timestamp is the time value for the log entry
 		Timestamp time.Time `json:"timestamp,omitempty"`
 		// Severity indicates the log level for the log entry.
-		// Example levels: "INFO", "WARNING", "500"
-		Severity string `json:"severity",omitempty`
+		Severity Severity `json:"severity,omitempty"`
 		// TextPayload is textual logs data for which the entry is being
 		// generated.
 		TextPayload string `json:"textPayload,omitempty"`
@@ -53,6 +55,9 @@ type (
 		// for which the entry is being generated.
 		StructPayload map[string]interface{} `json:"structPayload,omitempty"`
 	}
+
+	// Severity provides a set of logging levels for logger.Entry.
+	Severity int
 
 	// Adapter is the interface for building Aspect instances for mixer
 	// logging backends.
@@ -64,3 +69,63 @@ type (
 		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
 	}
 )
+
+const (
+	// Default indicates that the log entry has no assigned severity level.
+	Default Severity = iota
+	// Debug indicates that the log entry has debug or trace information.
+	Debug
+	// Info indicates that the log entry has routine info, including status or performance data
+	Info
+	// Notice indicates that the log entry has normal, but significant events, such as config changes.
+	Notice
+	// Warning indicates that the log entry has data on events that might cause issues.
+	Warning
+	// Error indicates that the log entry has data on events that are likely to cause issues.
+	Error
+	// Critical indicates that the log entry has data on events related to severe problems or outages.
+	Critical
+	// Alert indicates that the log entry has data on which human action should be taken immediately.
+	Alert
+	// Emergency indicates that the log entry has data on one (or more) systems that are unusable.
+	Emergency
+)
+
+var (
+	severityMap = map[Severity]string{
+		Default:   "DEFAULT",
+		Debug:     "DEBUG",
+		Info:      "INFO",
+		Notice:    "NOTICE",
+		Warning:   "WARNING",
+		Error:     "ERROR",
+		Critical:  "CRITICAL",
+		Alert:     "ALERT",
+		Emergency: "EMERGENCY",
+	}
+)
+
+func (s Severity) String() string {
+	if str, ok := severityMap[s]; ok {
+		return str
+	}
+	return fmt.Sprintf("%d", s)
+}
+
+// SeverityByName returns a logger.Severity based on the supplied string. It
+// attempts to look up the logger.Severity based on a map from enum to string.
+// Default (with false) is returned if the name is not found.
+func SeverityByName(s string) (Severity, bool) {
+	s = strings.ToUpper(s)
+	for severity, name := range severityMap {
+		if name == s {
+			return severity, true
+		}
+	}
+	return Default, false
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s Severity) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
@@ -44,7 +43,7 @@ type (
 		// resource that corresponds to the log entry.
 		Labels map[string]interface{} `json:"labels,omitempty"`
 		// Timestamp is the time value for the log entry
-		Timestamp time.Time `json:"timestamp,omitempty"`
+		Timestamp string `json:"timestamp,omitempty"`
 		// Severity indicates the log level for the log entry.
 		Severity Severity `json:"severity,omitempty"`
 		// TextPayload is textual logs data for which the entry is being

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -15,6 +15,8 @@
 package logger
 
 import (
+	"time"
+
 	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
 )
@@ -34,11 +36,18 @@ type (
 	Entry struct {
 		// LogName is the name of the log in which to record this entry.
 		LogName string
-		// Labels are the set of metadata associated with this entry.
+		// Labels are a set of metadata associated with this entry.
+		// For instance, Labels can be used to describe the monitored
+		// resource that corresponds to the log entry.
 		Labels map[string]interface{}
 		// Payload is the actual data for which the entry is being
 		// generated.
 		Payload string
+		// Timestamp is the time value for the log entry
+		Timestamp time.Time
+		// Severity indicates the log level for the log entry.
+		// Example levels: "INFO", "WARNING", "500"
+		Severity string
 	}
 
 	// Adapter is the interface for building Aspect instances for mixer

--- a/pkg/aspectsupport/BUILD
+++ b/pkg/aspectsupport/BUILD
@@ -14,7 +14,6 @@ config_setting(
 ISTIO_DEPS = [
     "//:mixer/v1",
     "//:mixer/v1/config",
-    "//:mixer/v1/config/aspect",
 ]
 
 DEPS = [

--- a/pkg/aspectsupport/logger/BUILD
+++ b/pkg/aspectsupport/logger/BUILD
@@ -19,7 +19,6 @@ go_library(
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
-        "@com_github_istio_api//:mixer/v1/config/aspect",
         "@com_github_istio_api//:mixer/v1/config/descriptor",
     ],
 )

--- a/pkg/aspectsupport/logger/BUILD
+++ b/pkg/aspectsupport/logger/BUILD
@@ -18,6 +18,8 @@ go_library(
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
+        "@com_github_istio_api//:mixer/v1/config/aspect",
+        "@com_github_istio_api//:mixer/v1/config/descriptor",
     ],
 )
 

--- a/pkg/aspectsupport/logger/BUILD
+++ b/pkg/aspectsupport/logger/BUILD
@@ -29,7 +29,6 @@ go_test(
     srcs = ["manager_test.go"],
     library = ":go_default_library",
     deps = [
-        "@com_github_golang_protobuf//jsonpb/jsonpb_test_proto:go_default_library",
         "@com_github_istio_api//:mixer/v1/config",
     ],
 )

--- a/pkg/aspectsupport/logger/BUILD
+++ b/pkg/aspectsupport/logger/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//pkg/aspect:go_default_library",
         "//pkg/aspect/logger:go_default_library",
         "//pkg/aspectsupport:go_default_library",
+        "//pkg/aspectsupport/logger/config:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/expr:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",

--- a/pkg/aspectsupport/logger/config/config.proto
+++ b/pkg/aspectsupport/logger/config/config.proto
@@ -27,6 +27,7 @@ option go_package="config";
 //    log_entry_descriptor_names: "application_log_entry", "action_log_entry"
 //    severity_attribute: "severity"
 //    timestamp_attribute: "timestamp"
+//    timestamp_format: "2006-Jan-02"
 //
 message Params {
     // Provides a way to identify a collection of related log entries.
@@ -47,5 +48,13 @@ message Params {
     // for the corresponding log enty. If this attribute is not specified, the
     // value from time.Now() will be used as the timestamp for the log.
     string timestamp_attribute = 4;
+
+    // The format to use when serializing timestamps. It is expected that
+    // this format string will follow the conventions of golang's time.Time
+    // package and use the reference date as defined in:
+    // https://golang.org/pkg/time/#pkg-constants.
+    //
+    // Default Value: "2006-01-02T15:04:05Z07:00" (RFC3339)
+    string timestamp_format = 5;
 
 }

--- a/pkg/aspectsupport/logger/config/config.proto
+++ b/pkg/aspectsupport/logger/config/config.proto
@@ -35,4 +35,15 @@ message Params {
     // LogEntryDescriptor is named in the config, the logger will not generate
     // any log entries.
     repeated string log_entry_descriptor_names = 2;
+
+    // The name of the attribute that will be used to derive log severity.
+    // If this attribute is not found in the set of attributes passed to this
+    // implementation, a default severity of INFO will be used.
+    string severity_attribute = 3;
+
+    // The name of the attribute that will be used to derive the timestamp
+    // for the corresponding log enty. If this attribute is not specified, the
+    // value from time.Now() will be used as the timestamp for the log.
+    string timestamp_attribute = 4;
+
 }

--- a/pkg/aspectsupport/logger/config/config.proto
+++ b/pkg/aspectsupport/logger/config/config.proto
@@ -25,6 +25,8 @@ option go_package="config";
 // params:
 //    log_name: "endpoint_log"
 //    log_entry_descriptor_names: "application_log_entry", "action_log_entry"
+//    severity_attribute: "severity"
+//    timestamp_attribute: "timestamp"
 //
 message Params {
     // Provides a way to identify a collection of related log entries.

--- a/pkg/aspectsupport/logger/config/config.proto
+++ b/pkg/aspectsupport/logger/config/config.proto
@@ -40,7 +40,7 @@ message Params {
 
     // The name of the attribute that will be used to derive log severity.
     // If this attribute is not found in the set of attributes passed to this
-    // implementation, a default severity of INFO will be used.
+    // implementation, a default severity of "DEFAULT" will be used.
     string severity_attribute = 3;
 
     // The name of the attribute that will be used to derive the timestamp

--- a/pkg/aspectsupport/logger/manager_test.go
+++ b/pkg/aspectsupport/logger/manager_test.go
@@ -15,19 +15,22 @@
 package logger
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/struct"
 	"istio.io/mixer/pkg/aspect"
+	"istio.io/mixer/pkg/aspect/logger"
+	"istio.io/mixer/pkg/aspectsupport"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 
 	jtpb "github.com/golang/protobuf/jsonpb/jsonpb_test_proto"
-	"github.com/golang/protobuf/ptypes/empty"
 	configpb "istio.io/api/mixer/v1/config"
-	"istio.io/mixer/pkg/aspect/logger"
-	"istio.io/mixer/pkg/aspectsupport"
+	aspectpb "istio.io/api/mixer/v1/config/aspect"
+	dpb "istio.io/api/mixer/v1/config/descriptor"
 )
 
 func TestNewManager(t *testing.T) {
@@ -37,24 +40,7 @@ func TestNewManager(t *testing.T) {
 	}
 }
 
-func TestNewAspectBadConfig(t *testing.T) {
-
-	newAspectShouldError := []aspectTestCase{
-		{"mismatched protos", widget, statusStruct},
-	}
-
-	m := NewManager()
-
-	for _, v := range newAspectShouldError {
-		c := aspectsupport.CombinedConfig{Adapter: &configpb.Adapter{Params: v.params}}
-		if _, err := m.NewAspect(&c, &testLogger{defaultCfg: v.defaultCfg}, testEnv{}); err == nil {
-			t.Errorf("NewAspect(): expected error for %s", v.name)
-		}
-	}
-}
-
-func TestNewAspectConfig(t *testing.T) {
-
+func TestManager_NewAspect(t *testing.T) {
 	newAspectShouldSucceed := []aspectTestCase{
 		{"empty", widget, &structpb.Struct{}},
 		{"nil", widget, nil},
@@ -71,42 +57,103 @@ func TestNewAspectConfig(t *testing.T) {
 	}
 }
 
-func TestNewAspectBadAdapter(t *testing.T) {
-	m := NewManager()
+func TestManager_NewAspectFailures(t *testing.T) {
+
+	defaultCfg := &aspectsupport.CombinedConfig{
+		Adapter: &configpb.Adapter{},
+		Aspect:  &configpb.Aspect{},
+	}
 
 	var generic aspect.Adapter
+	errLogger := &testLogger{defaultCfg: &structpb.Struct{}, errOnNewAspect: true}
 
-	if _, err := m.NewAspect(&aspectsupport.CombinedConfig{}, generic, testEnv{}); err == nil {
-		t.Error("NewAspect(): expected error for bad adapter")
+	failureCases := []struct {
+		cfg   *aspectsupport.CombinedConfig
+		adptr aspect.Adapter
+	}{
+		{defaultCfg, generic},
+		{defaultCfg, errLogger},
+	}
+
+	m := NewManager()
+	for _, v := range failureCases {
+		if _, err := m.NewAspect(v.cfg, v.adptr, testEnv{}); err == nil {
+			t.Error("NewAspect(): expected error for bad adapter")
+		}
 	}
 }
 
-func TestExecute(t *testing.T) {
+func TestExecutor_Execute(t *testing.T) {
+	noPayloadDesc := dpb.LogEntryDescriptor{
+		Name:       "test",
+		Attributes: []string{"key"},
+	}
+	payloadDesc := dpb.LogEntryDescriptor{
+		Name:             "test",
+		Attributes:       []string{"key"},
+		PayloadAttribute: "payload",
+	}
+	withInputsDesc := dpb.LogEntryDescriptor{
+		Name:             "test",
+		Attributes:       []string{"attr"},
+		PayloadAttribute: "payload",
+	}
+
+	noDescriptorExec := &executor{"istio_log", []dpb.LogEntryDescriptor{}, map[string]string{}, nil}
+	noPayloadExec := &executor{"istio_log", []dpb.LogEntryDescriptor{noPayloadDesc}, map[string]string{"attr": "val"}, nil}
+	payloadExec := &executor{"istio_log", []dpb.LogEntryDescriptor{payloadDesc}, map[string]string{"attr": "val"}, nil}
+	withInputsExec := &executor{"istio_log", []dpb.LogEntryDescriptor{withInputsDesc}, map[string]string{"attr": "val"}, nil}
+
 	executeShouldSucceed := []executeTestCase{
-		{"single attribute", map[string]string{"attr": "val"}, &testBag{}, &testEvaluator{}},
+		{"no descriptors", noDescriptorExec, &testBag{}, &testEvaluator{}, 0},
+		{"no payload", noPayloadExec, &testBag{strs: map[string]string{"key": "value"}}, &testEvaluator{}, 1},
+		{"payload not found", payloadExec, &testBag{strs: map[string]string{"key": "value"}}, &testEvaluator{}, 0},
+		{"with payload", payloadExec, &testBag{strs: map[string]string{"key": "value", "payload": "test"}}, &testEvaluator{}, 1},
+		{"with inputs", withInputsExec, &testBag{strs: map[string]string{"key": "value", "payload": "test"}}, &testEvaluator{}, 1},
 	}
 
 	for _, v := range executeShouldSucceed {
 		l := &testLogger{}
-		e := &executor{v.inputs, l}
-		if _, err := e.Execute(v.bag, v.mapper); err != nil {
+		v.exec.aspect = l
+
+		if _, err := v.exec.Execute(v.bag, v.mapper); err != nil {
 			t.Errorf("Execute(): should not have received error for %s (%v)", v.name, err)
 		}
-		if l.entryCount != 1 {
-			t.Errorf("Execute(): wanted entry count of 1, got %d", l.entryCount)
+		if l.entryCount != v.wantEntryCount {
+			t.Errorf("Execute(): got %d entries, wanted %d", l.entryCount, v.wantEntryCount)
 		}
 	}
 }
 
-func TestDefaultConfig(t *testing.T) {
+func TestExecutor_ExecuteFailures(t *testing.T) {
+
+	desc := dpb.LogEntryDescriptor{
+		Name:       "test",
+		Attributes: []string{"key"},
+	}
+
+	errorExec := &executor{"istio_log", []dpb.LogEntryDescriptor{desc}, map[string]string{}, &testLogger{errOnLog: true}}
+
+	executeShouldFail := []executeTestCase{
+		{"log failure", errorExec, &testBag{strs: map[string]string{"key": "value"}}, &testEvaluator{}, 1},
+	}
+
+	for _, v := range executeShouldFail {
+		if _, err := v.exec.Execute(v.bag, v.mapper); err == nil {
+			t.Errorf("Execute(): should have received error for %s", v.name)
+		}
+	}
+}
+
+func TestManager_DefaultConfig(t *testing.T) {
 	m := NewManager()
 	o := m.DefaultConfig()
-	if !proto.Equal(o, &empty.Empty{}) {
+	if !proto.Equal(o, &aspectpb.LoggerConfig{LogName: "istio_log"}) {
 		t.Errorf("DefaultConfig(): wanted empty proto, got %v", o)
 	}
 }
 
-func TestValidateConfig(t *testing.T) {
+func TestManager_ValidateConfig(t *testing.T) {
 	m := NewManager()
 	if err := m.ValidateConfig(&empty.Empty{}); err != nil {
 		t.Errorf("ValidateConfig(): unexpected error: %v", err)
@@ -121,23 +168,28 @@ type (
 		params     *structpb.Struct
 	}
 	executeTestCase struct {
-		name   string
-		inputs map[string]string
-		bag    attribute.Bag
-		mapper expr.Evaluator
+		name           string
+		exec           *executor
+		bag            attribute.Bag
+		mapper         expr.Evaluator
+		wantEntryCount int
 	}
 	testLogger struct {
 		logger.Adapter
 		logger.Aspect
 
-		defaultCfg proto.Message
-		entryCount int
+		defaultCfg     proto.Message
+		entryCount     int
+		errOnNewAspect bool
+		errOnLog       bool
 	}
 	testEvaluator struct {
 		expr.Evaluator
 	}
 	testBag struct {
 		attribute.Bag
+
+		strs map[string]string
 	}
 	testEnv struct {
 		aspect.Env
@@ -146,17 +198,32 @@ type (
 
 var (
 	widget       = &jtpb.Widget{Color: jtpb.Widget_RED.Enum(), RColor: []jtpb.Widget_Color{jtpb.Widget_GREEN}}
-	statusStruct = newStruct(structMap{"code": newStringVal("Test")})
 	widgetStruct = newStruct(structMap{"color": newStringVal("BLUE"), "simple": newStructVal(structMap{"o_bool": newBoolVal(false)})})
 )
 
-func (t *testLogger) NewAspect(e aspect.Env, m proto.Message) (logger.Aspect, error) { return t, nil }
-func (t *testLogger) DefaultConfig() proto.Message                                   { return t.defaultCfg }
-func (t *testLogger) Log([]logger.Entry) error                                       { t.entryCount++; return nil }
-func (t *testLogger) Close() error                                                   { return nil }
+func (t *testLogger) NewAspect(e aspect.Env, m proto.Message) (logger.Aspect, error) {
+	if t.errOnNewAspect {
+		return nil, errors.New("new aspect error")
+	}
+	return t, nil
+}
+func (t *testLogger) DefaultConfig() proto.Message { return t.defaultCfg }
+func (t *testLogger) Log([]logger.Entry) error {
+	if t.errOnLog {
+		return errors.New("log error")
+	}
+	t.entryCount++
+	return nil
+}
+func (t *testLogger) Close() error { return nil }
 
 func (t *testEvaluator) Eval(e string, bag attribute.Bag) (interface{}, error) {
 	return e, nil
+}
+
+func (t *testBag) String(name string) (string, bool) {
+	v, found := t.strs[name]
+	return v, found
 }
 
 func newStringVal(s string) *structpb.Value {


### PR DESCRIPTION
This PR updates the manager for the logger aspect to properly report the config for the logger.Aspect as the DefaultConfig(). It uses the logger aspect config to build a more detailed logger.Entry to pass into Log() calls. The existing stdioLogger is updated to reflect these changes to the logger aspect config handling.

A few notes:
* no LogEntryDescriptors are currently provided, nor are they looked up. A subsequent PR will address providing an initial "standard" LogEntryDescriptor for short-term use by the mixer.
* in BUILD.api, quota_descriptor.proto is disabled, pending https://github.com/istio/api/pull/20
* parts of pkg/aspectsupport/logger/manager.go are not covered by the existing tests, as it is expected that they will soon be replaced by config-related PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/157)
<!-- Reviewable:end -->
