### PR TITLE
Fix the segfault at server startup by populating the list of managers before calling NewManager

### DIFF
--- a/pkg/api/methodHandlers.go
+++ b/pkg/api/methodHandlers.go
@@ -85,14 +85,17 @@ type methodHandlers struct {
 func NewMethodHandlers(bindings ...StaticBinding) MethodHandlers {
 	managers := make([]aspect.Manager, len(bindings))
 	configs := map[Method][]*aspect.CombinedConfig{Check: {}, Report: {}, Quota: {}}
+
+	for i, binding := range bindings {
+		managers[i] = binding.Manager
+	}
 	adapterMgr := adapterManager.NewManager(managers)
 	registry := adapterMgr.Registry()
 
-	for i, binding := range bindings {
+	for _, binding := range bindings {
 		if err := binding.RegisterFn(registry); err != nil {
 			panic(fmt.Errorf("failed to register binding '%s' with err: %s", binding.Config.Builder.Name, err))
 		}
-		managers[i] = binding.Manager
 		for _, method := range binding.Methods {
 			configs[method] = append(configs[method], binding.Config)
 		}


### PR DESCRIPTION
Populate the list of manager first so we can create an aspectmanager, then use that aspect manager to populate the rest of the config data. This stops of from iterating over a set of nil `aspect.Manager`s when constructing the new aspectManager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/185)
<!-- Reviewable:end -->
