### PR TITLE
Config Struct - dispatch prep

### DIFF
--- a/cmd/server/BUILD
+++ b/cmd/server/BUILD
@@ -19,7 +19,7 @@ go_library(
         "//pkg/config/proto:go_default_library",
         "//pkg/tracing:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
+        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@com_github_istio_api//:mixer/v1/config",
         "@com_github_opentracing_basictracer//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",

--- a/cmd/server/BUILD
+++ b/cmd/server/BUILD
@@ -15,6 +15,8 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/config:go_default_library",
+        "//pkg/config/proto:go_default_library",
         "//pkg/tracing:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -34,7 +34,8 @@ import (
 	denyadapter "istio.io/mixer/adapter/denyChecker"
 	"istio.io/mixer/pkg/aspect"
 
-	istioconfig "istio.io/api/mixer/v1/config"
+	"istio.io/mixer/pkg/config"
+	istioconfig "istio.io/mixer/pkg/config/proto"
 )
 
 type serverArgs struct {
@@ -132,19 +133,19 @@ var configs = []api.StaticBinding{
 		RegisterFn: denyadapter.Register,
 		Manager:    aspect.NewDenyCheckerManager(),
 		Methods:    []api.Method{api.Check},
-		Config: &aspect.CombinedConfig{
+		Config: &config.Combined{
+			&istioconfig.Adapter{
+				Name:   "",
+				Kind:   "",
+				Impl:   "istio/denyChecker",
+				Params: new(structpb.Struct),
+			},
 			// denyChecker ignores its configs
 			&istioconfig.Aspect{
 				Kind:    "istio/denyChecker",
 				Adapter: "",
 				Inputs:  make(map[string]string),
 				Params:  new(structpb.Struct),
-			},
-			&istioconfig.Adapter{
-				Name:   "",
-				Kind:   "",
-				Impl:   "istio/denyChecker",
-				Params: new(structpb.Struct),
 			},
 		},
 	},

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -26,7 +26,7 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/empty"
 	"istio.io/mixer/pkg/api"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/tracing"
@@ -138,14 +138,14 @@ var configs = []api.StaticBinding{
 				Name:   "",
 				Kind:   "",
 				Impl:   "istio/denyChecker",
-				Params: new(structpb.Struct),
+				Params: &empty.Empty{},
 			},
 			// denyChecker ignores its configs
 			&istioconfig.Aspect{
 				Kind:    "istio/denyChecker",
 				Adapter: "",
 				Inputs:  make(map[string]string),
-				Params:  new(structpb.Struct),
+				Params:  &empty.Empty{},
 			},
 		},
 	},

--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -30,8 +30,8 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "@com_github_istio_api//:mixer/v1/config",
         "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
+        "@com_github_istio_api//:mixer/v1/config",
     ],
 )
 

--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -14,6 +14,8 @@ go_library(
         "//pkg/adapter:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/config:go_default_library",
+        "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "@com_github_golang_glog//:go_default_library",
     ],
@@ -29,6 +31,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "@com_github_istio_api//:mixer/v1/config",
+        "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
     ],
 )
 

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -61,7 +61,7 @@ func cacheKey(cfg *config.Combined) (*CacheKey, error) {
 		Impl: cfg.Adapter.GetImpl(),
 	}
 
-	//TODO shas and store with params
+	//TODO compute shas and store with params
 	var b bytes.Buffer
 	// use gob encoding so that we don't rely on proto marshal
 	enc := gob.NewEncoder(&b)
@@ -72,7 +72,6 @@ func cacheKey(cfg *config.Combined) (*CacheKey, error) {
 		}
 		ret.AdapterParamsSha = sha1.Sum(b.Bytes())
 	}
