### PR TITLE
Define the type aspect.Config to be a replacement for proto.Message.

### DIFF
--- a/adapter/denyChecker/BUILD
+++ b/adapter/denyChecker/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//pkg/aspect:go_default_library",
         "//pkg/aspect/denyChecker:go_default_library",
         "//pkg/registry:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
     ],

--- a/adapter/denyChecker/adapter.go
+++ b/adapter/denyChecker/adapter.go
@@ -16,7 +16,6 @@
 package denyChecker
 
 import (
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/pkg/aspect"
@@ -35,16 +34,16 @@ func Register(r registry.Registrar) error {
 
 type adapterState struct{}
 
-func newAdapter() denyChecker.Adapter                                              { return &adapterState{} }
-func (a *adapterState) Name() string                                               { return "istio/denyChecker" }
-func (a *adapterState) Description() string                                        { return "Deny every check request" }
-func (a *adapterState) Close() error                                               { return nil }
-func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) { return }
+func newAdapter() denyChecker.Adapter                                            { return &adapterState{} }
+func (a *adapterState) Name() string                                             { return "istio/denyChecker" }
+func (a *adapterState) Description() string                                      { return "Deny every check request" }
+func (a *adapterState) Close() error                                             { return nil }
+func (a *adapterState) ValidateConfig(c aspect.Config) (ce *aspect.ConfigErrors) { return }
 
-func (a *adapterState) DefaultConfig() proto.Message {
+func (a *adapterState) DefaultConfig() aspect.Config {
 	return &config.Params{Error: &status.Status{Code: int32(code.Code_FAILED_PRECONDITION)}}
 }
 
-func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {
-	return newAspect(cfg.(*config.Params))
+func (a *adapterState) NewAspect(env aspect.Env, c aspect.Config) (denyChecker.Aspect, error) {
+	return newAspect(c.(*config.Params))
 }

--- a/adapter/denyChecker/aspect.go
+++ b/adapter/denyChecker/aspect.go
@@ -17,9 +17,8 @@ package denyChecker
 import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 
-	"istio.io/mixer/pkg/aspect/denyChecker"
-
 	"istio.io/mixer/adapter/denyChecker/config"
+	"istio.io/mixer/pkg/aspect/denyChecker"
 )
 
 type aspectState struct {

--- a/adapter/genericListChecker/BUILD
+++ b/adapter/genericListChecker/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//pkg/aspect:go_default_library",
         "//pkg/aspect/listChecker:go_default_library",
         "//pkg/registry:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 

--- a/adapter/genericListChecker/adapter.go
+++ b/adapter/genericListChecker/adapter.go
@@ -16,8 +16,6 @@
 package genericListChecker
 
 import (
-	"github.com/golang/protobuf/proto"
-
 	"istio.io/mixer/adapter/genericListChecker/config"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/aspect/listChecker"
@@ -31,13 +29,13 @@ func Register(r registry.Registrar) error {
 
 type adapterState struct{}
 
-func newAdapter() listChecker.Adapter                                              { return &adapterState{} }
-func (a *adapterState) Name() string                                               { return "istio/genericListChecker" }
-func (a *adapterState) Description() string                                        { return "Checks whether a string is present in a list." }
-func (a *adapterState) Close() error                                               { return nil }
-func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) { return }
-func (a *adapterState) DefaultConfig() proto.Message                               { return &config.Params{} }
+func newAdapter() listChecker.Adapter                                            { return &adapterState{} }
+func (a *adapterState) Name() string                                             { return "istio/genericListChecker" }
+func (a *adapterState) Description() string                                      { return "Checks whether a string is present in a list." }
+func (a *adapterState) Close() error                                             { return nil }
+func (a *adapterState) ValidateConfig(c aspect.Config) (ce *aspect.ConfigErrors) { return }
+func (a *adapterState) DefaultConfig() aspect.Config                             { return &config.Params{} }
 
-func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
-	return newAspect(cfg.(*config.Params))
+func (a *adapterState) NewAspect(env aspect.Env, c aspect.Config) (listChecker.Aspect, error) {
+	return newAspect(c.(*config.Params))
 }

--- a/adapter/ipListChecker/BUILD
+++ b/adapter/ipListChecker/BUILD
@@ -13,8 +13,6 @@ go_library(
         "//pkg/aspect:go_default_library",
         "//pkg/aspect/listChecker:go_default_library",
         "//pkg/registry:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/adapter/ipListChecker/adapter.go
+++ b/adapter/ipListChecker/adapter.go
@@ -18,8 +18,6 @@ package ipListChecker
 import (
 	"net/url"
 
-	"github.com/golang/protobuf/proto"
-
 	"istio.io/mixer/adapter/ipListChecker/config"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/aspect/listChecker"
@@ -42,7 +40,7 @@ func (a *adapterState) Description() string {
 
 func (a *adapterState) Close() error { return nil }
 
-func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) {
+func (a *adapterState) ValidateConfig(cfg aspect.Config) (ce *aspect.ConfigErrors) {
 	c := cfg.(*config.Params)
 
 	u, err := url.Parse(c.ProviderUrl)
@@ -57,7 +55,7 @@ func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigError
 	return
 }
 
-func (a *adapterState) DefaultConfig() proto.Message {
+func (a *adapterState) DefaultConfig() aspect.Config {
 	return &config.Params{
 		ProviderUrl:     "http://localhost",
 		RefreshInterval: 60,
@@ -65,6 +63,6 @@ func (a *adapterState) DefaultConfig() proto.Message {
 	}
 }
 
-func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
-	return newAspect(env, cfg.(*config.Params))
+func (a *adapterState) NewAspect(env aspect.Env, c aspect.Config) (listChecker.Aspect, error) {
+	return newAspect(env, c.(*config.Params))
 }

--- a/adapter/stdioLogger/BUILD
+++ b/adapter/stdioLogger/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//pkg/aspect:go_default_library",
         "//pkg/aspect/logger:go_default_library",
         "//pkg/registry:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],
 )

--- a/adapter/stdioLogger/stdioLogger.go
+++ b/adapter/stdioLogger/stdioLogger.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/adapter/stdioLogger/config"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/aspect/logger"
@@ -45,10 +44,10 @@ func (a *adapter) Name() string { return "istio/stdioLogger" }
 func (a *adapter) Description() string {
 	return "Writes structured log entries to a standard I/O stream"
 }
-func (a *adapter) DefaultConfig() proto.Message                               { return &config.Params{} }
-func (a *adapter) Close() error                                               { return nil }
-func (a *adapter) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) { return nil }
-func (a *adapter) NewAspect(env aspect.Env, cfg proto.Message) (logger.Aspect, error) {
+func (a *adapter) DefaultConfig() aspect.Config                             { return &config.Params{} }
+func (a *adapter) Close() error                                             { return nil }
+func (a *adapter) ValidateConfig(c aspect.Config) (ce *aspect.ConfigErrors) { return nil }
+func (a *adapter) NewAspect(env aspect.Env, cfg aspect.Config) (logger.Aspect, error) {
 	c := cfg.(*config.Params)
 
 	w := os.Stderr

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -70,6 +70,7 @@ func withArgs(args []string, errorf errorFn) {
 	// hack to make flag.Parsed return true such that glog is happy
 	// about the flags having been parsed
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	/* #nosec */
 	_ = fs.Parse([]string{})
 	flag.CommandLine = fs
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,6 +40,7 @@ func withArgs(args []string, errorf errorFn) {
 	// hack to make flag.Parsed return true such that glog is happy
 	// about the flags having been parsed
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	/* #nosec */
 	_ = fs.Parse([]string{})
 	flag.CommandLine = fs
 

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	testPort       = 29999
 	testRequestID0 = 1234
 	testRequestID1 = 5678
 )
@@ -40,9 +39,9 @@ type testState struct {
 	connection *grpc.ClientConn
 }
 
-func (ts *testState) createGRPCServer() error {
+func (ts *testState) createGRPCServer(port uint16) error {
 	options := GRPCServerOptions{
-		Port:                 testPort,
+		Port:                 port,
 		MaxMessageSize:       1024 * 1024,
 		MaxConcurrentStreams: 32,
 		CompressedPayload:    false,
@@ -66,12 +65,12 @@ func (ts *testState) deleteGRPCServer() {
 	ts.apiServer = nil
 }
 
-func (ts *testState) createAPIClient() error {
+func (ts *testState) createAPIClient(port uint16) error {
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithInsecure())
 
 	var err error
-	if ts.connection, err = grpc.Dial(fmt.Sprintf("localhost:%v", testPort), opts...); err != nil {
+	if ts.connection, err = grpc.Dial(fmt.Sprintf("localhost:%v", port), opts...); err != nil {
 		return err
 	}
 
@@ -85,13 +84,13 @@ func (ts *testState) deleteAPIClient() {
 	ts.connection = nil
 }
 
-func prepTestState() (*testState, error) {
+func prepTestState(port uint16) (*testState, error) {
 	ts := &testState{}
-	if err := ts.createGRPCServer(); err != nil {
+	if err := ts.createGRPCServer(port); err != nil {
 		return nil, err
 	}
 
-	if err := ts.createAPIClient(); err != nil {
+	if err := ts.createAPIClient(port); err != nil {
 		ts.deleteGRPCServer()
 		return nil, err
 	}
@@ -120,7 +119,7 @@ func (ts *testState) Quota(ctx context.Context, tracker attribute.Tracker, reque
 }
 
 func TestCheck(t *testing.T) {
-	ts, err := prepTestState()
+	ts, err := prepTestState(29999)
 	if err != nil {
 		t.Errorf("unable to prep test state %v", err)
 		return
@@ -179,7 +178,7 @@ func TestCheck(t *testing.T) {
 }
 
 func TestReport(t *testing.T) {
-	ts, err := prepTestState()
+	ts, err := prepTestState(30000)
 	if err != nil {
 		t.Errorf("unable to prep test state %v", err)
 		return

--- a/pkg/aspect/aspect.go
+++ b/pkg/aspect/aspect.go
@@ -37,22 +37,25 @@ type (
 	// The extended interface is implemented by adapter implementations
 	Adapter interface {
 		io.Closer
+		ConfigValidator
+
 		// Name returns the official name of this adapter. ex. "istio/statsd".
 		Name() string
 		// Description returns a user-friendly description of this adapter.
 		Description() string
-
-		ConfigValidator
 	}
+
+	// Config represents a chunk of configuration state
+	Config proto.Message
 
 	// ConfigValidator handles adapter configuration defaults and validation.
 	ConfigValidator interface {
 		// DefaultConfig returns a default configuration struct for this
 		// adapter. This will be used by the configuration system to establish
 		// the shape of the block of configuration state passed to the NewAspect method.
-		DefaultConfig() (implConfig proto.Message)
+		DefaultConfig() (c Config)
 		// ValidateConfig determines whether the given configuration meets all correctness requirements.
-		ValidateConfig(implConfig proto.Message) *ConfigErrors
+		ValidateConfig(c Config) *ConfigErrors
 	}
 
 	// Env defines the environment in which an aspect executes.

--- a/pkg/aspect/configError.go
+++ b/pkg/aspect/configError.go
@@ -24,7 +24,7 @@ import (
 //
 // The usage pattern for this type is pretty simple:
 //
-//  	func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *adapter.ConfigErrors) {
+//  	func (a *adapterState) ValidateConfig(cfg aspect.Config) (ce *adapter.ConfigErrors) {
 //  		c := cfg.(*Config)
 // 			if c.Url == nil {
 //  			ce = ce.Appendf("Url", "Must have a valid URL")

--- a/pkg/aspect/denyChecker/BUILD
+++ b/pkg/aspect/denyChecker/BUILD
@@ -9,7 +9,6 @@ go_library(
     ],
     deps = [
         "//pkg/aspect:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
     ],
 )

--- a/pkg/aspect/denyChecker/denyChecker.go
+++ b/pkg/aspect/denyChecker/denyChecker.go
@@ -15,7 +15,6 @@
 package denyChecker
 
 import (
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"istio.io/mixer/pkg/aspect"
 )
@@ -32,6 +31,6 @@ type (
 	Adapter interface {
 		aspect.Adapter
 		// NewAspect returns a new DenyChecker
-		NewAspect(env aspect.Env, cfg proto.Message) (Aspect, error)
+		NewAspect(env aspect.Env, c aspect.Config) (Aspect, error)
 	}
 )

--- a/pkg/aspect/listChecker/BUILD
+++ b/pkg/aspect/listChecker/BUILD
@@ -9,6 +9,5 @@ go_library(
     ],
     deps = [
         "//pkg/aspect:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/pkg/aspect/listChecker/listChecker.go
+++ b/pkg/aspect/listChecker/listChecker.go
@@ -15,7 +15,6 @@
 package listChecker
 
 import (
-	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
 )
 
@@ -31,6 +30,6 @@ type (
 	Adapter interface {
 		aspect.Adapter
 		// NewAspect returns a new ListChecker
-		NewAspect(env aspect.Env, cfg proto.Message) (Aspect, error)
+		NewAspect(env aspect.Env, c aspect.Config) (Aspect, error)
 	}
 )

--- a/pkg/aspect/logger/BUILD
+++ b/pkg/aspect/logger/BUILD
@@ -9,6 +9,5 @@ go_library(
     ],
     deps = [
         "//pkg/aspect:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
 )
 
@@ -65,7 +64,7 @@ type (
 
 		// NewAspect returns a new Logger implementation, based on the
 		// supplied Aspect configuration for the backend.
-		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+		NewAspect(env aspect.Env, c aspect.Config) (Aspect, error)
 	}
 )
 

--- a/pkg/aspect/metrics/BUILD
+++ b/pkg/aspect/metrics/BUILD
@@ -9,7 +9,6 @@ go_library(
     ],
     deps = [
         "//pkg/aspect:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 

--- a/pkg/aspect/metrics/metrics.go
+++ b/pkg/aspect/metrics/metrics.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
 )
 
@@ -78,7 +77,7 @@ type (
 
 		// NewAspect returns a new quota implementation, based on the
 		// supplied Aspect configuration for the backend.
-		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+		NewAspect(env aspect.Env, config aspect.Config) (Aspect, error)
 	}
 )
 

--- a/pkg/aspect/quota/quota.go
+++ b/pkg/aspect/quota/quota.go
@@ -15,7 +15,6 @@
 package quota
 
 import (
-	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
 )
 
@@ -42,7 +41,7 @@ type (
 
 		// NewAspect returns a new quota implementation, based on the
 		// supplied Aspect configuration for the backend.
-		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+		NewAspect(env aspect.Env, c aspect.Config) (Aspect, error)
 	}
 
 	// Args supplies the arguments for quota operations.

--- a/pkg/aspectsupport/denyChecker/BUILD
+++ b/pkg/aspectsupport/denyChecker/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//pkg/aspectsupport/denyChecker/config:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/expr:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
     ],

--- a/pkg/aspectsupport/denyChecker/manager.go
+++ b/pkg/aspectsupport/denyChecker/manager.go
@@ -17,7 +17,6 @@ package denyChecker
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/pkg/aspect"
@@ -73,11 +72,11 @@ func (*manager) Kind() string {
 	return kind
 }
 
-func (*manager) DefaultConfig() proto.Message {
+func (*manager) DefaultConfig() aspect.Config {
 	return &config.Params{}
 }
 
-func (*manager) ValidateConfig(implConfig proto.Message) (ce *aspect.ConfigErrors) {
+func (*manager) ValidateConfig(c aspect.Config) (ce *aspect.ConfigErrors) {
 	return
 }
 

--- a/pkg/aspectsupport/listChecker/BUILD
+++ b/pkg/aspectsupport/listChecker/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//pkg/aspectsupport/listChecker/config:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/expr:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
     ],
 )

--- a/pkg/aspectsupport/listChecker/manager.go
+++ b/pkg/aspectsupport/listChecker/manager.go
@@ -17,7 +17,6 @@ package listChecker
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/pkg/aspect"
@@ -78,14 +77,14 @@ func (*manager) Kind() string {
 	return kind
 }
 
-func (*manager) DefaultConfig() proto.Message {
+func (*manager) DefaultConfig() aspect.Config {
 	return &config.Params{
 		CheckAttribute: "src.ip",
 	}
 }
 
-func (*manager) ValidateConfig(implConfig proto.Message) (ce *aspect.ConfigErrors) {
-	lc := implConfig.(*config.Params)
+func (*manager) ValidateConfig(c aspect.Config) (ce *aspect.ConfigErrors) {
+	lc := c.(*config.Params)
 	if lc.CheckAttribute == "" {
 		ce = ce.Appendf("check_attribute", "Missing")
 	}

--- a/pkg/aspectsupport/logger/manager.go
+++ b/pkg/aspectsupport/logger/manager.go
@@ -106,12 +106,12 @@ func (m *manager) NewAspect(c *aspectsupport.CombinedConfig, a aspect.Adapter, e
 }
 
 func (*manager) Kind() string { return "istio/logger" }
-func (*manager) DefaultConfig() proto.Message {
+func (*manager) DefaultConfig() aspect.Config {
 	return &config.Params{LogName: "istio_log", TimestampFormat: time.RFC3339}
 }
 
 // TODO: validation of timestamp format
-func (*manager) ValidateConfig(implConfig proto.Message) (ce *aspect.ConfigErrors) { return nil }
+func (*manager) ValidateConfig(c aspect.Config) (ce *aspect.ConfigErrors) { return nil }
 
 func (e *executor) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspectsupport.Output, error) {
 	var entries []logger.Entry

--- a/pkg/aspectsupport/logger/manager_test.go
+++ b/pkg/aspectsupport/logger/manager_test.go
@@ -244,7 +244,7 @@ type (
 	structMap      map[string]*structpb.Value
 	aspectTestCase struct {
 		name       string
-		defaultCfg proto.Message
+		defaultCfg aspect.Config
 		params     *structpb.Struct
 		want       *executor
 	}
@@ -259,7 +259,7 @@ type (
 		logger.Adapter
 		logger.Aspect
 
-		defaultCfg     proto.Message
+		defaultCfg     aspect.Config
 		entryCount     int
 		entries        []logger.Entry
 		errOnNewAspect bool
@@ -279,13 +279,13 @@ type (
 	}
 )
 
-func (t *testLogger) NewAspect(e aspect.Env, m proto.Message) (logger.Aspect, error) {
+func (t *testLogger) NewAspect(e aspect.Env, m aspect.Config) (logger.Aspect, error) {
 	if t.errOnNewAspect {
 		return nil, errors.New("new aspect error")
 	}
 	return t, nil
 }
-func (t *testLogger) DefaultConfig() proto.Message { return t.defaultCfg }
+func (t *testLogger) DefaultConfig() aspect.Config { return t.defaultCfg }
 func (t *testLogger) Log(l []logger.Entry) error {
 	if t.errOnLog {
 		return errors.New("log error")

--- a/pkg/aspectsupport/uber/BUILD
+++ b/pkg/aspectsupport/uber/BUILD
@@ -35,7 +35,6 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_istio_api//:mixer/v1/config",
     ],
 )

--- a/pkg/aspectsupport/uber/registry_test.go
+++ b/pkg/aspectsupport/uber/registry_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/aspect/denyChecker"
 	"istio.io/mixer/pkg/aspect/listChecker"
@@ -30,15 +29,15 @@ type testAdapter struct {
 	name string
 }
 
-func (t testAdapter) Name() string                                               { return t.name }
-func (testAdapter) Close() error                                                 { return nil }
-func (testAdapter) Description() string                                          { return "mock adapter for testing" }
-func (testAdapter) DefaultConfig() proto.Message                                 { return nil }
-func (testAdapter) ValidateConfig(implConfig proto.Message) *aspect.ConfigErrors { return nil }
+func (t testAdapter) Name() string                                      { return t.name }
+func (testAdapter) Close() error                                        { return nil }
+func (testAdapter) Description() string                                 { return "mock adapter for testing" }
+func (testAdapter) DefaultConfig() aspect.Config                        { return nil }
+func (testAdapter) ValidateConfig(c aspect.Config) *aspect.ConfigErrors { return nil }
 
 type denyAdapter struct{ testAdapter }
 
-func (denyAdapter) NewAspect(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {
+func (denyAdapter) NewAspect(env aspect.Env, cfg aspect.Config) (denyChecker.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -62,7 +61,7 @@ func TestRegisterDeny(t *testing.T) {
 
 type listAdapter struct{ testAdapter }
 
-func (listAdapter) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
+func (listAdapter) NewAspect(env aspect.Env, cfg aspect.Config) (listChecker.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -86,7 +85,7 @@ func TestCheckList(t *testing.T) {
 
 type loggerAdapter struct{ testAdapter }
 
-func (loggerAdapter) NewAspect(env aspect.Env, cfg proto.Message) (al.Aspect, error) {
+func (loggerAdapter) NewAspect(env aspect.Env, cfg aspect.Config) (al.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -110,7 +109,7 @@ func TestRegisterLogger(t *testing.T) {
 
 type quotaAdapter struct{ testAdapter }
 
-func (quotaAdapter) NewAspect(env aspect.Env, cfg proto.Message) (quota.Aspect, error) {
+func (quotaAdapter) NewAspect(env aspect.Env, cfg aspect.Config) (quota.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/config/BUILD
+++ b/pkg/config/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//pkg/attribute:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_mitchellh_mapstructure//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -27,7 +27,6 @@ package config
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v2"
 
@@ -89,7 +88,7 @@ func (p *Validator) validateGlobalConfig(cfg string) (ce *aspect.ConfigErrors) {
 	}
 	p.validated.adapterByKind = make(map[string][]*pb.Adapter)
 	p.validated.adapterByName = make(map[string]*pb.Adapter)
-	var acfg proto.Message
+	var acfg aspect.Config
 	var aArr []*pb.Adapter
 	var found bool
 	for _, aa := range m.GetAdapters() {
@@ -124,7 +123,7 @@ func (p *Validator) validateSelector(selector string) (err error) {
 // validateAspectRules validates the recursive configuration data structure.
 // It is primarily used by validate ServiceConfig.
 func (p *Validator) validateAspectRules(rules []*pb.AspectRule, path string, validatePresence bool) (ce *aspect.ConfigErrors) {
-	var acfg proto.Message
+	var acfg aspect.Config
 	var err error
 	for _, rule := range rules {
 		if err = p.validateSelector(rule.GetSelector()); err != nil {
@@ -200,7 +199,7 @@ func UnknownValidator(name string) error {
 }
 
 // ConvertParams converts returns a typed proto message based on available Validator.
-func ConvertParams(finder ValidatorFinder, name string, params interface{}, strict bool) (proto.Message, error) {
+func ConvertParams(finder ValidatorFinder, name string, params interface{}, strict bool) (aspect.Config, error) {
 	var avl aspect.ConfigValidator
 	var found bool
 
@@ -235,7 +234,7 @@ func NewDecoder(md *mapstructure.Metadata, dst interface{}) (Decoder, error) {
 
 // Decode interprets src interface{} as the specified proto message.
 // optional newDecoderFn can be passed in, otherwise standard NewDecoder is used.
-func Decode(src interface{}, dst proto.Message, strict bool, newDecoders ...newDecoderFn) (err error) {
+func Decode(src interface{}, dst aspect.Config, strict bool, newDecoders ...newDecoderFn) (err error) {
 	var md mapstructure.Metadata
 	var d Decoder
 	newDecoder := NewDecoder

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/mitchellh/mapstructure"
 	"istio.io/mixer/pkg/aspect"
 	listcheckerpb "istio.io/mixer/pkg/aspectsupport/listChecker/config"
@@ -39,12 +38,12 @@ type lc struct {
 	ce *aspect.ConfigErrors
 }
 
-func (m *lc) DefaultConfig() (implConfig proto.Message) {
+func (m *lc) DefaultConfig() (c aspect.Config) {
 	return &listcheckerpb.Params{}
 }
 
 // ValidateConfig determines whether the given configuration meets all correctness requirements.
-func (m *lc) ValidateConfig(implConfig proto.Message) *aspect.ConfigErrors {
+func (m *lc) ValidateConfig(c aspect.Config) *aspect.ConfigErrors {
 	return m.ce
 }
 
@@ -126,7 +125,7 @@ func TestFullConfigValidator(t *testing.T) {
 		cfg      string
 		exprErr  error
 	}{
-		{&aspect.ConfigError{"Kind", fmt.Errorf("adapter for Kind=metrics is not available")},
+		{&aspect.ConfigError{Field: "Kind", Underlying: fmt.Errorf("adapter for Kind=metrics is not available")},
 			map[string]aspect.ConfigValidator{
 				"istio/denychecker": &lc{},
 				"metrics":           &lc{},
@@ -144,13 +143,13 @@ func TestFullConfigValidator(t *testing.T) {
 				"metrics":           &lc{},
 				"listchecker":       &lc{},
 			}, "", false, sSvcConfig2, nil},
-		{&aspect.ConfigError{"NamedAdapter", fmt.Errorf("adapter by name denychecker.2 not available")},
+		{&aspect.ConfigError{Field: "NamedAdapter", Underlying: fmt.Errorf("adapter by name denychecker.2 not available")},
 			map[string]aspect.ConfigValidator{
 				"istio/denychecker": &lc{},
 				"metrics":           &lc{},
 				"listchecker":       &lc{},
 			}, "", false, sSvcConfig3, nil},
-		{&aspect.ConfigError{":Selector service.name == “*”", fmt.Errorf("invalid expression")},
+		{&aspect.ConfigError{Field: ":Selector service.name == “*”", Underlying: fmt.Errorf("invalid expression")},
 			map[string]aspect.ConfigValidator{
 				"istio/denychecker": &lc{},
 				"metrics":           &lc{},


### PR DESCRIPTION
This clarifies the type signatures and makes our code largely independent of
using protos for config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/160)
<!-- Reviewable:end -->
