### PR TITLE
Refactor NewAspect() methods to match aspect names.

### DIFF
--- a/adapter/denyChecker/adapter.go
+++ b/adapter/denyChecker/adapter.go
@@ -45,6 +45,6 @@ func (a *adapterState) DefaultConfig() proto.Message {
 	return &config.Params{Error: &status.Status{Code: int32(code.Code_FAILED_PRECONDITION)}}
 }
 
-func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {
+func (a *adapterState) NewDenyChecker(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {
 	return newAspect(cfg.(*config.Params))
 }

--- a/adapter/denyChecker/adapter_test.go
+++ b/adapter/denyChecker/adapter_test.go
@@ -27,7 +27,7 @@ import (
 func TestAll(t *testing.T) {
 	b := newAdapter()
 
-	a, err := b.NewAspect(nil, b.DefaultConfig())
+	a, err := b.NewDenyChecker(nil, b.DefaultConfig())
 	if err != nil {
 		t.Errorf("Unable to create aspect: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("a.Close failed: %v", err)
 	}
 
-	a, err = b.NewAspect(nil, &config.Params{Error: &status.Status{Code: int32(code.Code_INVALID_ARGUMENT)}})
+	a, err = b.NewDenyChecker(nil, &config.Params{Error: &status.Status{Code: int32(code.Code_INVALID_ARGUMENT)}})
 	if err != nil {
 		t.Errorf("Unable to create aspect: %v", err)
 	}

--- a/adapter/genericListChecker/adapter.go
+++ b/adapter/genericListChecker/adapter.go
@@ -38,6 +38,6 @@ func (a *adapterState) Close() error                                            
 func (a *adapterState) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) { return }
 func (a *adapterState) DefaultConfig() proto.Message                               { return &config.Params{} }
 
-func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
+func (a *adapterState) NewListChecker(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
 	return newAspect(cfg.(*config.Params))
 }

--- a/adapter/genericListChecker/adapter_test.go
+++ b/adapter/genericListChecker/adapter_test.go
@@ -45,7 +45,7 @@ func TestAll(t *testing.T) {
 	for _, c := range cases {
 		b := newAdapter()
 
-		a, err := b.NewAspect(nil, &c.ac)
+		a, err := b.NewListChecker(nil, &c.ac)
 		if err != nil {
 			t.Errorf("Unable to create adapter: %v", err)
 		}

--- a/adapter/ipListChecker/adapter.go
+++ b/adapter/ipListChecker/adapter.go
@@ -65,6 +65,6 @@ func (a *adapterState) DefaultConfig() proto.Message {
 	}
 }
 
-func (a *adapterState) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
+func (a *adapterState) NewListChecker(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
 	return newAspect(env, cfg.(*config.Params))
 }

--- a/adapter/ipListChecker/adapter_test.go
+++ b/adapter/ipListChecker/adapter_test.go
@@ -65,7 +65,7 @@ func TestBasic(t *testing.T) {
 		Ttl:             10,
 	}
 
-	a, err := b.NewAspect(&env{}, &config)
+	a, err := b.NewListChecker(&env{}, &config)
 	if err != nil {
 		t.Errorf("Unable to create adapter: %v", err)
 	}

--- a/adapter/stdioLogger/stdioLogger.go
+++ b/adapter/stdioLogger/stdioLogger.go
@@ -48,7 +48,7 @@ func (a *adapter) Description() string {
 func (a *adapter) DefaultConfig() proto.Message                               { return &config.Params{} }
 func (a *adapter) Close() error                                               { return nil }
 func (a *adapter) ValidateConfig(cfg proto.Message) (ce *aspect.ConfigErrors) { return nil }
-func (a *adapter) NewAspect(env aspect.Env, cfg proto.Message) (logger.Aspect, error) {
+func (a *adapter) NewLogger(env aspect.Env, cfg proto.Message) (logger.Aspect, error) {
 	c := cfg.(*config.Params)
 
 	w := os.Stderr
@@ -58,7 +58,6 @@ func (a *adapter) NewAspect(env aspect.Env, cfg proto.Message) (logger.Aspect, e
 
 	return &aspectImpl{w}, nil
 }
-
 func (a *aspectImpl) Close() error { return nil }
 func (a *aspectImpl) Log(entries []logger.Entry) error {
 	var errors *me.Error

--- a/adapter/stdioLogger/stdioLogger_test.go
+++ b/adapter/stdioLogger/stdioLogger_test.go
@@ -42,13 +42,13 @@ func TestAdapter_NewAspect(t *testing.T) {
 	e := testEnv{}
 	a := &adapter{}
 	for _, v := range tests {
-		asp, err := a.NewAspect(e, v.config)
+		asp, err := a.NewLogger(e, v.config)
 		if err != nil {
-			t.Errorf("NewAspect(env, %s) => unexpected error: %v", v.config, err)
+			t.Errorf("NewLogger(env, %s) => unexpected error: %v", v.config, err)
 		}
 		got := asp.(*aspectImpl)
 		if !reflect.DeepEqual(got, v.want) {
-			t.Errorf("NewAspect(env, %s) => %v, want %v", v.config, got, v.want)
+			t.Errorf("NewLogger(env, %s) => %v, want %v", v.config, got, v.want)
 		}
 	}
 }

--- a/pkg/aspect/accessLogger/accessLogger.go
+++ b/pkg/aspect/accessLogger/accessLogger.go
@@ -38,9 +38,9 @@ type (
 	Adapter interface {
 		aspect.Adapter
 
-		// NewAspect returns a new AccessLogger implementation, based
+		// NewAccessLogger returns a new AccessLogger implementation, based
 		// on the supplied Aspect configuration for the backend.
-		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+		NewAccessLogger(env aspect.Env, config proto.Message) (Aspect, error)
 	}
 
 	// Entry defines a basic wrapper around the access log information for

--- a/pkg/aspect/denyChecker/denyChecker.go
+++ b/pkg/aspect/denyChecker/denyChecker.go
@@ -31,7 +31,7 @@ type (
 	// Adapter builds the DenyChecker Aspect
 	Adapter interface {
 		aspect.Adapter
-		// NewAspect returns a new DenyChecker
-		NewAspect(env aspect.Env, cfg proto.Message) (Aspect, error)
+		// NewDenyChecker returns a new DenyChecker
+		NewDenyChecker(env aspect.Env, cfg proto.Message) (Aspect, error)
 	}
 )

--- a/pkg/aspect/listChecker/listChecker.go
+++ b/pkg/aspect/listChecker/listChecker.go
@@ -30,7 +30,7 @@ type (
 	// Adapter builds the ListChecker Aspect
 	Adapter interface {
 		aspect.Adapter
-		// NewAspect returns a new ListChecker
-		NewAspect(env aspect.Env, cfg proto.Message) (Aspect, error)
+		// NewListChecker returns a new ListChecker.
+		NewListChecker(env aspect.Env, cfg proto.Message) (Aspect, error)
 	}
 )

--- a/pkg/aspect/listChecker/listChecker.go
+++ b/pkg/aspect/listChecker/listChecker.go
@@ -30,7 +30,7 @@ type (
 	Adapter interface {
 		aspect.Adapter
 
-    // NewListChecker returns a new ListChecker.
+                // NewListChecker returns a new ListChecker.
 		NewListChecker(env aspect.Env, c aspect.Config) (Aspect, error)
 	}
 )

--- a/pkg/aspect/listChecker/listChecker.go
+++ b/pkg/aspect/listChecker/listChecker.go
@@ -30,7 +30,7 @@ type (
 	Adapter interface {
 		aspect.Adapter
 
-                // NewListChecker returns a new ListChecker.
+		// NewListChecker returns a new ListChecker.
 		NewListChecker(env aspect.Env, c aspect.Config) (Aspect, error)
 	}
 )

--- a/pkg/aspect/logger/logger.go
+++ b/pkg/aspect/logger/logger.go
@@ -63,9 +63,9 @@ type (
 	Adapter interface {
 		aspect.Adapter
 
-		// NewAspect returns a new Logger implementation, based on the
+		// NewLogger returns a new Logger implementation, based on the
 		// supplied Aspect configuration for the backend.
-		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+		NewLogger(env aspect.Env, config proto.Message) (Aspect, error)
 	}
 )
 

--- a/pkg/aspect/metrics/metrics.go
+++ b/pkg/aspect/metrics/metrics.go
@@ -76,9 +76,9 @@ type (
 	Adapter interface {
 		aspect.Adapter
 
-		// NewAspect returns a new quota implementation, based on the
+		// NewMetrics returns a new quota implementation, based on the
 		// supplied Aspect configuration for the backend.
-		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+		NewMetrics(env aspect.Env, config proto.Message) (Aspect, error)
 	}
 )
 

--- a/pkg/aspect/quota/quota.go
+++ b/pkg/aspect/quota/quota.go
@@ -40,9 +40,9 @@ type (
 	Adapter interface {
 		aspect.Adapter
 
-		// NewAspect returns a new quota implementation, based on the
+		// NewQuota returns a new quota implementation, based on the
 		// supplied Aspect configuration for the backend.
-		NewAspect(env aspect.Env, config proto.Message) (Aspect, error)
+		NewQuota(env aspect.Env, config proto.Message) (Aspect, error)
 	}
 
 	// Args supplies the arguments for quota operations.

--- a/pkg/aspectsupport/denyChecker/manager.go
+++ b/pkg/aspectsupport/denyChecker/manager.go
@@ -59,7 +59,7 @@ func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter
 	var asp denyChecker.Aspect
 	var err error
 
-	if asp, err = aa.NewAspect(env, adapterCfg); err != nil {
+	if asp, err = aa.NewDenyChecker(env, adapterCfg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/aspectsupport/listChecker/manager.go
+++ b/pkg/aspectsupport/listChecker/manager.go
@@ -62,7 +62,7 @@ func (m *manager) NewAspect(cfg *aspectsupport.CombinedConfig, ga aspect.Adapter
 	var asp listChecker.Aspect
 	var err error
 
-	if asp, err = aa.NewAspect(env, adapterCfg); err != nil {
+	if asp, err = aa.NewListChecker(env, adapterCfg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/aspectsupport/logger/manager.go
+++ b/pkg/aspectsupport/logger/manager.go
@@ -83,7 +83,7 @@ func (m *manager) NewAspect(c *aspectsupport.CombinedConfig, a aspect.Adapter, e
 		}
 	}
 
-	aspectImpl, err := logAdapter.NewAspect(env, cpb)
+	aspectImpl, err := logAdapter.NewLogger(env, cpb)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aspectsupport/logger/manager_test.go
+++ b/pkg/aspectsupport/logger/manager_test.go
@@ -41,7 +41,7 @@ func TestNewManager(t *testing.T) {
 	}
 }
 
-func TestManager_NewAspect(t *testing.T) {
+func TestManager_NewLogger(t *testing.T) {
 	tl := &testLogger{}
 
 	defaultExec := &executor{
@@ -87,7 +87,7 @@ func TestManager_NewAspect(t *testing.T) {
 	}
 }
 
-func TestManager_NewAspectFailures(t *testing.T) {
+func TestManager_NewLoggerFailures(t *testing.T) {
 
 	defaultCfg := &aspectsupport.CombinedConfig{
 		Adapter: &configpb.Adapter{},
@@ -279,7 +279,7 @@ type (
 	}
 )
 
-func (t *testLogger) NewAspect(e aspect.Env, m proto.Message) (logger.Aspect, error) {
+func (t *testLogger) NewLogger(e aspect.Env, m proto.Message) (logger.Aspect, error) {
 	if t.errOnNewAspect {
 		return nil, errors.New("new aspect error")
 	}

--- a/pkg/aspectsupport/uber/registry_test.go
+++ b/pkg/aspectsupport/uber/registry_test.go
@@ -38,7 +38,7 @@ func (testAdapter) ValidateConfig(implConfig proto.Message) *aspect.ConfigErrors
 
 type denyAdapter struct{ testAdapter }
 
-func (denyAdapter) NewAspect(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {
+func (denyAdapter) NewDenyChecker(env aspect.Env, cfg proto.Message) (denyChecker.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -62,7 +62,7 @@ func TestRegisterDeny(t *testing.T) {
 
 type listAdapter struct{ testAdapter }
 
-func (listAdapter) NewAspect(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
+func (listAdapter) NewListChecker(env aspect.Env, cfg proto.Message) (listChecker.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -86,7 +86,7 @@ func TestCheckList(t *testing.T) {
 
 type loggerAdapter struct{ testAdapter }
 
-func (loggerAdapter) NewAspect(env aspect.Env, cfg proto.Message) (al.Aspect, error) {
+func (loggerAdapter) NewLogger(env aspect.Env, cfg proto.Message) (al.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -110,7 +110,7 @@ func TestRegisterLogger(t *testing.T) {
 
 type quotaAdapter struct{ testAdapter }
 
-func (quotaAdapter) NewAspect(env aspect.Env, cfg proto.Message) (quota.Aspect, error) {
+func (quotaAdapter) NewQuota(env aspect.Env, cfg proto.Message) (quota.Aspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 


### PR DESCRIPTION
This will allow a single adapter to provide multiple aspects, as it avoids name collision that would result in `method redeclared` errors. This should make the builder -> aspect impl relationship clearer, as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/178)
<!-- Reviewable:end -->