-
 	b.Reset()
 	if cfg.Adapter.GetParams() != nil {
 		if err := enc.Encode(cfg.Aspect.GetParams()); err != nil {

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -18,9 +18,14 @@ import (
 	"fmt"
 	"sync"
 
+	"bytes"
+	"crypto/sha1"
+	"encoding/gob"
+
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
 )
 
@@ -44,27 +49,44 @@ type Manager struct {
 // CacheKey is used to cache fully constructed aspects
 // These parameters are used in constructing an aspect
 type CacheKey struct {
-	Kind   string
-	Impl   string
-	Params string
-	Args   string
+	Kind             string
+	Impl             string
+	AdapterParamsSha [sha1.Size]byte
+	AspectParamsSha  [sha1.Size]byte
 }
 
-func cacheKey(cfg *aspect.CombinedConfig) CacheKey {
-	return CacheKey{
-		Kind:   cfg.Aspect.GetKind(),
-		Impl:   cfg.Adapter.GetImpl(),
-		Params: cfg.Aspect.GetParams().String(),
-		Args:   cfg.Adapter.GetParams().String(),
+func cacheKey(cfg *config.Combined) (*CacheKey, error) {
+	ret := CacheKey{
+		Kind: cfg.Aspect.GetKind(),
+		Impl: cfg.Adapter.GetImpl(),
 	}
+
+	//TODO shas and store with params
+	var b bytes.Buffer
+	// use gob encoding so that we don't rely on proto marshal
+	enc := gob.NewEncoder(&b)
+
+	if cfg.Adapter.GetParams() != nil {
+		if err := enc.Encode(cfg.Adapter.GetParams()); err != nil {
+			return nil, err
+		}
+		ret.AdapterParamsSha = sha1.Sum(b.Bytes())
+	}
+
+	b.Reset()
+	if cfg.Adapter.GetParams() != nil {
+		if err := enc.Encode(cfg.Aspect.GetParams()); err != nil {
+			return nil, err
+		}
+
+		ret.AspectParamsSha = sha1.Sum(b.Bytes())
+	}
+
+	return &ret, nil
 }
 
 // NewManager Creates a new Uber Aspect manager
 func NewManager(areg RegistryQuerier, mgrs []aspect.Manager) *Manager {
-	// Add all managers here as new aspects are added
-	if mgrs == nil {
-		mgrs = aspectManagers()
-	}
 	mreg := make(map[string]aspect.Manager, len(mgrs))
 	for _, mgr := range mgrs {
 		mreg[mgr.Kind()] = mgr
@@ -78,7 +100,7 @@ func NewManager(areg RegistryQuerier, mgrs []aspect.Manager) *Manager {
 
 // Execute performs the aspect function based on CombinedConfig and attributes and an expression evaluator
 // returns aspect output or error if the operation could not be performed
-func (m *Manager) Execute(cfg *aspect.CombinedConfig, attrs attribute.Bag, mapper expr.Evaluator) (*aspect.Output, error) {
+func (m *Manager) Execute(cfg *config.Combined, attrs attribute.Bag, mapper expr.Evaluator) (*aspect.Output, error) {
 	var mgr aspect.Manager
 	var found bool
 
@@ -102,11 +124,14 @@ func (m *Manager) Execute(cfg *aspect.CombinedConfig, attrs attribute.Bag, mappe
 }
 
 // CacheGet -- get from the cache, use adapter.Manager to construct an object in case of a cache miss
-func (m *Manager) CacheGet(cfg *aspect.CombinedConfig, mgr aspect.Manager, adapter adapter.Adapter) (asp aspect.Wrapper, err error) {
-	key := cacheKey(cfg)
+func (m *Manager) CacheGet(cfg *config.Combined, mgr aspect.Manager, adapter adapter.Adapter) (asp aspect.Wrapper, err error) {
+	var key *CacheKey
+	if key, err = cacheKey(cfg); err != nil {
+		return nil, err
+	}
 	// try fast path with read lock
 	m.lock.RLock()
-	asp, found := m.aspectCache[key]
+	asp, found := m.aspectCache[*key]
 	m.lock.RUnlock()
 	if found {
 		return asp, nil
@@ -114,22 +139,14 @@ func (m *Manager) CacheGet(cfg *aspect.CombinedConfig, mgr aspect.Manager, adapt
 	// obtain write lock
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	asp, found = m.aspectCache[key]
+	asp, found = m.aspectCache[*key]
 	if !found {
 		env := newEnv(adapter.Name())
 		asp, err = mgr.NewAspect(cfg, adapter, env)
 		if err != nil {
 			return nil, err
 		}
-		m.aspectCache[key] = asp
+		m.aspectCache[*key] = asp
 	}
 	return asp, nil
-}
-
-// return list of aspect managers
-func aspectManagers() []aspect.Manager {
-	return []aspect.Manager{
-		aspect.NewListCheckerManager(),
-		aspect.NewDenyCheckerManager(),
-	}
 }

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -61,7 +61,7 @@ func cacheKey(cfg *config.Combined) (*CacheKey, error) {
 		Impl: cfg.Adapter.GetImpl(),
 	}
 
-	//TODO compute shas and store with params
+	//TODO pre-compute shas and store with params
 	var b bytes.Buffer
 	// use gob encoding so that we don't rely on proto marshal
 	enc := gob.NewEncoder(&b)

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -18,8 +18,13 @@ import (
 	"strings"
 	"testing"
 
-	istioconfig "istio.io/api/mixer/v1/config"
+	"istio.io/mixer/pkg/config"
+	configpb "istio.io/mixer/pkg/config/proto"
 
+	"fmt"
+
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
@@ -27,12 +32,15 @@ import (
 
 type (
 	fakereg struct {
-		RegistryQuerier
+		adp   adapter.Adapter
+		found bool
 	}
 
 	fakemgr struct {
 		kind string
 		aspect.Manager
+		w      *fakewrapper
+		called int8
 	}
 
 	fakebag struct {
@@ -42,26 +50,125 @@ type (
 	fakeevaluator struct {
 		expr.Evaluator
 	}
+
+	fakewrapper struct {
+		called int8
+	}
+
+	fakeadp struct {
+		name string
+		adapter.Adapter
+	}
 )
+
+func (f *fakeadp) Name() string { return f.name }
+
+func (f *fakewrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator) (output *aspect.Output, err error) {
+	f.called++
+	return
+}
 
 func (m *fakemgr) Kind() string {
 	return m.kind
 }
 
-func TestManager(t *testing.T) {
-	r := &fakereg{}
-	mgrs := []aspect.Manager{&fakemgr{kind: "k1"}, &fakemgr{kind: "k2"}}
-	m := NewManager(r, mgrs)
-	cfg := &aspect.CombinedConfig{
-		Aspect:  &istioconfig.Aspect{},
-		Adapter: &istioconfig.Adapter{},
+func (m *fakemgr) NewAspect(cfg *config.Combined, adp adapter.Adapter, env adapter.Env) (aspect.Wrapper, error) {
+	m.called++
+	if m.w == nil {
+		return nil, fmt.Errorf("unable to create aspect")
 	}
+
+	return m.w, nil
+}
+
+func (m *fakereg) ByImpl(adapterName string) (adapter.Adapter, bool) {
+	return m.adp, m.found
+}
+
+type ttable struct {
+	mgrFound  bool
+	kindFound bool
+	errString string
+	wrapper   *fakewrapper
+	cfg       *config.Combined
+}
+
+func getReg(found bool) *fakereg {
+	return &fakereg{&fakeadp{name: "k1impl1"}, found}
+}
+
+func mgrs(w *fakewrapper) []aspect.Manager {
+	return []aspect.Manager{&fakemgr{kind: "k1", w: w}, &fakemgr{kind: "k2"}}
+}
+
+func TestManager(t *testing.T) {
+	goodcfg := &config.Combined{
+		Aspect:  &configpb.Aspect{Kind: "k1", Params: &status.Status{}},
+		Adapter: &configpb.Adapter{Kind: "k1", Impl: "k1impl1", Params: &status.Status{}},
+	}
+
+	badcfg1 := &config.Combined{
+		Aspect: &configpb.Aspect{Kind: "k1", Params: &status.Status{}},
+		Adapter: &configpb.Adapter{Kind: "k1", Impl: "k1impl1",
+			Params: make(chan int)},
+	}
+	badcfg2 := &config.Combined{
+		Aspect: &configpb.Aspect{Kind: "k1", Params: make(chan int)},
+		Adapter: &configpb.Adapter{Kind: "k1", Impl: "k1impl1",
+			Params: &status.Status{}},
+	}
+	emptyMgrs := []aspect.Manager{}
 	attrs := &fakebag{}
 	mapper := &fakeevaluator{}
-	if _, err := m.Execute(cfg, attrs, mapper); err != nil {
-		if !strings.Contains(err.Error(), "could not find aspect manager") {
-			t.Error("excute errored out: ", err)
+
+	ttt := []ttable{
+		{false, false, "could not find aspect manager", nil, goodcfg},
+		{true, false, "could not find registered adapter", nil, goodcfg},
+		{true, true, "", &fakewrapper{}, goodcfg},
+		{true, true, "", nil, goodcfg},
+		{true, true, "can't handle type", nil, badcfg1},
+		{true, true, "can't handle type", nil, badcfg2},
+	}
+
+	for idx, tt := range ttt {
+		r := getReg(tt.kindFound)
+		mgr := emptyMgrs
+		if tt.mgrFound {
+			mgr = mgrs(tt.wrapper)
+		}
+		m := NewManager(r, mgr)
+		errStr := ""
+		if _, err := m.Execute(tt.cfg, attrs, mapper); err != nil {
+			errStr = err.Error()
+		}
+		if !strings.Contains(errStr, tt.errString) {
+			t.Errorf("[%d] expected: '%s' \ngot: '%s'", idx, tt.errString, errStr)
+		}
+
+		if tt.errString != "" || tt.wrapper == nil {
+			continue
+		}
+
+		if tt.wrapper.called != 1 {
+			t.Errorf("[%d] Expected wrapper call", idx)
+		}
+		fmgr := mgr[0].(*fakemgr)
+
+		if fmgr.called != 1 {
+			t.Errorf("[%d] Expected mgr.NewAspect call", idx)
+		}
+
+		// call again
+		// check for cache
+		_, _ = m.Execute(tt.cfg, attrs, mapper)
+		if tt.wrapper.called != 2 {
+			t.Errorf("[%d] Expected 2nd wrapper call", idx)
+		}
+
+		if fmgr.called != 1 {
+			t.Errorf("[%d] UnExpected mgr.NewAspect call %d", idx, fmgr.called)
 		}
 
 	}
+
 }

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//pkg/adapterManager:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/config:go_default_library",
         "//pkg/expr:go_default_library",
         "//pkg/tracing:go_default_library",
         "@com_github_golang_glog//:go_default_library",

--- a/pkg/api/methodHandlers.go
+++ b/pkg/api/methodHandlers.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/mixer/pkg/adapterManager"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
 
 	"fmt"
@@ -69,7 +70,7 @@ const (
 type StaticBinding struct {
 	RegisterFn adapter.RegisterFn
 	Manager    aspect.Manager
-	Config     *aspect.CombinedConfig
+	Config     *config.Combined
 	Methods    []Method
 }
 
@@ -78,14 +79,14 @@ type methodHandlers struct {
 	eval expr.Evaluator
 
 	// Configs for the aspects that'll be used to serve each API method.
-	configs map[Method][]*aspect.CombinedConfig
+	configs map[Method][]*config.Combined
 }
 
 // NewMethodHandlers returns a canonical MethodHandlers that implements all of the mixer's API surface
 func NewMethodHandlers(bindings ...StaticBinding) MethodHandlers {
 	registry := adapterManager.NewRegistry()
 	managers := make([]aspect.Manager, len(bindings))
-	configs := map[Method][]*aspect.CombinedConfig{Check: {}, Report: {}, Quota: {}}
+	configs := map[Method][]*config.Combined{Check: {}, Report: {}, Quota: {}}
 
 	for i, binding := range bindings {
 		if err := binding.RegisterFn(registry); err != nil {

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -14,6 +14,8 @@ go_library(
         "//pkg/adapter:go_default_library",
         "//pkg/aspect/config:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/config:go_default_library",
+        "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/pkg/aspect/denyCheckerManager.go
+++ b/pkg/aspect/denyCheckerManager.go
@@ -20,8 +20,9 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/pkg/adapter"
-	"istio.io/mixer/pkg/aspect/config"
+	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
 )
 
@@ -40,7 +41,7 @@ func NewDenyCheckerManager() Manager {
 }
 
 // NewAspect creates a denyChecker aspect.
-func (m *denyCheckerManager) NewAspect(cfg *CombinedConfig, ga adapter.Adapter, env adapter.Env) (Wrapper, error) {
+func (m *denyCheckerManager) NewAspect(cfg *config.Combined, ga adapter.Adapter, env adapter.Env) (Wrapper, error) {
 	aa, ok := ga.(adapter.DenyCheckerAdapter)
 	if !ok {
 		return nil, fmt.Errorf("adapter of incorrect type; expected adapter.DenyCheckerAdapter got %#v %T", ga, ga)
@@ -67,7 +68,7 @@ func (*denyCheckerManager) Kind() string {
 }
 
 func (*denyCheckerManager) DefaultConfig() adapter.AspectConfig {
-	return &config.DenyCheckerParams{}
+	return &aconfig.DenyCheckerParams{}
 }
 
 func (*denyCheckerManager) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) {

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -17,19 +17,13 @@ package aspect
 import (
 	"google.golang.org/genproto/googleapis/rpc/code"
 
-	istioconfig "istio.io/api/mixer/v1/config"
-
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
 )
 
 type (
-	// CombinedConfig combines all configuration related to an aspect
-	CombinedConfig struct {
-		Aspect  *istioconfig.Aspect
-		Adapter *istioconfig.Adapter
-	}
 
 	// Output from the Aspect Manager
 	Output struct {
@@ -44,7 +38,7 @@ type (
 	// to the rest of the system
 	Manager interface {
 		// NewAspect creates a new aspect instance given configuration.
-		NewAspect(cfg *CombinedConfig, adapter adapter.Adapter, env adapter.Env) (Wrapper, error)
+		NewAspect(cfg *config.Combined, adapter adapter.Adapter, env adapter.Env) (Wrapper, error)
 		// Kind return the kind of aspect
 		Kind() string
 


### PR DESCRIPTION
Wireup new config structs aspectmanagers down
1. Use config.Combined struct
2. Remove proto.struct from everywhere, it is not longer needed
3. Up test coverage for files touched.

Removed  repeated validation code from managers.
They are expected to get a validated config.
It is ok to panic since we will ensure that the dispatcher will catch all the panics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/184)
<!-- Reviewable:end -->
