### PR TITLE
Implement an opentracing carrier using Istio's attribute system

### DIFF
--- a/pkg/attribute/bag.go
+++ b/pkg/attribute/bag.go
@@ -45,7 +45,7 @@ type Bag interface {
 	// returns false iteration is stopped.
 	//
 	// The view into the values is provided in this form so that the bag can keep iteration thread safe.
-	Foreach(handler func(key string, val interface{}) bool)
+	ForEach(handler func(key string, val interface{}) bool)
 
 	// Done indicates the bag can be reclaimed.
 	Done()

--- a/pkg/attribute/bag.go
+++ b/pkg/attribute/bag.go
@@ -41,6 +41,12 @@ type Bag interface {
 	// Bytes returns the named attribute if it exists.
 	Bytes(name string) ([]uint8, bool)
 
+	// Foreach allows a caller to process all of the (key, value) pairs this bag knows about. If the provided func
+	// returns false iteration is stopped.
+	//
+	// The view into the values is provided in this form so that the bag can keep iteration thread safe.
+	Foreach(handler func(key string, val interface{}) bool)
+
 	// Done indicates the bag can be reclaimed.
 	Done()
 }

--- a/pkg/attribute/bag.go
+++ b/pkg/attribute/bag.go
@@ -26,38 +26,38 @@ type Bag interface {
 	// String returns the named attribute if it exists.
 	String(name string) (string, bool)
 
-	// StringKeys returns a snapshot of all keys corresponding string attributes this bag knows about.
+	// StringKeys returns a snapshot of all keys corresponding to string attributes this bag knows about.
 	StringKeys() []string
 
 	// Int64 returns the named attribute if it exists.
 	Int64(name string) (int64, bool)
 
-	// Int64Keys returns a snapshot of all keys corresponding int64 attributes this bag knows about.
+	// Int64Keys returns a snapshot of all keys corresponding to int64 attributes this bag knows about.
 	Int64Keys() []string
 
 	// Float64 returns the named attribute if it exists.
 	Float64(name string) (float64, bool)
 
-	// Float64Keys returns a snapshot of all keys corresponding float64 attributes this bag knows about.
+	// Float64Keys returns a snapshot of all keys corresponding to float64 attributes this bag knows about.
 	Float64Keys() []string
 
 	// Bool returns the named attribute if it exists.
 	Bool(name string) (bool, bool)
 
-	// BoolKeys returns a snapshot of all keys corresponding bool attributes this bag knows about.
+	// BoolKeys returns a snapshot of all keys corresponding to bool attributes this bag knows about.
 	BoolKeys() []string
 
 	// Time returns the named attribute if it exists.
 	Time(name string) (time.Time, bool)
 
-	// TimeKeys returns a snapshot of all keys corresponding time attributes this bag knows about.
+	// TimeKeys returns a snapshot of all keys corresponding to time attributes this bag knows about.
 	TimeKeys() []string
 
 	// Bytes returns the named attribute if it exists.
 	Bytes(name string) ([]uint8, bool)
 
-	// ByteKeys returns a snapshot of all keys corresponding byte attributes this bag knows about.
-	ByteKeys() []string
+	// ByteKeys returns a snapshot of all keys corresponding to byte attributes this bag knows about.
+	BytesKeys() []string
 
 	// Done indicates the bag can be reclaimed.
 	Done()

--- a/pkg/attribute/bag.go
+++ b/pkg/attribute/bag.go
@@ -26,26 +26,38 @@ type Bag interface {
 	// String returns the named attribute if it exists.
 	String(name string) (string, bool)
 
+	// StringKeys returns a snapshot of all keys corresponding string attributes this bag knows about.
+	StringKeys() []string
+
 	// Int64 returns the named attribute if it exists.
 	Int64(name string) (int64, bool)
+
+	// Int64Keys returns a snapshot of all keys corresponding int64 attributes this bag knows about.
+	Int64Keys() []string
 
 	// Float64 returns the named attribute if it exists.
 	Float64(name string) (float64, bool)
 
+	// Float64Keys returns a snapshot of all keys corresponding float64 attributes this bag knows about.
+	Float64Keys() []string
+
 	// Bool returns the named attribute if it exists.
 	Bool(name string) (bool, bool)
+
+	// BoolKeys returns a snapshot of all keys corresponding bool attributes this bag knows about.
+	BoolKeys() []string
 
 	// Time returns the named attribute if it exists.
 	Time(name string) (time.Time, bool)
 
+	// TimeKeys returns a snapshot of all keys corresponding time attributes this bag knows about.
+	TimeKeys() []string
+
 	// Bytes returns the named attribute if it exists.
 	Bytes(name string) ([]uint8, bool)
 
-	// Foreach allows a caller to process all of the (key, value) pairs this bag knows about. If the provided func
-	// returns false iteration is stopped.
-	//
-	// The view into the values is provided in this form so that the bag can keep iteration thread safe.
-	ForEach(handler func(key string, val interface{}) bool)
+	// ByteKeys returns a snapshot of all keys corresponding byte attributes this bag knows about.
+	ByteKeys() []string
 
 	// Done indicates the bag can be reclaimed.
 	Done()

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -330,7 +330,7 @@ func TestValue(t *testing.T) {
 	}
 }
 
-func TestForeach(t *testing.T) {
+func TestForEach(t *testing.T) {
 	am := NewManager()
 	at := am.NewTracker()
 	defer at.Done()
@@ -338,7 +338,7 @@ func TestForeach(t *testing.T) {
 	defer ab.Done()
 
 	callCount := 0
-	ab.Foreach(func(key string, val interface{}) bool {
+	ab.ForEach(func(key string, val interface{}) bool {
 		callCount++
 		switch val.(type) {
 		case string:

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -329,128 +329,255 @@ func TestValue(t *testing.T) {
 	}
 }
 
+type d map[string]interface{}
+type ttable struct {
+	inRoot  d
+	inChild d
+	out     d
+}
+
 func TestStringKeys(t *testing.T) {
-	at := NewManager().NewTracker()
-	defer at.Done()
-	root, _ := at.StartRequest(&mixerpb.Attributes{})
-	defer root.Done()
-	ab := root.Child()
-	defer ab.Done()
-
-	data := map[string]string{"one": "a", "two": "b"}
-	for k, v := range data {
-		ab.SetString(k, v)
-	}
-
-	keys := ab.StringKeys()
-	for _, key := range keys {
-		if val, found := data[key]; !found {
-			t.Errorf("data[%s] = %s, wanted key in set: %v", key, val, keys)
-		}
-	}
+	testKeys(t,
+		[]ttable{
+			{
+				d{},
+				d{},
+				d{},
+			},
+			{
+				d{"root": "r"},
+				d{},
+				d{"root": "r"},
+			},
+			{
+				d{},
+				d{"one": "a", "two": "b"},
+				d{"one": "a", "two": "b"},
+			},
+			{
+				d{"root": "r"},
+				d{"one": "a", "two": "b"},
+				d{"root": "r", "one": "a", "two": "b"},
+			},
+		},
+		func(ab MutableBag, k string, v interface{}) {
+			vs := v.(string)
+			ab.SetString(k, vs)
+		},
+		func(b Bag) []string {
+			return b.StringKeys()
+		},
+	)
 }
 
 func TestInt64Keys(t *testing.T) {
-	at := NewManager().NewTracker()
-	defer at.Done()
-	root, _ := at.StartRequest(&mixerpb.Attributes{})
-	defer root.Done()
-	ab := root.Child()
-	defer ab.Done()
-
-	data := map[string]int64{"one": 1, "two": 2}
-	for k, v := range data {
-		ab.SetInt64(k, v)
-	}
-
-	keys := ab.Int64Keys()
-	for _, key := range keys {
-		if val, found := data[key]; !found {
-			t.Errorf("data[%s] = %d, wanted key in set: %v", key, val, keys)
-		}
-	}
+	testKeys(t,
+		[]ttable{
+			{
+				d{},
+				d{},
+				d{},
+			},
+			{
+				d{"root": int64(1)},
+				d{},
+				d{"root": int64(1)},
+			},
+			{
+				d{},
+				d{"one": int64(2), "two": int64(3)},
+				d{"one": int64(2), "two": int64(3)},
+			},
+			{
+				d{"root": int64(1)},
+				d{"one": int64(2), "two": int64(3)},
+				d{"root": int64(1), "one": int64(2), "two": int64(3)},
+			},
+		},
+		func(ab MutableBag, k string, v interface{}) {
+			vs := v.(int64)
+			ab.SetInt64(k, vs)
+		},
+		func(b Bag) []string {
+			return b.Int64Keys()
+		},
+	)
 }
 
 func TestFloat64Keys(t *testing.T) {
-	at := NewManager().NewTracker()
-	defer at.Done()
-	root, _ := at.StartRequest(&mixerpb.Attributes{})
-	defer root.Done()
-	ab := root.Child()
-	defer ab.Done()
-
-	data := map[string]float64{"one": 1.0, "two": 2.0}
-	for k, v := range data {
-		ab.SetFloat64(k, v)
-	}
-
-	keys := ab.Float64Keys()
-	for _, key := range keys {
-		if val, found := data[key]; !found {
-			t.Errorf("data[%s] = %f, wanted key in set: %v", key, val, keys)
-		}
-	}
+	testKeys(t,
+		[]ttable{
+			{
+				d{},
+				d{},
+				d{},
+			},
+			{
+				d{"root": float64(1)},
+				d{},
+				d{"root": float64(1)},
+			},
+			{
+				d{},
+				d{"one": float64(2), "two": float64(3)},
+				d{"one": float64(2), "two": float64(3)},
+			},
+			{
+				d{"root": float64(1)},
+				d{"one": float64(2), "two": float64(3)},
+				d{"root": float64(1), "one": float64(2), "two": float64(3)},
+			},
+		},
+		func(ab MutableBag, k string, v interface{}) {
+			vs := v.(float64)
+			ab.SetFloat64(k, vs)
+		},
+		func(b Bag) []string {
+			return b.Float64Keys()
+		},
+	)
 }
 
 func TestBoolKeys(t *testing.T) {
-	at := NewManager().NewTracker()
-	defer at.Done()
-	root, _ := at.StartRequest(&mixerpb.Attributes{})
-	defer root.Done()
-	ab := root.Child()
-	defer ab.Done()
-
-	data := map[string]bool{"one": true, "two": false}
-	for k, v := range data {
-		ab.SetBool(k, v)
-	}
-
-	keys := ab.BoolKeys()
-	for _, key := range keys {
-		if val, found := data[key]; !found {
-			t.Errorf("data[%s] = %t, wanted key in set: %v", key, val, keys)
-		}
-	}
+	testKeys(t,
+		[]ttable{
+			{
+				d{},
+				d{},
+				d{},
+			},
+			{
+				d{"root": true},
+				d{},
+				d{"root": true},
+			},
+			{
+				d{},
+				d{"one": true, "two": false},
+				d{"one": true, "two": false},
+			},
+			{
+				d{"root": false},
+				d{"one": true, "two": false},
+				d{"root": false, "one": true, "two": false},
+			},
+		},
+		func(ab MutableBag, k string, v interface{}) {
+			vs := v.(bool)
+			ab.SetBool(k, vs)
+		},
+		func(b Bag) []string {
+			return b.BoolKeys()
+		},
+	)
 }
 
 func TestTimeKeys(t *testing.T) {
-	at := NewManager().NewTracker()
-	defer at.Done()
-	root, _ := at.StartRequest(&mixerpb.Attributes{})
-	defer root.Done()
-	ab := root.Child()
-	defer ab.Done()
-
-	data := map[string]time.Time{"one": t10, "two": t9}
-	for k, v := range data {
-		ab.SetTime(k, v)
-	}
-
-	keys := ab.TimeKeys()
-	for _, key := range keys {
-		if val, found := data[key]; !found {
-			t.Errorf("data[%s] = %v, wanted key in set: %v", key, val, keys)
-		}
-	}
+	testKeys(t,
+		[]ttable{
+			{
+				d{},
+				d{},
+				d{},
+			},
+			{
+				d{"root": t9},
+				d{},
+				d{"root": t9},
+			},
+			{
+				d{},
+				d{"one": t10, "two": t42},
+				d{"one": t10, "two": t42},
+			},
+			{
+				d{"root": t9},
+				d{"one": t10, "two": t42},
+				d{"root": t9, "one": t10, "two": t42},
+			},
+		},
+		func(ab MutableBag, k string, v interface{}) {
+			vs := v.(time.Time)
+			ab.SetTime(k, vs)
+		},
+		func(b Bag) []string {
+			return b.TimeKeys()
+		},
+	)
 }
 
 func TestByteKeys(t *testing.T) {
-	at := NewManager().NewTracker()
-	defer at.Done()
-	root, _ := at.StartRequest(&mixerpb.Attributes{})
-	defer root.Done()
-	ab := root.Child()
-	defer ab.Done()
+	testKeys(t,
+		[]ttable{
+			{
+				d{},
+				d{},
+				d{},
+			},
+			{
+				d{"root": []byte{11}},
+				d{},
+				d{"root": []byte{11}},
+			},
+			{
+				d{},
+				d{"one": []byte{12}, "two": []byte{13}},
+				d{"one": []byte{12}, "two": []byte{13}},
+			},
+			{
+				d{"root": []byte{1}},
+				d{"one": []byte{2}, "two": []byte{3}},
+				d{"root": []byte{1}, "one": []byte{2}, "two": []byte{3}},
+			},
+		},
+		func(ab MutableBag, k string, v interface{}) {
+			vs := v.([]byte)
+			ab.SetBytes(k, vs)
+		},
+		func(b Bag) []string {
+			return b.BytesKeys()
+		},
+	)
+}
 
-	data := map[string][]uint8{"one": {11}, "two": {13}}
-	for k, v := range data {
-		ab.SetBytes(k, v)
+func testKeys(t *testing.T, cases []ttable, setVal func(MutableBag, string, interface{}), keyFn func(Bag) []string) {
+	for _, tc := range cases {
+		at := NewManager().NewTracker()
+		root, _ := at.StartRequest(&mixerpb.Attributes{})
+		for k, v := range tc.inRoot {
+			setVal(root, k, v)
+		}
+
+		ab := root.Child()
+		for k, v := range tc.inChild {
+			setVal(ab, k, v)
+		}
+
+		keys := keyFn(ab)
+		// verify everything that was returned was expected
+		for _, key := range keys {
+			if _, found := tc.out[key]; !found {
+				t.Errorf("keyFn() = [..., %s, ...], wanted (key, val) in set: %v", key, tc.out)
+			}
+		}
+		// and that everything that was expected was returned
+		for key := range tc.out {
+			if !contains(keys, key) {
+				t.Errorf("keyFn() = %v, wanted '%s' in set", keys, key)
+			}
+		}
+
+		at.Done()
+		root.Done()
+		ab.Done()
 	}
+}
 
-	keys := ab.BytesKeys()
-	for _, key := range keys {
-		if val, found := data[key]; !found {
-			t.Errorf("data[%s] = %v, wanted key in set: %v", key, val, keys)
+func contains(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
 		}
 	}
+	return false
 }

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -447,7 +447,7 @@ func TestByteKeys(t *testing.T) {
 		ab.SetBytes(k, v)
 	}
 
-	keys := ab.ByteKeys()
+	keys := ab.BytesKeys()
 	for _, key := range keys {
 		if val, found := data[key]; !found {
 			t.Errorf("data[%s] = %v, wanted key in set: %v", key, val, keys)

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -15,7 +15,6 @@
 package attribute
 
 import (
-	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -330,46 +329,128 @@ func TestValue(t *testing.T) {
 	}
 }
 
-func TestForEach(t *testing.T) {
-	am := NewManager()
-	at := am.NewTracker()
+func TestStringKeys(t *testing.T) {
+	at := NewManager().NewTracker()
 	defer at.Done()
-	ab, _ := at.StartRequest(&attrs)
+	root, _ := at.StartRequest(&mixerpb.Attributes{})
+	defer root.Done()
+	ab := root.Child()
 	defer ab.Done()
 
-	callCount := 0
-	ab.ForEach(func(key string, val interface{}) bool {
-		callCount++
-		switch val.(type) {
-		case string:
-			if s, ok := ab.String(key); !ok || val != s {
-				t.Errorf("ab.Foreach(func(%s, %s) { ab.String(%s) = %v }); wanted %v", key, val, key, s, val)
-			}
-		case int64:
-			if i64, ok := ab.Int64(key); !ok || val != i64 {
-				t.Errorf("ab.Foreach(func(%s, %s) { ab.Int64(%s) = %v }); wanted %v", key, val, key, i64, val)
-			}
-		case float64:
-			if f64, ok := ab.Float64(key); !ok || val != f64 {
-				t.Errorf("ab.Foreach(func(%s, %s) { ab.Float64(%s) = %v }); wanted %v", key, val, key, f64, val)
-			}
-		case bool:
-			if b, ok := ab.Bool(key); !ok || val != b {
-				t.Errorf("ab.Foreach(func(%s, %s) { ab.Bool(%s) = %v }); wanted %v", key, val, key, b, val)
-			}
-		case time.Time:
-			if ti, ok := ab.Time(key); !ok || val != ti {
-				t.Errorf("ab.Foreach(func(%s, %s) { ab.Time(%s) = %v }); wanted %v", key, val, key, ti, val)
-			}
-		case []uint8:
-			bval := val.([]uint8)
-			if bits, ok := ab.Bytes(key); !ok || !bytes.Equal(bval, bits) {
-				t.Errorf("ab.Foreach(func(%s, %s) { ab.Bytes(%s) = %v }); wanted %v", key, val, key, bits, val)
-			}
+	data := map[string]string{"one": "a", "two": "b"}
+	for k, v := range data {
+		ab.SetString(k, v)
+	}
+
+	keys := ab.StringKeys()
+	for _, key := range keys {
+		if val, found := data[key]; !found {
+			t.Errorf("data[%s] = %s, wanted key in set: %v", key, val, keys)
 		}
-		return true
-	})
-	if callCount != len(attrs.Dictionary) {
-		t.Errorf("ab.Foreach(handler) only called handler %d times, expected %d calls.", callCount, len(attrs.Dictionary))
+	}
+}
+
+func TestInt64Keys(t *testing.T) {
+	at := NewManager().NewTracker()
+	defer at.Done()
+	root, _ := at.StartRequest(&mixerpb.Attributes{})
+	defer root.Done()
+	ab := root.Child()
+	defer ab.Done()
+
+	data := map[string]int64{"one": 1, "two": 2}
+	for k, v := range data {
+		ab.SetInt64(k, v)
+	}
+
+	keys := ab.Int64Keys()
+	for _, key := range keys {
+		if val, found := data[key]; !found {
+			t.Errorf("data[%s] = %d, wanted key in set: %v", key, val, keys)
+		}
+	}
+}
+
+func TestFloat64Keys(t *testing.T) {
+	at := NewManager().NewTracker()
+	defer at.Done()
+	root, _ := at.StartRequest(&mixerpb.Attributes{})
+	defer root.Done()
+	ab := root.Child()
+	defer ab.Done()
+
+	data := map[string]float64{"one": 1.0, "two": 2.0}
+	for k, v := range data {
+		ab.SetFloat64(k, v)
+	}
+
+	keys := ab.Float64Keys()
+	for _, key := range keys {
+		if val, found := data[key]; !found {
+			t.Errorf("data[%s] = %f, wanted key in set: %v", key, val, keys)
+		}
+	}
+}
+
+func TestBoolKeys(t *testing.T) {
+	at := NewManager().NewTracker()
+	defer at.Done()
+	root, _ := at.StartRequest(&mixerpb.Attributes{})
+	defer root.Done()
+	ab := root.Child()
+	defer ab.Done()
+
+	data := map[string]bool{"one": true, "two": false}
+	for k, v := range data {
+		ab.SetBool(k, v)
+	}
+
+	keys := ab.BoolKeys()
+	for _, key := range keys {
+		if val, found := data[key]; !found {
+			t.Errorf("data[%s] = %t, wanted key in set: %v", key, val, keys)
+		}
+	}
+}
+
+func TestTimeKeys(t *testing.T) {
+	at := NewManager().NewTracker()
+	defer at.Done()
+	root, _ := at.StartRequest(&mixerpb.Attributes{})
+	defer root.Done()
+	ab := root.Child()
+	defer ab.Done()
+
+	data := map[string]time.Time{"one": t10, "two": t9}
+	for k, v := range data {
+		ab.SetTime(k, v)
+	}
+
+	keys := ab.TimeKeys()
+	for _, key := range keys {
+		if val, found := data[key]; !found {
+			t.Errorf("data[%s] = %v, wanted key in set: %v", key, val, keys)
+		}
+	}
+}
+
+func TestByteKeys(t *testing.T) {
+	at := NewManager().NewTracker()
+	defer at.Done()
+	root, _ := at.StartRequest(&mixerpb.Attributes{})
+	defer root.Done()
+	ab := root.Child()
+	defer ab.Done()
+
+	data := map[string][]uint8{"one": {11}, "two": {13}}
+	for k, v := range data {
+		ab.SetBytes(k, v)
+	}
+
+	keys := ab.ByteKeys()
+	for _, key := range keys {
+		if val, found := data[key]; !found {
+			t.Errorf("data[%s] = %v, wanted key in set: %v", key, val, keys)
+		}
 	}
 }

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -157,7 +157,7 @@ func (mb *mutableBag) SetBytes(name string, value []uint8) {
 	mb.Unlock()
 }
 
-func (mb *mutableBag) Foreach(handler func(key string, val interface{}) bool) {
+func (mb *mutableBag) ForEach(handler func(key string, val interface{}) bool) {
 	// We don't defer the unlock even though we have many exit points in this function so that we can unlock this
 	// bag before we recurse up to the parent bag.
 	mb.RLock()
@@ -201,7 +201,7 @@ func (mb *mutableBag) Foreach(handler func(key string, val interface{}) bool) {
 
 	// We're done with this bag, there's no reason to hold the read lock while the iterating over the parent's keys.
 	mb.RUnlock()
-	mb.parent.Foreach(handler)
+	mb.parent.ForEach(handler)
 }
 
 func (mb *mutableBag) Reset() {

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -72,6 +72,19 @@ func (mb *mutableBag) SetString(name string, value string) {
 	mb.Unlock()
 }
 
+func (mb *mutableBag) StringKeys() []string {
+	i := 0
+
+	mb.RLock()
+	keys := make([]string, len(mb.strings))
+	for k := range mb.strings {
+		keys[i] = k
+		i++
+	}
+	mb.RUnlock()
+	return append(keys, mb.parent.StringKeys()...)
+}
+
 func (mb *mutableBag) Int64(name string) (int64, bool) {
 	var r int64
 	var b bool
@@ -87,6 +100,19 @@ func (mb *mutableBag) SetInt64(name string, value int64) {
 	mb.Lock()
 	mb.int64s[name] = value
 	mb.Unlock()
+}
+
+func (mb *mutableBag) Int64Keys() []string {
+	i := 0
+
+	mb.RLock()
+	keys := make([]string, len(mb.int64s))
+	for k := range mb.int64s {
+		keys[i] = k
+		i++
+	}
+	mb.RUnlock()
+	return append(keys, mb.parent.Int64Keys()...)
 }
 
 func (mb *mutableBag) Float64(name string) (float64, bool) {
@@ -106,6 +132,19 @@ func (mb *mutableBag) SetFloat64(name string, value float64) {
 	mb.Unlock()
 }
 
+func (mb *mutableBag) Float64Keys() []string {
+	i := 0
+
+	mb.RLock()
+	keys := make([]string, len(mb.float64s))
+	for k := range mb.float64s {
+		keys[i] = k
+		i++
+	}
+	mb.RUnlock()
+	return append(keys, mb.parent.Float64Keys()...)
+}
+
 func (mb *mutableBag) Bool(name string) (bool, bool) {
 	var r bool
 	var b bool
@@ -121,6 +160,19 @@ func (mb *mutableBag) SetBool(name string, value bool) {
 	mb.Lock()
 	mb.bools[name] = value
 	mb.Unlock()
+}
+
+func (mb *mutableBag) BoolKeys() []string {
+	i := 0
+
+	mb.RLock()
+	keys := make([]string, len(mb.bools))
+	for k := range mb.bools {
+		keys[i] = k
+		i++
+	}
+	mb.RUnlock()
+	return append(keys, mb.parent.BoolKeys()...)
 }
 
 func (mb *mutableBag) Time(name string) (time.Time, bool) {
@@ -140,6 +192,19 @@ func (mb *mutableBag) SetTime(name string, value time.Time) {
 	mb.Unlock()
 }
 
+func (mb *mutableBag) TimeKeys() []string {
+	i := 0
+
+	mb.RLock()
+	keys := make([]string, len(mb.times))
+	for k := range mb.times {
+		keys[i] = k
+		i++
+	}
+	mb.RUnlock()
+	return append(keys, mb.parent.TimeKeys()...)
+}
+
 func (mb *mutableBag) Bytes(name string) ([]uint8, bool) {
 	var r []uint8
 	var b bool
@@ -157,51 +222,17 @@ func (mb *mutableBag) SetBytes(name string, value []uint8) {
 	mb.Unlock()
 }
 
-func (mb *mutableBag) ForEach(handler func(key string, val interface{}) bool) {
-	// We don't defer the unlock even though we have many exit points in this function so that we can unlock this
-	// bag before we recurse up to the parent bag.
+func (mb *mutableBag) ByteKeys() []string {
+	i := 0
+
 	mb.RLock()
-
-	for key, val := range mb.strings {
-		if !handler(key, val) {
-			mb.RUnlock()
-			return
-		}
+	keys := make([]string, len(mb.bytes))
+	for k := range mb.bytes {
+		keys[i] = k
+		i++
 	}
-	for key, val := range mb.int64s {
-		if !handler(key, val) {
-			mb.RUnlock()
-			return
-		}
-	}
-	for key, val := range mb.float64s {
-		if !handler(key, val) {
-			mb.RUnlock()
-			return
-		}
-	}
-	for key, val := range mb.bools {
-		if !handler(key, val) {
-			mb.RUnlock()
-			return
-		}
-	}
-	for key, val := range mb.times {
-		if !handler(key, val) {
-			mb.RUnlock()
-			return
-		}
-	}
-	for key, val := range mb.bytes {
-		if !handler(key, val) {
-			mb.RUnlock()
-			return
-		}
-	}
-
-	// We're done with this bag, there's no reason to hold the read lock while the iterating over the parent's keys.
 	mb.RUnlock()
-	mb.parent.ForEach(handler)
+	return append(keys, mb.parent.ByteKeys()...)
 }
 
 func (mb *mutableBag) Reset() {

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -222,7 +222,7 @@ func (mb *mutableBag) SetBytes(name string, value []uint8) {
 	mb.Unlock()
 }
 
-func (mb *mutableBag) ByteKeys() []string {
+func (mb *mutableBag) BytesKeys() []string {
 	i := 0
 
 	mb.RLock()
@@ -232,7 +232,7 @@ func (mb *mutableBag) ByteKeys() []string {
 		i++
 	}
 	mb.RUnlock()
-	return append(keys, mb.parent.ByteKeys()...)
+	return append(keys, mb.parent.BytesKeys()...)
 }
 
 func (mb *mutableBag) Reset() {

--- a/pkg/attribute/rootBag.go
+++ b/pkg/attribute/rootBag.go
@@ -64,9 +64,29 @@ func (rb *rootBag) String(name string) (string, bool) {
 	return r, b
 }
 
+func (rb *rootBag) StringKeys() []string {
+	i := 0
+	keys := make([]string, len(rb.strings))
+	for k := range rb.strings {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
 func (rb *rootBag) Int64(name string) (int64, bool) {
 	r, b := rb.int64s[name]
 	return r, b
+}
+
+func (rb *rootBag) Int64Keys() []string {
+	i := 0
+	keys := make([]string, len(rb.int64s))
+	for k := range rb.int64s {
+		keys[i] = k
+		i++
+	}
+	return keys
 }
 
 func (rb *rootBag) Float64(name string) (float64, bool) {
@@ -74,9 +94,29 @@ func (rb *rootBag) Float64(name string) (float64, bool) {
 	return r, b
 }
 
+func (rb *rootBag) Float64Keys() []string {
+	i := 0
+	keys := make([]string, len(rb.float64s))
+	for k := range rb.float64s {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
 func (rb *rootBag) Bool(name string) (bool, bool) {
 	r, b := rb.bools[name]
 	return r, b
+}
+
+func (rb *rootBag) BoolKeys() []string {
+	i := 0
+	keys := make([]string, len(rb.bools))
+	for k := range rb.bools {
+		keys[i] = k
+		i++
+	}
+	return keys
 }
 
 func (rb *rootBag) Time(name string) (time.Time, bool) {
@@ -84,42 +124,29 @@ func (rb *rootBag) Time(name string) (time.Time, bool) {
 	return r, b
 }
 
+func (rb *rootBag) TimeKeys() []string {
+	i := 0
+	keys := make([]string, len(rb.times))
+	for k := range rb.times {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
 func (rb *rootBag) Bytes(name string) ([]uint8, bool) {
 	r, b := rb.bytes[name]
 	return r, b
 }
 
-func (rb *rootBag) ForEach(handler func(key string, val interface{}) bool) {
-	for key, val := range rb.strings {
-		if !handler(key, val) {
-			return
-		}
+func (rb *rootBag) ByteKeys() []string {
+	i := 0
+	keys := make([]string, len(rb.bytes))
+	for k := range rb.bytes {
+		keys[i] = k
+		i++
 	}
-	for key, val := range rb.int64s {
-		if !handler(key, val) {
-			return
-		}
-	}
-	for key, val := range rb.float64s {
-		if !handler(key, val) {
-			return
-		}
-	}
-	for key, val := range rb.bools {
-		if !handler(key, val) {
-			return
-		}
-	}
-	for key, val := range rb.times {
-		if !handler(key, val) {
-			return
-		}
-	}
-	for key, val := range rb.bytes {
-		if !handler(key, val) {
-			return
-		}
-	}
+	return keys
 }
 
 func (rb *rootBag) reset() {

--- a/pkg/attribute/rootBag.go
+++ b/pkg/attribute/rootBag.go
@@ -139,7 +139,7 @@ func (rb *rootBag) Bytes(name string) ([]uint8, bool) {
 	return r, b
 }
 
-func (rb *rootBag) ByteKeys() []string {
+func (rb *rootBag) BytesKeys() []string {
 	i := 0
 	keys := make([]string, len(rb.bytes))
 	for k := range rb.bytes {

--- a/pkg/attribute/rootBag.go
+++ b/pkg/attribute/rootBag.go
@@ -89,6 +89,39 @@ func (rb *rootBag) Bytes(name string) ([]uint8, bool) {
 	return r, b
 }
 
+func (rb *rootBag) Foreach(handler func(key string, val interface{}) bool) {
+	for key, val := range rb.strings {
+		if !handler(key, val) {
+			return
+		}
+	}
+	for key, val := range rb.int64s {
+		if !handler(key, val) {
+			return
+		}
+	}
+	for key, val := range rb.float64s {
+		if !handler(key, val) {
+			return
+		}
+	}
+	for key, val := range rb.bools {
+		if !handler(key, val) {
+			return
+		}
+	}
+	for key, val := range rb.times {
+		if !handler(key, val) {
+			return
+		}
+	}
+	for key, val := range rb.bytes {
+		if !handler(key, val) {
+			return
+		}
+	}
+}
+
 func (rb *rootBag) reset() {
 	// my kingdom for a clear method on maps!
 

--- a/pkg/attribute/rootBag.go
+++ b/pkg/attribute/rootBag.go
@@ -89,7 +89,7 @@ func (rb *rootBag) Bytes(name string) ([]uint8, bool) {
 	return r, b
 }
 
-func (rb *rootBag) Foreach(handler func(key string, val interface{}) bool) {
+func (rb *rootBag) ForEach(handler func(key string, val interface{}) bool) {
 	for key, val := range rb.strings {
 		if !handler(key, val) {
 			return

--- a/pkg/tracing/BUILD
+++ b/pkg/tracing/BUILD
@@ -5,11 +5,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "attributes.go",
         "basictracing.go",
         "metadata.go",
         "tracing.go",
     ],
     deps = [
+        "//pkg/attribute:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_opentracing_basictracer//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
@@ -26,12 +28,14 @@ go_test(
     name = "small_tests",
     size = "small",
     srcs = [
+        "attributes_test.go",
         "basictracing_test.go",
         "metadata_test.go",
         "tracing_test.go",
     ],
     library = ":go_default_library",
     deps = [
+        "@com_github_istio_api//:mixer/v1",
         "@com_github_opentracing_opentracing_go//mocktracer:go_default_library",
     ],
 )

--- a/pkg/tracing/attributes.go
+++ b/pkg/tracing/attributes.go
@@ -21,9 +21,8 @@ package tracing
 import (
 	"context"
 	"strings"
-	"sync"
 
-	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/mixer/pkg/attribute"
 )
 
 const (
@@ -32,21 +31,13 @@ const (
 )
 
 // AttributeCarrier implements opentracing's TextMapWriter and TextMapReader interfaces using Istio's attribute system.
-//
-// TODO: this type is fundamentally flawed: when it operates on the set of attributes it must be threadsafe, but
-// this type does not own the attribute set. This means the locks we use only provide protections against multiple
-// threads using the carrier, not the underlying Attribute set we're pointing at. Either we need to guarantee this is
-// only ever accessed by a single thread (unlikely given adapters should propagate span info and they're executed
-// concurrently) or we need something that owns the attributes to take the lock (i.e. the attributes.Bag type should be
-// extended so that this type can use it instead of using the raw attributes proto).
 type AttributeCarrier struct {
-	sync.RWMutex
-	a *mixerpb.Attributes
+	mb attribute.MutableBag
 }
 
 // NewCarrier initializes a carrier that can be used to modify the attributes in the current request context.
-func NewCarrier(attributes *mixerpb.Attributes) *AttributeCarrier {
-	return &AttributeCarrier{a: attributes}
+func NewCarrier(bag attribute.MutableBag) *AttributeCarrier {
+	return &AttributeCarrier{mb: bag.Child()}
 }
 
 type carrierKey struct{}
@@ -69,72 +60,23 @@ func FromContext(ctx context.Context) *AttributeCarrier {
 // AttributeCarrier to denote opentracing attributes. The AttributeCarrier specific prefix is stripped from the key
 // before its passed to handler.
 func (c *AttributeCarrier) ForeachKey(handler func(key, val string) error) error {
-	// TODO: the only thing preventing us from implementing the carrier on top of attribute.Bag instead of attributes
-	// directly is the lack of ability to iterate over keys in the bag for this method. If the bag interface was
-	// updated to provide the set of keys it knows about, we'd have a substantially easier time.
-
-	c.RLock()
-	// Look through the dictionary for keys with our prefix, check that they refer to string attributes, then call handle
-	for i, key := range c.a.Dictionary {
-		if strings.HasPrefix(key, prefix) {
-			if val, found := c.a.StringAttributes[i]; found {
-				if err := handler(key[prefixLength:], val); err != nil {
-					c.RUnlock()
-					return err
+	var err error
+	c.mb.Foreach(func(key string, val interface{}) bool {
+		if sval, ok := val.(string); ok {
+			if strings.HasPrefix(key, prefix) {
+				if err = handler(key[prefixLength:], sval); err != nil {
+					return false
 				}
 			}
 		}
-	}
-	c.RUnlock()
-	return nil
+		return true
+	})
+	// If we made it through with no problems, err == nil, otherwise it's some error from handler.
+	return err
 }
 
 // Set adds (key, val) to the set of string attributes in the request scope. It prefixes the key with an istio-private
 // string to avoid collisions with other attributes when arbitrary tracer implementations are used.
 func (c *AttributeCarrier) Set(key, val string) {
-	// We have to deal with the case that the key already exists in the attribute set, and the case that its new.
-	// First we see if it exists in the attribute set already.
-	keyIndex := int32(-1)
-	prefixedKey := prefix + key
-	c.RLock()
-	for i, k := range c.a.Dictionary {
-		if k == prefixedKey {
-			keyIndex = i
-			break
-		}
-	}
-	c.RUnlock()
-
-	// Key exists in the map already; update the value in the string attribute set.
-	//
-	// TODO: since we use a constant prefix private to this package, we assume that if the key is found it references
-	// a string attribute (the AttributeCarrier has the invariant that all attributes it writes are stringly typed).
-	// If we're being paranoid, we could verify that the key refers to a string attribute and take some other action
-	// (panic, overwrite, etc) if it does not.
-	if keyIndex > 0 {
-		c.Lock()
-		c.a.StringAttributes[keyIndex] = val
-		c.Unlock()
-		return
-	}
-
-	// Key does not exist in the map, add it
-	c.Lock()
-	index := largestKey(c.a.Dictionary) + 1
-	c.a.Dictionary[index] = key
-	c.a.StringAttributes[index] = val
-	c.Unlock()
-	return
-}
-
-// Note: the map should be read locked when this method is called. We don't take a lock in this method because
-// the lock should also cover updates to the map using the key we found.
-func largestKey(m map[int32]string) int32 {
-	largest := int32(-1)
-	for k := range m {
-		if k > largest {
-			largest = k
-		}
-	}
-	return largest
+	c.mb.SetString(prefix+key, val)
 }

--- a/pkg/tracing/attributes.go
+++ b/pkg/tracing/attributes.go
@@ -1,0 +1,140 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains an implementation of an opentracing carrier built on top of the mixer's attribute bag. This allows
+// clients to inject their span metadata into the set of attributes its reporting to the mixer, and lets the mixer extract
+// span information propagated as attributes in a standard call to the mixer.
+
+package tracing
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	mixerpb "istio.io/api/mixer/v1"
+)
+
+const (
+	prefix       = "istio-ot-"
+	prefixLength = len(prefix)
+)
+
+// AttributeCarrier implements opentracing's TextMapWriter and TextMapReader interfaces using Istio's attribute system.
+//
+// TODO: this type is fundamentally flawed: when it operates on the set of attributes it must be threadsafe, but
+// this type does not own the attribute set. This means the locks we use only provide protections against multiple
+// threads using the carrier, not the underlying Attribute set we're pointing at. Either we need to guarantee this is
+// only ever accessed by a single thread (unlikely given adapters should propagate span info and they're executed
+// concurrently) or we need something that owns the attributes to take the lock (i.e. the attributes.Bag type should be
+// extended so that this type can use it instead of using the raw attributes proto).
+type AttributeCarrier struct {
+	sync.RWMutex
+	a *mixerpb.Attributes
+}
+
+// NewCarrier initializes a carrier that can be used to modify the attributes in the current request context.
+func NewCarrier(attributes *mixerpb.Attributes) *AttributeCarrier {
+	return &AttributeCarrier{a: attributes}
+}
+
+type carrierKey struct{}
+
+// NewContext annotates the provided context with the provided carrier and returns the updated context.
+func NewContext(ctx context.Context, carrier *AttributeCarrier) context.Context {
+	return context.WithValue(ctx, carrierKey{}, carrier)
+}
+
+// FromContext extracts the AttributeCarrier from the provided context, or returns nil if one is not found.
+func FromContext(ctx context.Context) *AttributeCarrier {
+	mc := ctx.Value(carrierKey{})
+	if c, ok := mc.(*AttributeCarrier); ok {
+		return c
+	}
+	return nil
+}
+
+// ForeachKey iterates over the keys that correspond to string attributes, filtering keys for the prefix used by the
+// AttributeCarrier to denote opentracing attributes. The AttributeCarrier specific prefix is stripped from the key
+// before its passed to handler.
+func (c *AttributeCarrier) ForeachKey(handler func(key, val string) error) error {
+	// TODO: the only thing preventing us from implementing the carrier on top of attribute.Bag instead of attributes
+	// directly is the lack of ability to iterate over keys in the bag for this method. If the bag interface was
+	// updated to provide the set of keys it knows about, we'd have a substantially easier time.
+
+	c.RLock()
+	// Look through the dictionary for keys with our prefix, check that they refer to string attributes, then call handle
+	for i, key := range c.a.Dictionary {
+		if strings.HasPrefix(key, prefix) {
+			if val, found := c.a.StringAttributes[i]; found {
+				if err := handler(key[prefixLength:], val); err != nil {
+					c.RUnlock()
+					return err
+				}
+			}
+		}
+	}
+	c.RUnlock()
+	return nil
+}
+
+// Set adds (key, val) to the set of string attributes in the request scope. It prefixes the key with an istio-private
+// string to avoid collisions with other attributes when arbitrary tracer implementations are used.
+func (c *AttributeCarrier) Set(key, val string) {
+	// We have to deal with the case that the key already exists in the attribute set, and the case that its new.
+	// First we see if it exists in the attribute set already.
+	keyIndex := int32(-1)
+	prefixedKey := prefix + key
+	c.RLock()
+	for i, k := range c.a.Dictionary {
+		if k == prefixedKey {
+			keyIndex = i
+			break
+		}
+	}
+	c.RUnlock()
+
+	// Key exists in the map already; update the value in the string attribute set.
+	//
+	// TODO: since we use a constant prefix private to this package, we assume that if the key is found it references
+	// a string attribute (the AttributeCarrier has the invariant that all attributes it writes are stringly typed).
+	// If we're being paranoid, we could verify that the key refers to a string attribute and take some other action
+	// (panic, overwrite, etc) if it does not.
+	if keyIndex > 0 {
+		c.Lock()
+		c.a.StringAttributes[keyIndex] = val
+		c.Unlock()
+		return
+	}
+
+	// Key does not exist in the map, add it
+	c.Lock()
+	index := largestKey(c.a.Dictionary) + 1
+	c.a.Dictionary[index] = key
+	c.a.StringAttributes[index] = val
+	c.Unlock()
+	return
+}
+
+// Note: the map should be read locked when this method is called. We don't take a lock in this method because
+// the lock should also cover updates to the map using the key we found.
+func largestKey(m map[int32]string) int32 {
+	largest := int32(-1)
+	for k := range m {
+		if k > largest {
+			largest = k
+		}
+	}
+	return largest
+}

--- a/pkg/tracing/attributes.go
+++ b/pkg/tracing/attributes.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// TODO: elevate this to a global registry, especially since non-go clients (the proxy) will need to use the same prefix
-	prefix       = "istio-ot-"
+	prefix       = ":istio-ot-"
 	prefixLength = len(prefix)
 )
 

--- a/pkg/tracing/attributes.go
+++ b/pkg/tracing/attributes.go
@@ -61,7 +61,7 @@ func FromContext(ctx context.Context) *AttributeCarrier {
 // before its passed to handler.
 func (c *AttributeCarrier) ForeachKey(handler func(key, val string) error) error {
 	var err error
-	c.mb.Foreach(func(key string, val interface{}) bool {
+	c.mb.ForEach(func(key string, val interface{}) bool {
 		if sval, ok := val.(string); ok {
 			if strings.HasPrefix(key, prefix) {
 				if err = handler(key[prefixLength:], sval); err != nil {

--- a/pkg/tracing/attributes_test.go
+++ b/pkg/tracing/attributes_test.go
@@ -95,12 +95,15 @@ func TestForeachKey(t *testing.T) {
 			b.SetString(prefix+k, v)
 		}
 
-		NewCarrier(b).ForeachKey(func(key, val string) error {
+		err := NewCarrier(b).ForeachKey(func(key, val string) error {
 			if dval, found := c.data[key]; !found || dval != val {
 				t.Errorf("ForeachKey(func(%s, %s)); wanted func(%s, %s)", key, val, key, dval)
 			}
 			return nil
 		})
+		if err != nil {
+			t.Errorf("ForeachKey failed with unexpected err: %v", err)
+		}
 	}
 }
 

--- a/pkg/tracing/attributes_test.go
+++ b/pkg/tracing/attributes_test.go
@@ -1,0 +1,124 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"testing"
+
+	mixerpb "istio.io/api/mixer/v1"
+
+	"context"
+	"fmt"
+
+	"istio.io/mixer/pkg/attribute"
+)
+
+var (
+	attrs = &mixerpb.Attributes{
+		Dictionary:       map[int32]string{1: "N1", 2: "N2", 3: "N3", 4: "N4", 5: "N5", 6: "N6", 7: "N7", 8: "N8", 9: "N11", 10: "N12"},
+		StringAttributes: map[int32]string{1: "1", 2: "2"},
+		Int64Attributes:  map[int32]int64{3: 3, 4: 4},
+		DoubleAttributes: map[int32]float64{5: 5.0, 6: 6.0},
+		BoolAttributes:   map[int32]bool{7: true, 8: false},
+		BytesAttributes:  map[int32][]uint8{9: {9}, 10: {10}},
+	}
+)
+
+func TestContext(t *testing.T) {
+	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	if err != nil {
+		t.Errorf("Failed to construct bag with err: %s", err)
+	}
+
+	if c := FromContext(context.Background()); c != nil {
+		t.Errorf("FromContext(context.Background()) = %v; wanted nil", c)
+	}
+
+	c := NewCarrier(bag)
+
+	ctx := context.Background()
+	ctx = NewContext(ctx, c)
+	if cc := FromContext(ctx); cc != c {
+		t.Errorf("FromContext(ctx) = %v; wanted %v; context: %v", cc, c, ctx)
+	}
+}
+
+func TestSet(t *testing.T) {
+	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	if err != nil {
+		t.Errorf("Failed to construct bag with err: %s", err)
+	}
+
+	cases := []struct {
+		key string
+		val string
+	}{
+		{"a", "b"},
+		{"foo", "bar"},
+		{"spanID", "1235"},
+	}
+	for _, c := range cases {
+		cr := NewCarrier(bag)
+		cr.Set(c.key, c.val)
+		if val, ok := cr.mb.String(prefix + c.key); !ok || val != c.val {
+			t.Errorf("carrier.Set(%s, %s); bag.String(%s) = %s; wanted %s", c.key, c.val, prefix+c.key, val, c.val)
+		}
+	}
+}
+
+func TestForeachKey(t *testing.T) {
+	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	if err != nil {
+		t.Errorf("Failed to construct bag with err: %s", err)
+	}
+
+	cases := []struct {
+		data map[string]string
+	}{
+		{map[string]string{"a": "b", "c": "d"}},
+	}
+	for _, c := range cases {
+		b := bag.Child()
+		for k, v := range c.data {
+			b.SetString(prefix+k, v)
+		}
+
+		NewCarrier(b).ForeachKey(func(key, val string) error {
+			if dval, found := c.data[key]; !found || dval != val {
+				t.Errorf("ForeachKey(func(%s, %s)); wanted func(%s, %s)", key, val, key, dval)
+			}
+			return nil
+		})
+	}
+}
+
+func TestForeachKey_PropagatesErr(t *testing.T) {
+	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	if err != nil {
+		t.Errorf("Failed to construct bag with err: %s", err)
+	}
+
+	c := NewCarrier(bag)
+	c.Set("k", "v")
+
+	err = fmt.Errorf("expected")
+	propErr := c.ForeachKey(func(key, val string) error {
+		return err
+	})
+
+	if propErr != err {
+		t.Errorf("ForeachKey(...) = %v; wanted err %v", propErr, err)
+	}
+}


### PR DESCRIPTION
Opentracing defines carriers which are responsible for propagating trace state between servers. These carriers expose the following interface:

    Set(key, value string)
    ForeachKey(handler func(key, val string) error) error

We implement that interface on top of the mixer's `attribute.MutableBag`. This change introduces the carrier struct itself, and modifies the `Bag` interface to expose a way to iterate over the elements of the bag, `ForEach(func(key string, val interface{}) bool)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/192)
<!-- Reviewable:end -->
