### PR TITLE
Builders must have unique names

### DIFF
--- a/adapter/stdioLogger/stdioLogger.go
+++ b/adapter/stdioLogger/stdioLogger.go
@@ -32,17 +32,18 @@ type (
 	logger  struct{ logStream io.Writer }
 )
 
-var (
-	name = "istio/stdioLogger"
-	desc = "Writes structured log entries to a standard I/O stream"
-	conf = &config.Params{}
-)
-
 // Register records the builders exposed by this adapter.
 func Register(r adapter.Registrar) {
-	b := builder{adapter.NewDefaultBuilder(name, desc, conf)}
-	r.RegisterLogger(b)
-	r.RegisterAccessLogger(b)
+	r.RegisterLogger(builder{adapter.NewDefaultBuilder(
+		"istio/stdioLogger",
+		"Writes structured log entries to a standard I/O stream",
+		&config.Params{},
+	)})
+	r.RegisterAccessLogger(builder{adapter.NewDefaultBuilder(
+		"istio/stdioAccessLogger",
+		"Writes structured access log entries to a standard I/O stream",
+		&config.Params{},
+	)})
 }
 
 func (builder) NewLogger(env adapter.Env, cfg adapter.AspectConfig) (adapter.LoggerAspect, error) {

--- a/adapter/stdioLogger/stdioLogger.go
+++ b/adapter/stdioLogger/stdioLogger.go
@@ -34,6 +34,7 @@ type (
 
 // Register records the builders exposed by this adapter.
 func Register(r adapter.Registrar) {
+	//TODO update registration code after https://github.com/istio/mixer/issues/204 is resolved.
 	r.RegisterLogger(builder{adapter.NewDefaultBuilder(
 		"istio/stdioLogger",
 		"Writes structured log entries to a standard I/O stream",


### PR DESCRIPTION
At present 2 builders cannot have the same name even if their Aspect is different.


This was causing panic while starting mixer.
We need integration tests :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/203)
<!-- Reviewable:end -->
