### PR TITLE
Initial implementation of tracing in the mixer with opentracing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,6 +132,12 @@ new_go_repository(
     importpath = "github.com/hashicorp/errwrap",
 )
 
+new_go_repository(
+    name = "com_github_opentracing_opentracing_go",
+    commit = "ac5446f53f2c0fc68dc16dc5f426eae1cd288b34",
+    importpath = "github.com/opentracing/opentracing-go",
+)
+
 load("//:repositories.bzl", "new_git_or_local_repository")
 
 new_git_or_local_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,6 +138,19 @@ new_go_repository(
     importpath = "github.com/opentracing/opentracing-go",
 )
 
+new_go_repository(
+    name = "com_github_opentracing_basictracer",
+    commit = "1b32af207119a14b1b231d451df3ed04a72efebf",
+    importpath = "github.com/opentracing/basictracer-go"
+)
+
+# Transitive dep of com_github_opentracing_basictracer
+new_go_repository(
+    name = "com_github_gogo_protobuf",
+    commit = "909568be09de550ed094403c2bf8a261b5bb730a",
+    importpath = "github.com/gogo/protobuf"
+)
+
 load("//:repositories.bzl", "new_git_or_local_repository")
 
 new_git_or_local_repository(

--- a/cmd/client/BUILD
+++ b/cmd/client/BUILD
@@ -13,10 +13,13 @@ go_library(
     ],
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/tracing:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_istio_api//:mixer/v1",
+        "@com_github_opentracing_basictracer//:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/cmd/client/check.go
+++ b/cmd/client/check.go
@@ -42,7 +42,7 @@ func check(rootArgs *rootArgs, args []string, errorf errorFn) {
 	}
 
 	var cs *clientState
-	if cs, err = createAPIClient(rootArgs.mixerAddress); err != nil {
+	if cs, err = createAPIClient(rootArgs.mixerAddress, rootArgs.enableTracing); err != nil {
 		errorf("Unable to establish connection to %s", rootArgs.mixerAddress)
 		return
 	}

--- a/cmd/client/report.go
+++ b/cmd/client/report.go
@@ -48,7 +48,7 @@ func report(rootArgs *rootArgs, args []string, errorf errorFn) {
 	}
 
 	var cs *clientState
-	if cs, err = createAPIClient(rootArgs.mixerAddress); err != nil {
+	if cs, err = createAPIClient(rootArgs.mixerAddress, rootArgs.enableTracing); err != nil {
 		errorf("Unable to establish connection to %s: %v", rootArgs.mixerAddress, err)
 		return
 	}

--- a/cmd/client/util.go
+++ b/cmd/client/util.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -41,7 +42,7 @@ func createAPIClient(port string, enableTracing bool) (*clientState, error) {
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithInsecure())
 	if enableTracing {
-		opts = append(opts, grpc.WithStreamInterceptor(tracing.ClientInterceptor(bt.New(tracing.StdoutRecorder()))))
+		opts = append(opts, grpc.WithStreamInterceptor(tracing.ClientInterceptor(bt.New(tracing.IORecorder(os.Stdout)))))
 	}
 
 	var err error

--- a/cmd/client/util.go
+++ b/cmd/client/util.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 
 	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/mixer/pkg/tracing"
 )
 
 type clientState struct {
@@ -37,6 +38,7 @@ func createAPIClient(port string) (*clientState, error) {
 
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithInsecure())
+	opts = append(opts, grpc.WithStreamInterceptor(tracing.ClientInterceptor()))
 
 	var err error
 	if cs.connection, err = grpc.Dial(port, opts...); err != nil {

--- a/cmd/server/BUILD
+++ b/cmd/server/BUILD
@@ -14,6 +14,8 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/attribute:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_opentracing_basictracer//:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/cmd/server/BUILD
+++ b/cmd/server/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/tracing:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_opentracing_basictracer//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	bt "github.com/opentracing/basictracer-go"
@@ -93,7 +94,7 @@ func runServer(sa *serverArgs) error {
 
 	var tracer ot.Tracer
 	if sa.enableTracing {
-		tracer = bt.New(tracing.StdoutRecorder())
+		tracer = bt.New(tracing.IORecorder(os.Stdout))
 	}
 
 	attrMgr := attribute.NewManager()

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -10,6 +10,7 @@ go_library(
     ],
     deps = [
         "//pkg/attribute:go_default_library",
+        "//pkg/tracing:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
@@ -17,6 +18,8 @@ go_library(
         "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
         "@com_github_istio_api//:mixer/v1",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_opentracing_opentracing_go//log:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
     ],

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -170,7 +170,7 @@ func (s *GRPCServer) streamLoop(stream grpc.ServerStream, request proto.Message,
 		}
 
 		var span ot.Span
-		span, ctx = ot.StartSpanFromContext(ctx, fmt.Sprintf("%s-%d", methodName, i))
+		span, ctx = ot.StartSpanFromContext(ctx, methodName)
 		span.LogFields(log.Object("gRPC request", request))
 
 		// do the actual work for the message

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -59,10 +59,6 @@ type GRPCServerOptions struct {
 	// Port specifies the IP port the server should listen on.
 	Port uint16
 
-	// EnableTracing determines whether OpenTracing is used to add trace information to
-	// all API calls.
-	EnableTracing bool
-
 	// CompressedPayload determines whether compression should be
 	// used on individual messages.
 	CompressedPayload bool
@@ -84,8 +80,8 @@ type GRPCServerOptions struct {
 	// processing incoming attribute requests.
 	AttributeManager attribute.Manager
 
-	// Tracer is the tracer instance to use with OpenTracing. If EnableTracing is false
-	// this is unused.
+	// Tracer is the tracer instance to use with OpenTracing. If Tracer is nil no tracing
+	// will be enabled.
 	Tracer ot.Tracer
 }
 
@@ -132,13 +128,8 @@ func NewGRPCServer(options *GRPCServerOptions) (*GRPCServer, error) {
 		grpcOptions = append(grpcOptions, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}
 
-	if options.EnableTracing {
-		// If options.Tracer is nil we won't set the GlobalTracer, defaulting to the no-op tracer.
-		//
-		// TODO: should we panic if tracing is enabled but no tracer is provided?
-		if options.Tracer != nil {
-			ot.SetGlobalTracer(options.Tracer)
-		}
+	if options.Tracer != nil {
+		ot.SetGlobalTracer(options.Tracer)
 	}
 
 	// get everything wired up

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -160,7 +160,7 @@ func (s *GRPCServer) streamLoop(stream grpc.ServerStream, request proto.Message,
 	root, ctx := tracing.StartRootSpan(stream.Context(), methodName)
 	defer root.Finish()
 
-	for i := 1; ; i++ {
+	for {
 		// get a single message
 		if err := stream.RecvMsg(request); err == io.EOF {
 			return nil

--- a/pkg/tracing/BUILD
+++ b/pkg/tracing/BUILD
@@ -5,10 +5,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "basictracing.go",
         "metadata.go",
         "tracing.go",
     ],
     deps = [
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_opentracing_basictracer//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_opentracing_opentracing_go//ext:go_default_library",
         "@com_github_opentracing_opentracing_go//log:go_default_library",
@@ -20,7 +23,7 @@ go_library(
 )
 
 go_test(
-    name = "tracing_test",
+    name = "small_tests",
     size = "small",
     srcs = [
         "tracing_test.go",

--- a/pkg/tracing/BUILD
+++ b/pkg/tracing/BUILD
@@ -26,6 +26,8 @@ go_test(
     name = "small_tests",
     size = "small",
     srcs = [
+        "basictracing_test.go",
+        "metadata_test.go",
         "tracing_test.go",
     ],
     library = ":go_default_library",

--- a/pkg/tracing/BUILD
+++ b/pkg/tracing/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "metadata.go",
+        "tracing.go",
+    ],
+    deps = [
+        "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_opentracing_opentracing_go//ext:go_default_library",
+        "@com_github_opentracing_opentracing_go//log:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//metadata:go_default_library",
+        "@org_golang_google_grpc//tap:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+    ],
+)
+
+go_test(
+    name = "tracing_test",
+    size = "small",
+    srcs = [
+        "tracing_test.go",
+    ],
+    library = ":go_default_library",
+    deps = [
+        "@com_github_opentracing_opentracing_go//mocktracer:go_default_library",
+    ],
+)

--- a/pkg/tracing/basictracing.go
+++ b/pkg/tracing/basictracing.go
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.//
+// limitations under the License.
 //
 // Copyright (c) 2017, gRPC Ecosystem
 // All rights reserved.
@@ -46,6 +46,7 @@ package tracing
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/golang/glog"
 	bt "github.com/opentracing/basictracer-go"
@@ -65,16 +66,18 @@ func (l loggingRecorder) RecordSpan(span bt.RawSpan) {
 	glog.Info(spanToString(span))
 }
 
-type stdoutRecorder struct{}
+type ioRecorder struct {
+	sink io.Writer
+}
 
-// StdoutRecorder returns a SpanRecorder which writes its spans to stdout.
-func StdoutRecorder() bt.SpanRecorder {
-	return stdoutRecorder{}
+// IORecorder returns a SpanRecorder which writes its spans to the provided io.Writer.
+func IORecorder(w io.Writer) bt.SpanRecorder {
+	return ioRecorder{w}
 }
 
 // RecordSpan writes span to stdout.
-func (s stdoutRecorder) RecordSpan(span bt.RawSpan) {
-	fmt.Println(spanToString(span))
+func (s ioRecorder) RecordSpan(span bt.RawSpan) {
+	fmt.Fprintln(s.sink, spanToString(span))
 }
 
 func spanToString(span bt.RawSpan) string {

--- a/pkg/tracing/basictracing_test.go
+++ b/pkg/tracing/basictracing_test.go
@@ -1,0 +1,58 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"testing"
+	"time"
+
+	"bytes"
+
+	"github.com/golang/glog"
+	bt "github.com/opentracing/basictracer-go"
+)
+
+var span = bt.RawSpan{
+	Context: bt.SpanContext{
+		TraceID: 1,
+		SpanID:  2,
+		Sampled: false,
+	},
+	ParentSpanID: 1,
+	Operation:    "test span",
+	Start:        time.Now(),
+}
+
+func TestLoggingRecorder(t *testing.T) {
+	recorder := LoggingRecorder()
+	recorder.RecordSpan(span)
+
+	glog.Flush()
+	if glog.Stats.Info.Lines() == 0 {
+		t.Errorf("LoggingRecorder didn't write span %v to info", span)
+	}
+}
+
+func TestIORecorder(t *testing.T) {
+	buf := new(bytes.Buffer)
+	recorder := IORecorder(buf)
+	recorder.RecordSpan(span)
+
+	// The IORecorder uses fmt.Fprintln, so we always have a newline at the end.
+	expected := spanToString(span) + "\n"
+	if buf.String() != expected {
+		t.Errorf("Expected output string '%s' for span %v, actual: '%s'", expected, span, buf.String())
+	}
+}

--- a/pkg/tracing/metadata.go
+++ b/pkg/tracing/metadata.go
@@ -1,0 +1,40 @@
+package tracing
+
+// TODO: PR https://github.com/grpc-ecosystem/grpc-opentracing/ to rework these functions to be reusable
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// metadataReaderWriter satisfies both the opentracing.TextMapReader and
+// opentracing.TextMapWriter interfaces.
+type metadataReaderWriter struct {
+	metadata.MD
+}
+
+func (w metadataReaderWriter) Set(key, val string) {
+	// The GRPC HPACK implementation rejects any uppercase keys here.
+	//
+	// As such, since the HTTP_HEADERS format is case-insensitive anyway, we
+	// blindly lowercase the key (which is guaranteed to work in the
+	// Inject/Extract sense per the OpenTracing spec).
+	key = strings.ToLower(key)
+	w.MD[key] = append(w.MD[key], val)
+}
+
+func (w metadataReaderWriter) ForeachKey(handler func(key, val string) error) error {
+	for k, vals := range w.MD {
+		for _, v := range vals {
+			if dk, dv, err := metadata.DecodeKeyValue(k, v); err == nil {
+				if err = handler(dk, dv); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/tracing/metadata_test.go
+++ b/pkg/tracing/metadata_test.go
@@ -1,0 +1,43 @@
+package tracing
+
+import (
+	"testing"
+
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func TestMetadataReaderWriter(t *testing.T) {
+	md := metadata.New(make(map[string]string))
+	rw := metadataReaderWriter{md}
+
+	rw.Set("foo", "bar")
+	rw.Set("foo", "bar2")
+	err := rw.ForeachKey(func(key, val string) error {
+		if key != "foo" {
+			t.Errorf("Got unexpected key, expected: 'foo', actual '%s', metadata: %v", key, md)
+		}
+		if !(val == "bar" || val == "bar2") {
+			t.Errorf("Got unexpected value for key 'foo', actual '%s' expected 'bar' or 'bar2'", val)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("Got err from ForEachKey: %v", err)
+	}
+}
+
+func TestMetadataReaderWriter_PropagateErr(t *testing.T) {
+	md := metadata.New(make(map[string]string))
+	rw := metadataReaderWriter{md}
+
+	rw.Set("foo", "bar")
+	rw.Set("foo", "bar2")
+	expectedErr := fmt.Errorf("expected error")
+
+	err := rw.ForeachKey(func(key, val string) error { return expectedErr })
+	if err != expectedErr {
+		t.Errorf("Expecte err '%v' to be propagated out, actual '%v'", expectedErr, err)
+	}
+}

--- a/pkg/tracing/metadata_test.go
+++ b/pkg/tracing/metadata_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tracing
 
 import (

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -15,7 +15,8 @@ import (
 
 // TODO: Keep track of per-stream state, e.g. the Tracer impl to use in traces for this stream. This will enable things
 // like different tracers per stream (client). Currently this package is built on the assumption that only the global
-// tracer is used, which isn't great (it makes testing harder, for example).
+// tracer is used, which isn't great (it makes testing harder, for example). This state could also be used to keep
+// track of per stream config like metadata propagation format.
 //
 // TODO: investigate wrapping the server stream in one with a mutable context, so that we can use an interceptor or TAP
 // handler to set up the root span rather than doing it in the server's stream loop.
@@ -78,7 +79,7 @@ func StartRootSpan(ctx context.Context, operationName string) (ot.Span, context.
 	if !ok {
 		md = metadata.New(nil)
 	}
-	spanContext, err := ot.GlobalTracer().Extract(ot.TextMap, metadataReaderWriter{md})
+	spanContext, err := ot.GlobalTracer().Extract(ot.HTTPHeaders, metadataReaderWriter{md})
 	if err != nil {
 		// TODO: establish some sort of error reporting mechanism here. We
 		// don't know where to put such an error and must rely on Tracer

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,112 @@
+package tracing
+
+import (
+	"context"
+
+	xctx "golang.org/x/net/context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+// TODO: Keep track of per-stream state, e.g. the Tracer impl to use in traces for this stream. This will enable things
+// like different tracers per stream (client). Currently this package is built on the assumption that only the global
+// tracer is used, which isn't great (it makes testing harder, for example).
+//
+// TODO: investigate wrapping the server stream in one with a mutable context, so that we can use an interceptor or TAP
+// handler to set up the root span rather than doing it in the server's stream loop.
+//
+// TODO: investigate merging some of this code with https://github.com/grpc-ecosystem/grpc-opentracing/
+
+var (
+	noopSpan = ot.NoopTracer{}.StartSpan("")
+
+	gRPCComponentTag = ot.Tag{string(ext.Component), "gRPC"}
+)
+
+// ClientInterceptor establishes a span that lives for the entire lifetime of the server-client stream and propagates
+// it via gRPC request metadata to the client.
+func ClientInterceptor() grpc.StreamClientInterceptor {
+	return func(
+		ctx xctx.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption) (grpc.ClientStream, error) {
+
+		span, ctx := ot.StartSpanFromContext(ctx, method, ext.SpanKindRPCClient)
+		defer span.Finish()
+		ctx = propagateSpan(ctx, span)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+// CurrentSpan extracts the current span from the context, or returns a no-op span if no span exists in the context.
+// This avoids boilerplate nil checking when calling opentracing.SpanFromContext.
+func CurrentSpan(ctx context.Context) ot.Span {
+	// TODO: figure out how to handle a span not existing in the context: this shouldn't happen because a root trace
+	// is always created for the life of a stream. (Possible cause would be someone creating a new context, or not
+	// propagating the context correctly.)
+	if current := ot.SpanFromContext(ctx); current != nil {
+		return current
+	}
+	return noopSpan
+}
+
+type rootSpanKey struct{}
+
+// RootSpan retrieves the root span from the context. This may be different than the current context returned by
+// opentracing.SpanFromContext(ctx)
+func RootSpan(ctx context.Context) ot.Span {
+	val := ctx.Value(rootSpanKey{})
+	if root, ok := val.(ot.Span); ok {
+		return root
+	}
+	return noopSpan
+}
+
+// StartRootSpan creates a span that is the root of all Istio spans in the current request context. This span will be a
+// child of any spans propagated to the server in the request's metadata. The returned span is retrievable from the
+// context via tracing.RootSpan.
+func StartRootSpan(ctx context.Context, operationName string) (ot.Span, context.Context) {
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
+	spanContext, err := ot.GlobalTracer().Extract(ot.TextMap, metadataReaderWriter{md})
+	if err != nil {
+		// TODO: establish some sort of error reporting mechanism here. We
+		// don't know where to put such an error and must rely on Tracer
+		// implementations to do something appropriate for the time being.
+
+		// We set the spancontext to nil if there's an error so we don't get funky values from ext.RPCServerOption
+		// (in particular the mock tracer impl doesn't handle a non nil empty span context gracefully).
+		spanContext = nil
+	}
+	span, ctx := ot.StartSpanFromContext(ctx, operationName, ext.RPCServerOption(spanContext), gRPCComponentTag)
+	ctx = context.WithValue(ctx, rootSpanKey{}, span)
+	return span, ctx
+}
+
+// propagateSpan inserts metadata about the span into the context's metadata so that the span is propagated to the receiver.
+// This should be used to prepare the context for outgoing calls.
+//
+// TODO: consider creating a public version of this method for use at individual call sites if the interceptor isn't
+// sufficient for some reason.
+func propagateSpan(ctx context.Context, span ot.Span) context.Context {
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
+	mdWriter := metadataReaderWriter{md}
+	err := ot.GlobalTracer().Inject(span.Context(), ot.HTTPHeaders, mdWriter)
+	if err != nil {
+		span.LogFields(log.String("event", "Tracer.Inject() failed"), log.Error(err))
+	}
+	return metadata.NewContext(ctx, md)
+}

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,13 +1,30 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tracing
 
 import (
 	"context"
 	"testing"
 
+	xctx "golang.org/x/net/context"
+
 	"google.golang.org/grpc/metadata"
 
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
+	"google.golang.org/grpc"
 )
 
 func init() {
@@ -38,7 +55,7 @@ func TestStartRootSpan(t *testing.T) {
 
 	// Shove the first span into the context's grpc metadata, so that StartRootSpan will think it got a propagated span
 	// We use a new context so we're guarantee we're not relying on a span being in the context (i.e. so ot.SpanFromContext() == nil)
-	newCtx := propagateSpan(context.Background(), s)
+	newCtx := propagateSpan(context.Background(), ot.GlobalTracer(), s)
 
 	ss, newCtx := StartRootSpan(newCtx, "second")
 	if root := RootSpan(newCtx); root != ss {
@@ -53,7 +70,7 @@ func TestStartRootSpan(t *testing.T) {
 
 func TestPropagateSpan(t *testing.T) {
 	span := ot.StartSpan("first")
-	ctx := propagateSpan(context.Background(), span)
+	ctx := propagateSpan(context.Background(), ot.GlobalTracer(), span)
 
 	md, ok := metadata.FromContext(ctx)
 	if !ok {
@@ -74,5 +91,30 @@ func TestPropagateSpan(t *testing.T) {
 			mockSpan.SpanContext.SpanID,
 			mockCtx.SpanID,
 			ctx)
+	}
+}
+
+func TestClientInterceptor(t *testing.T) {
+	tracer := mocktracer.New()
+	interceptor := ClientInterceptor(tracer)
+	ctx := context.Background()
+
+	_, err := interceptor(ctx, nil, nil, "interceptor test",
+		func(ctx xctx.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+			ctxSpan := CurrentSpan(ctx)
+			if ctxSpan == noopSpan {
+				t.Errorf("No span found inside intercepted handler; ctx: %v", ctx)
+			}
+
+			mockCtxSpan := ctxSpan.(*mocktracer.MockSpan)
+			root, ctx := StartRootSpan(ctx, "root")
+			mockRoot := root.(*mocktracer.MockSpan)
+			if mockRoot.ParentID != mockCtxSpan.SpanContext.SpanID {
+				t.Errorf("Couldn't construct root span out of metadata from client interceptor; ctx: %v", ctx)
+			}
+			return nil, nil
+		})
+	if err != nil {
+		t.Errorf("Got error from interceptor: %v", err)
 	}
 }

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,78 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+)
+
+func init() {
+	ot.SetGlobalTracer(mocktracer.New())
+}
+
+func TestCurrentSpan(t *testing.T) {
+	span, ctx := ot.StartSpanFromContext(context.Background(), "first")
+
+	if currentSpan := CurrentSpan(ctx); currentSpan != span {
+		t.Errorf("Failed to extract the current span from the context, expected '%v' actual '%v'; context: '%v'", span, currentSpan, ctx)
+	}
+}
+
+func TestStartRootSpan(t *testing.T) {
+	ctx := context.Background()
+	s, ctx := StartRootSpan(ctx, "first")
+
+	if root := RootSpan(ctx); root != s {
+		t.Errorf("No root span in context, expected span '%v'; context: %v", s, ctx)
+	}
+
+	first, _ := s.(*mocktracer.MockSpan)
+	// We had no metadata in the context being propagated, so we expect no parent
+	if first.ParentID != 0 {
+		t.Errorf("Expected no parent for root span with no request metadata, actual '%d'; context: %v", first.ParentID, ctx)
+	}
+
+	// Shove the first span into the context's grpc metadata, so that StartRootSpan will think it got a propagated span
+	// We use a new context so we're guarantee we're not relying on a span being in the context (i.e. so ot.SpanFromContext() == nil)
+	newCtx := propagateSpan(context.Background(), s)
+
+	ss, newCtx := StartRootSpan(newCtx, "second")
+	if root := RootSpan(newCtx); root != ss {
+		t.Errorf("No root span in context, expected span '%v'; context: %v", s, ctx)
+	}
+
+	second, _ := ss.(*mocktracer.MockSpan)
+	if second.ParentID != first.SpanContext.SpanID {
+		t.Errorf("Expected second to have parentID '%d', actual '%d'; context: %v", first.SpanContext.SpanID, second.ParentID, ctx)
+	}
+}
+
+func TestPropagateSpan(t *testing.T) {
+	span := ot.StartSpan("first")
+	ctx := propagateSpan(context.Background(), span)
+
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
+
+	sCtx, err := ot.GlobalTracer().Extract(ot.HTTPHeaders, metadataReaderWriter{md})
+	if err != nil {
+		t.Errorf("Failed to extract metadata with err: %s", err)
+	}
+
+	mockSpan, _ := span.(*mocktracer.MockSpan)
+	mockCtx, _ := sCtx.(mocktracer.MockSpanContext)
+
+	if mockCtx.SpanID != mockSpan.SpanContext.SpanID {
+		t.Errorf(
+			"Extracted spancontext doesn't match propagated span: expected spanID '%d', actual '%d'; context: %v",
+			mockSpan.SpanContext.SpanID,
+			mockCtx.SpanID,
+			ctx)
+	}
+}


### PR DESCRIPTION
Initial implementation of tracing in the mixer with opentracing. In opentracing a tracer starts spans, spans together form a trace. We generate a span which represents the entire stream of calls between a client and mixer, with a child span for each request served by the mixer. We also introduce a client interceptor which propagates the mixer's current span to the callee.

There's still a bit more to do to get opentracing into a better state, but I think this is a reasonable start.

Implementation notes:
- I chose to handle the root span in the GRPCServer's streamLoop method rather than in gRPC's ServerStreamInterceptor (doesn't allow mutation of the context, so we can't propagate span metadata through the mixer) or its transport layer handler (allows mutating the context but
 doesn't bookend the stream so we can't finish the root span) due to the shortcomes mentioned inline.
- Quite a bit of this code should eventually migrate into github.com/grpc-ecosystem/grpc-opentracing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/158)
<!-- Reviewable:end -->
