### PR TITLE
Add a Tracer struct to the tracing package

### DIFF
--- a/cmd/client/BUILD
+++ b/cmd/client/BUILD
@@ -20,6 +20,7 @@ go_library(
         "@com_github_istio_api//:mixer/v1",
         "@com_github_opentracing_basictracer//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_opentracing_opentracing_go//ext:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/cmd/client/check.go
+++ b/cmd/client/check.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/spf13/cobra"
+
 	mixerpb "istio.io/api/mixer/v1"
 )
 
@@ -48,8 +50,11 @@ func check(rootArgs *rootArgs, args []string, errorf errorFn) {
 	}
 	defer deleteAPIClient(cs)
 
+	span, ctx := cs.tracer.StartRootSpan(context.Background(), "mixc Check", ext.SpanKindRPCClient)
+	_, ctx = cs.tracer.PropagateSpan(ctx, span)
+
 	var stream mixerpb.Mixer_CheckClient
-	if stream, err = cs.client.Check(context.Background()); err != nil {
+	if stream, err = cs.client.Check(ctx); err != nil {
 		errorf("Check RPC failed: %v", err)
 		return
 	}
@@ -76,5 +81,7 @@ func check(rootArgs *rootArgs, args []string, errorf errorFn) {
 		errorf("Failed to close gRPC stream: %v", err)
 	}
 
-	fmt.Printf("Check RPC returned '%v'\n", response.Result)
+	span.Finish()
+
+	fmt.Printf("Check RPC returned %v\n", response.Result)
 }

--- a/cmd/client/util.go
+++ b/cmd/client/util.go
@@ -34,6 +34,7 @@ import (
 type clientState struct {
 	client     mixerpb.MixerClient
 	connection *grpc.ClientConn
+	tracer     tracing.Tracer
 }
 
 func createAPIClient(port string, enableTracing bool) (*clientState, error) {
@@ -42,7 +43,8 @@ func createAPIClient(port string, enableTracing bool) (*clientState, error) {
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithInsecure())
 	if enableTracing {
-		opts = append(opts, grpc.WithStreamInterceptor(tracing.ClientInterceptor(bt.New(tracing.IORecorder(os.Stdout)))))
+		tracer := tracing.NewTracer(bt.New(tracing.IORecorder(os.Stdout)))
+		cs.tracer = tracer
 	}
 
 	var err error


### PR DESCRIPTION
This new struct wraps an opentracing.Tracer with a flag that's true if tracing is enabled in the mixer. This flag is used to short-circuit potentially expensive tracing operations if tracing is disabled. In the future this struct will also hold user-specified tracing options; it also lays the groundwork for being able to force tracing on a per-request basis.

We also rework the tracing package given newly discovered info, namely that the gRPC's StreamClientInterceptor does *not* behave in the same way as the StreamServerInterceptor. It looks like we won't be able to use gRPC's interceptor machinery to handle tracing. As a result, we implement span creation and propagation directly in mixc's check and quota commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/173)
<!-- Reviewable:end -->
