### PR TITLE
add ability to read from config maps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -169,6 +169,172 @@ new_git_or_local_repository(
     use_local = False,
 )
 
+new_go_repository(
+    name = "io_k8s_client_go",
+    commit = "243d8a9cb66a51ad8676157f79e71033b4014a2a",
+    importpath = "k8s.io/client-go",
+)
+
+# following are k8s client deps
+new_go_repository(
+    name = "com_github_juju_ratelimit",
+    commit = "77ed1c8a01217656d2080ad51981f6e99adaa177",
+    importpath = "github.com/juju/ratelimit",
+)
+
+new_go_repository(
+    name = "com_github_emicklei_go_restful",
+    commit = "89ef8af493ab468a45a42bb0d89a06fccdd2fb22",
+    importpath = "github.com/emicklei/go-restful",
+)
+
+new_go_repository(
+    name = "com_github_davecgh_go_spew",
+    commit = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
+    importpath = "github.com/davecgh/go-spew",
+)
+
+new_go_repository(
+    name = "com_github_ugorji_go",
+    commit = "f1f1a805ed361a0e078bb537e4ea78cd37dcf065",
+    importpath = "github.com/ugorji/go",
+)
+
+new_go_repository(
+    name = "com_github_go_openapi_spec",
+    commit = "6aced65f8501fe1217321abf0749d354824ba2ff",
+    importpath = "github.com/go-openapi/spec",
+)
+
+new_go_repository(
+    name = "com_github_google_gofuzz",
+    commit = "bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5",
+    importpath = "github.com/google/gofuzz",
+)
+
+new_go_repository(
+    name = "in_gopkg_inf_v0",
+    commit = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4",
+    importpath = "gopkg.in/inf.v0",
+)
+
+new_go_repository(
+    name = "com_github_coreos_go_oidc",
+    # commit = "5644a2f50e2d2d5ba0b474bc5bc55fea1925936d",
+    commit = "5a7f09ab5787e846efa7f56f4a08b6d6926d08c4",
+    importpath = "github.com/coreos/go-oidc",
+)
+
+new_go_repository(
+    name = "com_github_ghodss_yaml",
+    commit = "73d445a93680fa1a78ae23a5839bad48f32ba1ee",
+    importpath = "github.com/ghodss/yaml",
+)
+
+new_go_repository(
+    name = "com_github_blang_semver",
+    commit = "31b736133b98f26d5e078ec9eb591666edfd091f",
+    importpath = "github.com/blang/semver",
+)
+
+new_go_repository(
+    name = "org_golang_x_oauth2",
+    commit = "3c3a985cb79f52a3190fbc056984415ca6763d01",
+    importpath = "golang.org/x/oauth2",
+)
+
+new_go_repository(
+    name = "com_github_pborman_uuid",
+    commit = "ca53cad383cad2479bbba7f7a1a05797ec1386e4",
+    importpath = "github.com/pborman/uuid",
+)
+
+new_go_repository(
+    name = "com_github_go_openapi_jsonreference",
+    commit = "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272",
+    importpath = "github.com/go-openapi/jsonreference",
+)
+
+new_go_repository(
+    name = "com_github_go_openapi_jsonpointer",
+    commit = "46af16f9f7b149af66e5d1bd010e3574dc06de98",
+    importpath = "github.com/go-openapi/jsonpointer",
+)
+
+new_go_repository(
+    name = "com_github_go_openapi_swag",
+    commit = "1d0bd113de87027671077d3c71eb3ac5d7dbba72",
+    importpath = "github.com/go-openapi/swag",
+)
+
+new_go_repository(
+    name = "com_github_PuerkitoBio_purell",
+    commit = "8a290539e2e8629dbc4e6bad948158f790ec31f4",
+    importpath = "github.com/PuerkitoBio/purell",
+)
+
+new_go_repository(
+    name = "com_github_mailru_easyjson",
+    commit = "d5b7844b561a7bc640052f1b935f7b800330d7e0",
+    importpath = "github.com/mailru/easyjson",
+)
+
+new_go_repository(
+    name = "org_golang_x_text",
+    commit = "2910a502d2bf9e43193af9d68ca516529614eed3",
+    importpath = "golang.org/x/text",
+)
+
+new_go_repository(
+    name = "com_github_PuerkitoBio_urlesc",
+    commit = "5bd2802263f21d8788851d5305584c82a5c75d7e",
+    importpath = "github.com/PuerkitoBio/urlesc",
+)
+
+new_go_repository(
+    name = "com_github_docker_distribution",
+    commit = "cd27f179f2c10c5d300e6d09025b538c475b0d51",
+    importpath = "github.com/docker/distribution",
+)
+
+new_go_repository(
+    name = "com_github_jonboulle_clockwork",
+    commit = "72f9bd7c4e0c2a40055ab3d0f09654f730cce982",
+    importpath = "github.com/jonboulle/clockwork",
+)
+
+new_go_repository(
+    name = "com_google_cloud_go",
+    commit = "3b1ae45394a234c385be014e9a488f2bb6eef821",
+    importpath = "cloud.google.com/go",
+)
+
+new_go_repository(
+    name = "com_github_coreos_pkg",
+    commit = "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8",
+    importpath = "github.com/coreos/pkg",
+)
+
+new_go_repository(
+    name = "com_github_imdario_mergo",
+    commit = "6633656539c1639d9d78127b7d47c622b5d7b6dc",
+    importpath = "github.com/imdario/mergo",
+)
+
+new_go_repository(
+    name = "com_github_howeyc_gopass",
+    commit = "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d",
+    importpath = "github.com/howeyc/gopass",
+)
+
+new_go_repository(
+    name = "org_golang_x_crypto",
+    commit = "1f22c0103821b9390939b6776727195525381532",
+    importpath = "golang.org/x/crypto",
+)
+# k8s client deps
+
+
 new_http_archive(
     name = "docker_ubuntu",
     url = "https://codeload.github.com/tianon/docker-brew-ubuntu-core/zip/b6f1fe19228e5b6b7aed98dcba02f18088282f90",

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -11,7 +11,10 @@ prep_linters() {
 		go get -u github.com/3rf/codecoroner
 		gometalinter --install --vendored-linters >/dev/null
 	fi
-    bin/bazel_to_go.py
+        bin/bazel_to_go.py
+
+	# remove vendor directory from k8s client-go
+	rm -Rf vendor/k8s.io/client-go/vendor/
 }
 
 go_metalinter(){

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -50,6 +50,7 @@ type serverArgs struct {
 	// mixer manager args
 	serviceConfigFile      string
 	globalConfigFile       string
+	kubeConfig             string
 	configFetchIntervalSec uint
 }
 
@@ -81,6 +82,8 @@ func serverCmd(errorf errorFn) *cobra.Command {
 
 	serverCmd.PersistentFlags().StringVarP(&sa.serviceConfigFile, "serviceConfigFile", "", "serviceConfig.yml", "Combined Service Config")
 	serverCmd.PersistentFlags().StringVarP(&sa.globalConfigFile, "globalConfigFile", "", "globalConfig.yml", "Global Config")
+	serverCmd.PersistentFlags().StringVarP(&sa.kubeConfig, "kubeConfig", "", "", "kube Config")
+
 	serverCmd.PersistentFlags().UintVarP(&sa.configFetchIntervalSec, "configFetchInterval", "", 5, "Config fetch interval in seconds")
 
 	return &serverCmd
@@ -132,7 +135,7 @@ func runServer(sa *serverArgs) error {
 	eval := expr.NewIdentityEvaluator()
 	adapterMgr := adapterManager.NewManager(adapter.Inventory(), aspect.Inventory(), eval)
 	configManager := config.NewManager(eval, adapterMgr.AspectValidatorFinder(), adapterMgr.BuilderValidatorFinder(),
-		sa.globalConfigFile, sa.serviceConfigFile, time.Second*time.Duration(sa.configFetchIntervalSec))
+		sa.globalConfigFile, sa.serviceConfigFile, sa.kubeConfig, time.Second*time.Duration(sa.configFetchIntervalSec))
 	handler := api.NewHandler(adapterMgr, adapterMgr.AspectMap())
 
 	grpcServerOptions, err := serverOpts(sa, handler)

--- a/pkg/config/BUILD
+++ b/pkg/config/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "api.go",
+        "k8s.go",
         "manager.go",
         "runtime.go",
         "validator.go",
@@ -19,6 +20,11 @@ go_library(
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_mitchellh_mapstructure//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//pkg/api/v1:go_default_library",
+        "@io_k8s_client_go//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_client_go//tools/clientcmd:go_default_library",
     ],
 )
 
@@ -26,6 +32,7 @@ go_test(
     name = "small_tests",
     size = "small",
     srcs = [
+        "k8s_test.go",
         "runtime_test.go",
         "validator_test.go",
     ],

--- a/pkg/config/k8s.go
+++ b/pkg/config/k8s.go
@@ -1,0 +1,104 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	meta_v1 "k8s.io/client-go/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ConfigMapScheme defines url scheme for a config map.
+const ConfigMapScheme = "configmap"
+
+type (
+	readMap              func(ns string, mapName string) (*v1.ConfigMap, error)
+	buildConfigFromFlags func(masterUrl, kubeconfigPath string) (*rest.Config, error)
+	newForConfig         func(config *rest.Config) (*kubernetes.Clientset, error)
+
+	// K8sResourceFetcher provides ability to read from configMapUrl.
+	K8sResourceFetcher struct {
+		readMap              readMap
+		buildConfigFromFlags buildConfigFromFlags
+		newForConfig         newForConfig
+	}
+)
+
+// NewK8sResourceFetcher constructs a kubernetes resource fetcher.
+// if kubecofig is omitted, in-cluster or local config is used appropriately.
+func NewK8sResourceFetcher(kubeconfig string) (*K8sResourceFetcher, error) {
+	f := &K8sResourceFetcher{
+		buildConfigFromFlags: clientcmd.BuildConfigFromFlags,
+		newForConfig:         kubernetes.NewForConfig,
+	}
+	return f.newK8sResourceFetcher(kubeconfig)
+}
+
+func (f *K8sResourceFetcher) newK8sResourceFetcher(kubeconfig string) (*K8sResourceFetcher, error) {
+	// if not running in k8s, use standard local config.
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" && kubeconfig == "" {
+		kubeconfig = os.Getenv("HOME") + "/.kube/config"
+	}
+	config, err := f.buildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	k8sClient, err := f.newForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	f.readMap = func(ns string, mapName string) (*v1.ConfigMap, error) {
+		return k8sClient.ConfigMaps(ns).Get(mapName, meta_v1.GetOptions{})
+	}
+
+	return f, nil
+}
+
+// ReadFile reads the specified configmap resource
+func (f *K8sResourceFetcher) ReadFile(configMapURL string) ([]byte, error) {
+	u, err := url.Parse(configMapURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme != ConfigMapScheme {
+		return nil, fmt.Errorf("unknown url scheme %s", u.Scheme)
+	}
+
+	mapname := strings.TrimLeft(u.Path, "/")
+
+	cfg, err := f.readMap(u.Host, mapname)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.Data) > 1 {
+		glog.Warningf("map has multiple configs")
+	}
+	var data []byte
+	for _, v := range cfg.Data {
+		data = []byte(v)
+		break
+	}
+	return data, nil
+}

--- a/pkg/config/k8s_test.go
+++ b/pkg/config/k8s_test.go
@@ -1,0 +1,105 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+)
+
+func k8sRF(bErr error, nErr error) *K8sResourceFetcher {
+	return &K8sResourceFetcher{
+		buildConfigFromFlags: func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+			return nil, bErr
+		},
+		newForConfig: func(config *rest.Config) (*kubernetes.Clientset, error) {
+			return nil, nErr
+		},
+	}
+}
+
+func TestNewK8sResourceFetcherErrors(t *testing.T) {
+	_, err := NewK8sResourceFetcher("_DOES_NOT_EXIST_")
+	if err == nil {
+		t.Error("Expected failure")
+	}
+
+	ccErr := errors.New("client Creation Error")
+	f := k8sRF(nil, ccErr)
+	_, err = f.newK8sResourceFetcher("")
+	if err != ccErr {
+		t.Errorf("Got :%#v\nWant: %#v", err, ccErr)
+	}
+
+	f = k8sRF(nil, nil)
+	_, err = f.newK8sResourceFetcher("")
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+
+}
+
+func TestReadFile(t *testing.T) {
+	f := &K8sResourceFetcher{}
+
+	_, err := f.ReadFile("abc.txt")
+	substr := "unknown url scheme"
+	if err == nil || !strings.Contains(err.Error(), substr) {
+		t.Errorf("Got: %s, Want: %#v", err.Error(), substr)
+	}
+
+	_, err = f.ReadFile(":abc.txt")
+	substr = "missing protocol scheme"
+	if err == nil || !strings.Contains(err.Error(), substr) {
+		t.Errorf("Got: %s, Want: %#v", err.Error(), substr)
+	}
+
+	ccErr := errors.New("unable to read map")
+	f = &K8sResourceFetcher{
+		readMap: func(ns string, mapName string) (*v1.ConfigMap, error) {
+			return nil, ccErr
+		},
+	}
+	_, err = f.ReadFile(ConfigMapScheme + "://abc.txt")
+	if err != ccErr {
+		t.Errorf("Got: %#v\nWant: %#v", err, ccErr)
+	}
+
+	contents := "Got This File"
+	f = &K8sResourceFetcher{
+		readMap: func(ns string, mapName string) (*v1.ConfigMap, error) {
+			return &v1.ConfigMap{
+				Data: map[string]string{
+					"c0": contents,
+					"c1": contents,
+				},
+			}, nil
+		},
+	}
+
+	b, err := f.ReadFile(ConfigMapScheme + "://abc.txt")
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+
+	if string(b[:]) != contents {
+		t.Errorf("Got: %s\nWant: %s", string(b[:]), contents)
+	}
+}

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -95,7 +95,7 @@ func TestConfigManager(t *testing.T) {
 }
 
 func newmanager(args *managerArgs) *Manager {
-	return NewManager(args.eval, args.aspectFinder, args.builderFinder, args.globalConfig, args.serviceConfig, args.loopDelay)
+	return NewManager(args.eval, args.aspectFinder, args.builderFinder, args.globalConfig, args.serviceConfig, args.kubeConfig, args.loopDelay)
 }
 
 type managerArgs struct {
@@ -105,6 +105,7 @@ type managerArgs struct {
 	loopDelay     time.Duration
 	globalConfig  string
 	serviceConfig string
+	kubeConfig    string
 }
 
 func testConfigManager(t *testing.T, mgr *Manager, mt mtest, idx int, loopDelay time.Duration) {


### PR DESCRIPTION
--serviceConfigFile and --globalConfigFile can be specified as
configmap://{namespace}/mapname 
kubeconfig it automatically detected, but it can also be specified.


Since this PR brings in k8s client-go, it adds many dependencies to WORKSPACE.
Some dependencies require auto build file generation. This may fail on a Mac if your file system is `case insensitive`.
To fix it create a `case sensitive` partition on the Mac and point bazel to it.
```--output_base=/Volumes/casesentitive/BAZEL_OUT```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/210)
<!-- Reviewable:end -->
