### PR TITLE
Add a check for the disabled tracer in PropagateSpan and extractSpanContext

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -115,6 +115,10 @@ func (t *Tracer) StartSpanFromContext(ctx context.Context, operationName string,
 // This should be used to prepare the context for outgoing calls.
 func (t *Tracer) PropagateSpan(ctx context.Context, span ot.Span) (metadata.MD, context.Context) {
 	md := extractMetadata(ctx)
+	if !t.enabled {
+		return md, ctx
+	}
+
 	if err := t.Inject(span.Context(), ot.TextMap, metadataReaderWriter{md}); err != nil {
 		glog.Warningf("Failed to inject opentracing span state with tracer %v into ctx %v with err %v", t.Tracer, ctx, err)
 	}
@@ -122,6 +126,10 @@ func (t *Tracer) PropagateSpan(ctx context.Context, span ot.Span) (metadata.MD, 
 }
 
 func (t *Tracer) extractSpanContext(ctx context.Context, md metadata.MD) ot.SpanContext {
+	if !t.enabled {
+		return nil
+	}
+
 	spanContext, err := t.Extract(ot.TextMap, metadataReaderWriter{md})
 	if err != nil {
 		glog.Warningf("Failed to extract opentracing metadata with tracer %v from ctx %v with err %v", t.Tracer, ctx, err)

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -35,7 +35,7 @@ func TestCurrentSpan(t *testing.T) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "first")
 
 	if currentSpan := CurrentSpan(ctx); currentSpan != span {
-		t.Errorf("Failed to extract the current span from the context, expected '%v' actual '%v'; context: '%v'", span, currentSpan, ctx)
+		t.Errorf("CurrentSpan(ctx) = %v; wanted '%v'; context: '%v'", currentSpan, span, ctx)
 	}
 }
 
@@ -50,7 +50,7 @@ func TestStartSpanFromContext(t *testing.T) {
 	mockSpan, _ := span.(*mocktracer.MockSpan)
 	mockChild, _ := childSpan.(*mocktracer.MockSpan)
 	if mockChild.ParentID != mockSpan.SpanContext.SpanID {
-		t.Errorf("Failed to extract parent from ctx %+v; expected parent %d, actual %d", ctx, mockSpan.SpanContext.SpanID, mockChild.ParentID)
+		t.Errorf("StartSpanFromContext(ctx).ParentID = %d; wanted %d; context: %v", mockChild.ParentID, mockSpan.SpanContext.SpanID, ctx)
 	}
 }
 
@@ -66,7 +66,7 @@ func TestStartRootSpan(t *testing.T) {
 	first, _ := s.(*mocktracer.MockSpan)
 	// We had no metadata in the context being propagated, so we expect no parent
 	if first.ParentID != 0 {
-		t.Errorf("Expected no parent for root span with no request metadata, actual '%d'; context: %v", first.ParentID, ctx)
+		t.Errorf("RootSpan(ctx).ParentID = %d; wanted non-zero parent; context: %v", first.ParentID, ctx)
 	}
 
 	// Shove the first span into the context's grpc metadata, so that StartRootSpan will think it got a propagated span
@@ -75,19 +75,19 @@ func TestStartRootSpan(t *testing.T) {
 
 	ss, newCtx := tracer.StartRootSpan(newCtx, "second")
 	if root := RootSpan(newCtx); root != ss {
-		t.Errorf("No root span in context, expected span '%v'; context: %v", s, ctx)
+		t.Errorf("RootSpan(newCtx) = %v; wanted %v; context: %v", root, ss, ctx)
 	}
 
 	second, _ := ss.(*mocktracer.MockSpan)
 	if second.ParentID != first.SpanContext.SpanID {
-		t.Errorf("Expected second to have parentID '%d', actual '%d'; context: %v", first.SpanContext.SpanID, second.ParentID, ctx)
+		t.Errorf("second.ParentID = %d; wanted %d; context: %v", second.ParentID, first.SpanContext.SpanID, ctx)
 	}
 }
 
 func TestStartRootSpan_NoRootReturnsNoopSpan(t *testing.T) {
 	ctx := context.Background()
 	if span := RootSpan(ctx); span != noopSpan {
-		t.Errorf("Extracting root span from ctx without calling StartRootSpan expected no-op span, actual: %v; ctx: %v", span, ctx)
+		t.Errorf("RootSpan(ctx) = %v; wanted %v; ctx: %v", span, noopSpan, ctx)
 	}
 }
 
@@ -111,7 +111,7 @@ func TestPropagateSpan(t *testing.T) {
 
 	if mockCtx.SpanID != mockSpan.SpanContext.SpanID {
 		t.Errorf(
-			"Extracted spancontext doesn't match propagated span: expected spanID '%d', actual '%d'; context: %v",
+			"tracer.Extract(...).SpanID = '%d'; want %v; ctx was %v",
 			mockSpan.SpanContext.SpanID,
 			mockCtx.SpanID,
 			ctx)
@@ -122,19 +122,19 @@ func TestDisabledTracer(t *testing.T) {
 	tracer := DisabledTracer()
 
 	if span, _ := tracer.StartRootSpan(context.Background(), ""); span != noopSpan {
-		t.Errorf("Expected disabled tracer to return noop span, actual: %+v", span)
+		t.Errorf("StartRootSpan on disabled tracer returned '%v'; want '%v'", span, noopSpan)
 	}
 
 	if span, _ := tracer.StartSpanFromContext(context.Background(), ""); span != noopSpan {
-		t.Errorf("Expected disabled tracer to return noop span, actual: %+v", span)
+		t.Errorf("StartSpanFromContext on disabled tracer returned '%v'; want '%v'", span, noopSpan)
 	}
 
 	ctx := context.Background()
 	if _, nctx := tracer.PropagateSpan(ctx, noopSpan); nctx != ctx {
-		t.Errorf("PropagateSpan on disabled tracer modified the context; expected: %v, actual %v", ctx, nctx)
+		t.Errorf("PropagateSpan on disabled tracer returned '%v'; want '%v'", nctx, ctx)
 	}
 
 	if sc := tracer.extractSpanContext(ctx, extractMetadata(ctx)); sc != nil {
-		t.Errorf("ExtractSpan on disabled tracer should return a nil spancontext, actual: %v", sc)
+		t.Errorf("ExtractSpan on disabled tracer returned '%v'; want nil", sc)
 	}
 }

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -128,4 +128,13 @@ func TestDisabledTracer(t *testing.T) {
 	if span, _ := tracer.StartSpanFromContext(context.Background(), ""); span != noopSpan {
 		t.Errorf("Expected disabled tracer to return noop span, actual: %+v", span)
 	}
+
+	ctx := context.Background()
+	if _, nctx := tracer.PropagateSpan(ctx, noopSpan); nctx != ctx {
+		t.Errorf("PropagateSpan on disabled tracer modified the context; expected: %v, actual %v", ctx, nctx)
+	}
+
+	if sc := tracer.extractSpanContext(ctx, extractMetadata(ctx)); sc != nil {
+		t.Errorf("ExtractSpan on disabled tracer should return a nil spancontext, actual: %v", sc)
+	}
 }

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -110,11 +110,7 @@ func TestPropagateSpan(t *testing.T) {
 	mockCtx, _ := sCtx.(mocktracer.MockSpanContext)
 
 	if mockCtx.SpanID != mockSpan.SpanContext.SpanID {
-		t.Errorf(
-			"tracer.Extract(...).SpanID = '%d'; want %v; ctx was %v",
-			mockSpan.SpanContext.SpanID,
-			mockCtx.SpanID,
-			ctx)
+		t.Errorf("tracer.Extract(...).SpanID = '%d'; want %v; ctx was %v", mockSpan.SpanContext.SpanID, mockCtx.SpanID, ctx)
 	}
 }
 


### PR DESCRIPTION
Add a check for the disabled tracer in PropagateSpan and extractSpanContext. PropagateSpan was previously private and only called by other methods in the package which already checked the tracer state, but was made public without adding the check. A check was added to extractSpanContext as well to prevent the same from happening in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/191)
<!-- Reviewable:end -->
