### PR TITLE
Add accessLogger aspect support to stdioLogger.

### DIFF
--- a/pkg/adapter/accessLogger.go
+++ b/pkg/adapter/accessLogger.go
@@ -57,13 +57,13 @@ type (
 	AccessLogEntry struct {
 		// LogName is the name of the access log stream to which the
 		// entry corresponds.
-		LogName string
+		LogName string `json:"logName,omitempty"`
 		// Log is the text-formatted access log entry data. It will
 		// be prepared by the aspect manager, based upon aspect config.
-		Log string
+		Log string `json:"log,omitempty"`
 		// Labels is the set of key-value pairs that can be used to
 		// generate a structured access log for this entry. The aspect
 		// manager will populate this map based on aspect config.
-		Labels map[string]interface{}
+		Labels map[string]interface{} `json:"labels,omitempty"`
 	}
 )

--- a/pkg/adapter/registrar.go
+++ b/pkg/adapter/registrar.go
@@ -25,6 +25,9 @@ type Registrar interface {
 	// RegisterLogger registers a new Logger builder.
 	RegisterLogger(LoggerBuilder)
 
+	// RegisterAccessLogger registers a new AccessLogger builder.
+	RegisterAccessLogger(AccessLoggerBuilder)
+
 	// RegisterQuota registers a new Quota builder.
 	RegisterQuota(QuotaBuilder)
 }

--- a/pkg/adapter/testing/adapters.go
+++ b/pkg/adapter/testing/adapters.go
@@ -23,10 +23,11 @@ import (
 )
 
 type fakeRegistrar struct {
-	denyCheckers []adapter.DenyCheckerBuilder
-	listCheckers []adapter.ListCheckerBuilder
-	loggers      []adapter.LoggerBuilder
-	quotas       []adapter.QuotaBuilder
+	denyCheckers  []adapter.DenyCheckerBuilder
+	listCheckers  []adapter.ListCheckerBuilder
+	loggers       []adapter.LoggerBuilder
+	accessLoggers []adapter.AccessLoggerBuilder
+	quotas        []adapter.QuotaBuilder
 }
 
 func (r *fakeRegistrar) RegisterListChecker(b adapter.ListCheckerBuilder) {
@@ -39,6 +40,10 @@ func (r *fakeRegistrar) RegisterDenyChecker(b adapter.DenyCheckerBuilder) {
 
 func (r *fakeRegistrar) RegisterLogger(b adapter.LoggerBuilder) {
 	r.loggers = append(r.loggers, b)
+}
+
+func (r *fakeRegistrar) RegisterAccessLogger(b adapter.AccessLoggerBuilder) {
+	r.accessLoggers = append(r.accessLoggers, b)
 }
 
 func (r *fakeRegistrar) RegisterQuota(b adapter.QuotaBuilder) {

--- a/pkg/adapterManager/registry.go
+++ b/pkg/adapterManager/registry.go
@@ -67,6 +67,11 @@ func (r *registry) RegisterLogger(logger adapter.LoggerBuilder) {
 	r.insert(logger)
 }
 
+// RegisterAccessLogger registers a new Logger builder.
+func (r *registry) RegisterAccessLogger(logger adapter.AccessLoggerBuilder) {
+	r.insert(logger)
+}
+
 // RegisterQuota registers a new Quota builder.
 func (r *registry) RegisterQuota(quota adapter.QuotaBuilder) {
 	r.insert(quota)

--- a/pkg/adapterManager/registry_test.go
+++ b/pkg/adapterManager/registry_test.go
@@ -97,6 +97,28 @@ func TestRegisterLogger(t *testing.T) {
 	}
 }
 
+type accessLoggerBuilder struct{ testBuilder }
+
+func (accessLoggerBuilder) NewAccessLogger(env adapter.Env, cfg adapter.AspectConfig) (adapter.AccessLoggerAspect, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestRegistry_RegisterAccessLogger(t *testing.T) {
+	reg := newRegistry(nil)
+	builder := accessLoggerBuilder{testBuilder{name: "foo"}}
+
+	reg.RegisterAccessLogger(builder)
+
+	impl, ok := reg.FindBuilder(builder.Name())
+	if !ok {
+		t.Errorf("No builder by impl with name %s, expected builder: %v", builder.Name(), builder)
+	}
+
+	if deny, ok := impl.(accessLoggerBuilder); !ok || deny != builder {
+		t.Errorf("reg.ByImpl(%s) expected builder '%v', actual '%v'", builder.Name(), builder, impl)
+	}
+}
+
 type quotaBuilder struct{ testBuilder }
 
 func (quotaBuilder) NewQuota(env adapter.Env, cfg adapter.AspectConfig) (adapter.QuotaAspect, error) {


### PR DESCRIPTION
This establishes a basic access logger impl for mixer via stdio. A few updates are made to the registry, etc., to support the access logger aspect (registration).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/198)
<!-- Reviewable:end -->
