### PR TITLE
Make the mixer robust to adapter panics and end processing early on timeout

### DIFF
--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -29,6 +29,8 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
+        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
+        "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
         "@com_github_istio_api//:mixer/v1/config",
     ],
 )

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -95,11 +95,7 @@ func (m *Manager) Execute(cfg *aspect.CombinedConfig, attrs attribute.Bag, mappe
 		return nil, fmt.Errorf("could not find registered adapter %#v", cfg.Builder.Impl)
 	}
 
-	var asp aspect.Wrapper
-	if asp, err = m.cacheGet(cfg, mgr, adapter); err != nil {
-		return nil, err
-	}
-
+	// Both cacheGet and asp.Execute call adapter-supplied code, so we need to guard against both panicking.
 	defer func() {
 		if r := recover(); r != nil {
 			out = nil // invalidate whatever partial result we got; should we set this to a Code.Code_INTERNAL or similar?
@@ -107,6 +103,12 @@ func (m *Manager) Execute(cfg *aspect.CombinedConfig, attrs attribute.Bag, mappe
 			return
 		}
 	}()
+
+	var asp aspect.Wrapper
+	if asp, err = m.cacheGet(cfg, mgr, adapter); err != nil {
+		return nil, err
+	}
+
 	// TODO act on adapter.Output
 	return asp.Execute(attrs, mapper)
 }

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -82,7 +82,7 @@ func (m *Manager) Registry() *Registry {
 
 // Execute performs the aspect function based on CombinedConfig and attributes and an expression evaluator
 // returns aspect output or error if the operation could not be performed
-func (m *Manager) Execute(cfg *aspect.CombinedConfig, attrs attribute.Bag, mapper expr.Evaluator) (*aspect.Output, error) {
+func (m *Manager) Execute(cfg *aspect.CombinedConfig, attrs attribute.Bag, mapper expr.Evaluator) (out *aspect.Output, err error) {
 	var mgr aspect.Manager
 	var found bool
 
@@ -96,11 +96,17 @@ func (m *Manager) Execute(cfg *aspect.CombinedConfig, attrs attribute.Bag, mappe
 	}
 
 	var asp aspect.Wrapper
-	var err error
 	if asp, err = m.cacheGet(cfg, mgr, adapter); err != nil {
 		return nil, err
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			out = nil // invalidate whatever partial result we got; should we set this to a Code.Code_INTERNAL or similar?
+			err = fmt.Errorf("adapter '%s' panicked with '%v'", cfg.Builder.Name, r)
+			return
+		}
+	}()
 	// TODO act on adapter.Output
 	return asp.Execute(attrs, mapper)
 }

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -118,12 +118,12 @@ func TestRecovery_NewAspect(t *testing.T) {
 		&istioconfig.Adapter{Name: name},
 	}
 
-	if _, err := m.Execute(cfg, nil, nil); err != nil {
-		if !strings.Contains(err.Error(), "NewAspect") {
-			t.Errorf("Expected err from panic with message containing 'NewAspect', actual: %v", err)
-		}
-	} else {
+	_, err := m.Execute(cfg, nil, nil)
+	if err == nil {
 		t.Error("Aspect threw, but got no err from manager.Execute")
+	}
+	if !strings.Contains(err.Error(), "NewAspect") {
+		t.Errorf("Expected err from panic with message containing 'NewAspect', actual: %v", err)
 	}
 }
 
@@ -140,11 +140,11 @@ func TestRecovery_AspectExecute(t *testing.T) {
 		&istioconfig.Adapter{Name: name},
 	}
 
-	if _, err := m.Execute(cfg, nil, nil); err != nil {
-		if !strings.Contains(err.Error(), "Execute") {
-			t.Errorf("Expected err from panic with message containing 'Execute', actual: %v", err)
-		}
-	} else {
+	_, err := m.Execute(cfg, nil, nil)
+	if err == nil {
 		t.Error("Aspect threw, but got no err from manager.Execute")
+	}
+	if !strings.Contains(err.Error(), "Execute") {
+		t.Errorf("Expected err from panic with message containing 'Execute', actual: %v", err)
 	}
 }

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -15,11 +15,16 @@
 package adapterManager
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"google.golang.org/genproto/googleapis/rpc/code"
+	"google.golang.org/genproto/googleapis/rpc/status"
+
 	istioconfig "istio.io/api/mixer/v1/config"
 
+	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
@@ -38,11 +43,50 @@ type (
 	fakeevaluator struct {
 		expr.Evaluator
 	}
+
+	testManager struct {
+		name     string
+		throw    bool
+		instance testAspect
+	}
+
+	testAspect struct {
+		throw bool
+	}
 )
 
 func (m *fakemgr) Kind() string {
 	return m.kind
 }
+
+func newTestManager(name string, throwOnNewAspect bool, aspectThrowOnExecute bool) testManager {
+	return testManager{name, throwOnNewAspect, testAspect{aspectThrowOnExecute}}
+}
+func (testManager) Close() error                                                { return nil }
+func (testManager) DefaultConfig() adapter.AspectConfig                         { return nil }
+func (testManager) ValidateConfig(c adapter.AspectConfig) *adapter.ConfigErrors { return nil }
+func (testManager) Kind() string                                                { return "denyChecker" }
+func (m testManager) Name() string                                              { return m.name }
+func (testManager) Description() string                                         { return "deny checker aspect manager for testing" }
+
+func (m testManager) NewAspect(cfg *aspect.CombinedConfig, adapter adapter.Builder, env adapter.Env) (aspect.Wrapper, error) {
+	if m.throw {
+		panic("NewAspect panic")
+	}
+	return m.instance, nil
+}
+func (m testManager) NewDenyChecker(env adapter.Env, c adapter.AspectConfig) (adapter.DenyCheckerAspect, error) {
+	return m.instance, nil
+}
+
+func (testAspect) Close() error { return nil }
+func (t testAspect) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*aspect.Output, error) {
+	if t.throw {
+		panic("Execute panic")
+	}
+	return nil, fmt.Errorf("empty")
+}
+func (testAspect) Deny() status.Status { return status.Status{Code: int32(code.Code_INTERNAL)} }
 
 func TestManager(t *testing.T) {
 	mgrs := []aspect.Manager{&fakemgr{kind: "k1"}, &fakemgr{kind: "k2"}}
@@ -58,5 +102,49 @@ func TestManager(t *testing.T) {
 			t.Error("excute errored out: ", err)
 		}
 
+	}
+}
+
+func TestRecovery_NewAspect(t *testing.T) {
+	name := "NewAspect Throws"
+	cacheThrow := newTestManager(name, true, false)
+	m := NewManager([]aspect.Manager{cacheThrow})
+	if err := m.Registry().RegisterDenyChecker(cacheThrow); err != nil {
+		t.Errorf("Failed to register deny checker in test setup with err: %v", err)
+	}
+
+	cfg := &aspect.CombinedConfig{
+		&istioconfig.Aspect{Kind: name},
+		&istioconfig.Adapter{Name: name},
+	}
+
+	if _, err := m.Execute(cfg, nil, nil); err != nil {
+		if !strings.Contains(err.Error(), "NewAspect") {
+			t.Errorf("Expected err from panic with message containing 'NewAspect', actual: %v", err)
+		}
+	} else {
+		t.Error("Aspect threw, but got no err from manager.Execute")
+	}
+}
+
+func TestRecovery_AspectExecute(t *testing.T) {
+	name := "aspect.Execute Throws"
+	aspectThrow := newTestManager(name, false, true)
+	m := NewManager([]aspect.Manager{aspectThrow})
+	if err := m.Registry().RegisterDenyChecker(aspectThrow); err != nil {
+		t.Errorf("Failed to register deny checker in test setup with err: %v", err)
+	}
+
+	cfg := &aspect.CombinedConfig{
+		&istioconfig.Aspect{Kind: name},
+		&istioconfig.Adapter{Name: name},
+	}
+
+	if _, err := m.Execute(cfg, nil, nil); err != nil {
+		if !strings.Contains(err.Error(), "Execute") {
+			t.Errorf("Expected err from panic with message containing 'Execute', actual: %v", err)
+		}
+	} else {
+		t.Error("Aspect threw, but got no err from manager.Execute")
 	}
 }

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -34,6 +34,9 @@ go_library(
 go_test(
     name = "small_tests",
     size = "small",
-    srcs = ["grpcServer_test.go"],
+    srcs = [
+        "grpcServer_test.go",
+        "methodHandlers_test.go",
+    ],
     library = ":go_default_library",
 )

--- a/pkg/api/methodHandlers.go
+++ b/pkg/api/methodHandlers.go
@@ -120,8 +120,6 @@ func (h *methodHandlers) execute(ctx context.Context, tracker attribute.Tracker,
 	// get a new context with the attribute bag attached
 	ctx = attribute.NewContext(ctx, ab)
 	for _, conf := range h.configs[method] {
-		// TODO: should we keep this check? In theory, it saves us from starting a goroutine for the next adapter before we check to see
-		// if the context is done inside of execWrapper.
 		select {
 		case <-ctx.Done():
 			return newStatusWithMessage(code.Code_DEADLINE_EXCEEDED, ctx.Err().Error())
@@ -144,34 +142,20 @@ func (h *methodHandlers) execute(ctx context.Context, tracker attribute.Tracker,
 
 // execWrapper is responsible for dispatching calls to the manager and recovering from panics in adapter impls.
 // It also monitors the RPC's deadline for timeouts.
-func (h *methodHandlers) execWrapper(ctx context.Context, conf *aspectsupport.CombinedConfig, ab attribute.Bag) (*aspectsupport.Output, error) {
-	type result struct {
-		out *aspectsupport.Output
-		err error
-	}
-	c := make(chan result)
-	// TODO: should we use some threadpool impl instead of just spawning a thread?
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				glog.Warningf("Recovered from panic in adapter '%s'", conf.Adapter.Name)
-				if err, ok := r.(error); ok {
-					c <- result{nil, err}
-				} else {
-					c <- result{nil, fmt.Errorf("adapter '%s' panicked", conf.Adapter.Name)}
-				}
+func (h *methodHandlers) execWrapper(ctx context.Context, conf *aspectsupport.CombinedConfig, ab attribute.Bag) (out *aspectsupport.Output, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			glog.Errorf("Recovered from panic in adapter '%s'", conf.Adapter.Name)
+			out = nil
+			if panicErr, ok := r.(error); ok {
+				err = panicErr
+			} else {
+				err = fmt.Errorf("adapter '%s' panicked", conf.Adapter.Name)
 			}
-		}()
-		o, err := h.mngr.Execute(conf, ab, h.eval)
-		c <- result{o, err}
+			return
+		}
 	}()
-
-	select {
-	case res := <-c:
-		return res.out, res.err
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
+	return h.mngr.Execute(conf, ab, h.eval)
 }
 
 func (h *methodHandlers) Check(ctx context.Context, tracker attribute.Tracker, request *mixerpb.CheckRequest, response *mixerpb.CheckResponse) {

--- a/pkg/api/methodHandlers.go
+++ b/pkg/api/methodHandlers.go
@@ -120,9 +120,16 @@ func (h *methodHandlers) execute(ctx context.Context, tracker attribute.Tracker,
 	// get a new context with the attribute bag attached
 	ctx = attribute.NewContext(ctx, ab)
 	for _, conf := range h.configs[method] {
-		// TODO: plumb ctx through uber.manager.Execute
-		_ = ctx
-		out, err := h.mngr.Execute(conf, ab, h.eval)
+		// TODO: should we keep this check? In theory, it saves us from starting a goroutine for the next adapter before we check to see
+		// if the context is done inside of execWrapper.
+		select {
+		case <-ctx.Done():
+			return newStatusWithMessage(code.Code_DEADLINE_EXCEEDED, ctx.Err().Error())
+		default: // Don't block on Done, keep on processing with adapters.
+		}
+
+		// TODO: should we set a shorter deadline for each adapter? As written, we only care about the request's deadline.
+		out, err := h.execWrapper(ctx, conf, ab)
 		if err != nil {
 			errorStr := fmt.Sprintf("Adapter %s returned err: %v", conf.Builder.Name, err)
 			glog.Warning(errorStr)
@@ -133,6 +140,38 @@ func (h *methodHandlers) execute(ctx context.Context, tracker attribute.Tracker,
 		}
 	}
 	return newStatus(code.Code_OK)
+}
+
+// execWrapper is responsible for dispatching calls to the manager and recovering from panics in adapter impls.
+// It also monitors the RPC's deadline for timeouts.
+func (h *methodHandlers) execWrapper(ctx context.Context, conf *aspectsupport.CombinedConfig, ab attribute.Bag) (*aspectsupport.Output, error) {
+	type result struct {
+		out *aspectsupport.Output
+		err error
+	}
+	c := make(chan result)
+	// TODO: should we use some threadpool impl instead of just spawning a thread?
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				glog.Warningf("Recovered from panic in adapter '%s'", conf.Adapter.Name)
+				if err, ok := r.(error); ok {
+					c <- result{nil, err}
+				} else {
+					c <- result{nil, fmt.Errorf("adapter '%s' panicked", conf.Adapter.Name)}
+				}
+			}
+		}()
+		o, err := h.mngr.Execute(conf, ab, h.eval)
+		c <- result{o, err}
+	}()
+
+	select {
+	case res := <-c:
+		return res.out, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (h *methodHandlers) Check(ctx context.Context, tracker attribute.Tracker, request *mixerpb.CheckRequest, response *mixerpb.CheckResponse) {

--- a/pkg/api/methodHandlers_test.go
+++ b/pkg/api/methodHandlers_test.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/genproto/googleapis/rpc/code"
+
+	mixerpb "istio.io/api/mixer/v1"
+	istioconfig "istio.io/api/mixer/v1/config"
+
+	"istio.io/mixer/pkg/adapterManager"
+	"istio.io/mixer/pkg/aspect"
+	"istio.io/mixer/pkg/attribute"
+)
+
+func TestRequestCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	// we're skipping NewMethodHandlers so we don't have to deal with config since configuration should've matter when we have a canceled ctx
+	handler := &methodHandlers{
+		configs: map[Method][]*aspect.CombinedConfig{Check: {&aspect.CombinedConfig{}}},
+	}
+
+	cancel()
+
+	s := handler.execute(ctx, attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, Check)
+	if s.Code != int32(code.Code_DEADLINE_EXCEEDED) {
+		t.Errorf("Didn't return deadline exceeded when handler.execute was called with a canceled context, got status: %v", s)
+	}
+}
+
+func TestAspectManagerErrorsPropagated(t *testing.T) {
+	// invalid configs so the aspectmanager.Manager fails
+	handler := &methodHandlers{
+		mngr:    adapterManager.NewManager(nil),
+		configs: map[Method][]*aspect.CombinedConfig{Check: {&aspect.CombinedConfig{&istioconfig.Aspect{Kind: ""}, &istioconfig.Adapter{}}}},
+	}
+
+	s := handler.execute(context.Background(), attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, Check)
+	if s.Code != int32(code.Code_INTERNAL) {
+		t.Errorf("Expected internal error status with invalid adapter config, got status: %v", s)
+	}
+}

--- a/pkg/api/methodHandlers_test.go
+++ b/pkg/api/methodHandlers_test.go
@@ -39,7 +39,7 @@ func TestRequestCancellation(t *testing.T) {
 
 	s := handler.execute(ctx, attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, Check)
 	if s.Code != int32(code.Code_DEADLINE_EXCEEDED) {
-		t.Errorf("Didn't return deadline exceeded when handler.execute was called with a canceled context, got status: %v", s)
+		t.Errorf("execute(canceledContext, ...) returned %v, wanted status with code %v", s, code.Code_DEADLINE_EXCEEDED)
 	}
 }
 
@@ -52,6 +52,6 @@ func TestAspectManagerErrorsPropagated(t *testing.T) {
 
 	s := handler.execute(context.Background(), attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, Check)
 	if s.Code != int32(code.Code_INTERNAL) {
-		t.Errorf("Expected internal error status with invalid adapter config, got status: %v", s)
+		t.Errorf("execute(..., invalidConfig, ...) returned %v, wanted status with code %v", s, code.Code_INTERNAL)
 	}
 }


### PR DESCRIPTION
Wrap the dispatch to our adapters in a function which will recover them panicking. This wrapper also polls for the cancellation of the request's context and aborts early if it is canceled (e.g. because we exceeded the requests's deadline).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/177)
<!-- Reviewable:end -->
