### PR TITLE
Add support for simple evalPredicate

### DIFF
--- a/pkg/expr/BUILD
+++ b/pkg/expr/BUILD
@@ -7,7 +7,10 @@ go_library(
         "identity.go",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//pkg/attribute:go_default_library"],
+    deps = [
+        "//pkg/attribute:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/expr/identity.go
+++ b/pkg/expr/identity.go
@@ -22,11 +22,13 @@ import (
 	"istio.io/mixer/pkg/attribute"
 )
 
-// identity is an evaluator that expects mapExpression to be a key in the attribute bag. It does no evaluation, only lookup.
+// identity is an evaluator that expects mapExpression to be a key in the attribute bag.
+// It does equality-only evaluation in EvalPredicate.
+// Otherwise it does no evaluation, only lookup.
 type identity struct{}
 
-// NewIdentityEvaluator returns an evaluator that performs no evaluations; instead it uses the provided mapExpression
-// as the key into the attribute bag.
+// NewIdentityEvaluator returns an evaluator that performs equality-only evaluation in EvalPredicate;
+// Otherwise it uses the provided mapExpression as the key into the attribute bag.
 func NewIdentityEvaluator() Evaluator {
 	return identity{}
 }
@@ -36,7 +38,7 @@ func (identity) Eval(mapExpression string, bag attribute.Bag) (interface{}, erro
 	if val, found := attribute.Value(bag, mapExpression); found {
 		return val, nil
 	}
-	return nil, fmt.Errorf("%s not in attribute bag", mapExpression)
+	return nil, fmt.Errorf("missing attribute %s", mapExpression)
 }
 
 // EvalString attempts to extract the key `mapExpression` from the set of string attributes in the bag. It performs no evaluation.
@@ -44,7 +46,7 @@ func (identity) EvalString(mapExpression string, bag attribute.Bag) (string, err
 	if val, exists := bag.String(mapExpression); exists {
 		return val, nil
 	}
-	return "", fmt.Errorf("%s not in attribute bag", mapExpression)
+	return "", fmt.Errorf("missing attribute %s", mapExpression)
 }
 
 // resolve if a symbol starts with '$' attribute is accessed, otherwise it is treated as a constant

--- a/pkg/expr/identity.go
+++ b/pkg/expr/identity.go
@@ -50,7 +50,7 @@ func (identity) EvalString(mapExpression string, bag attribute.Bag) (string, err
 }
 
 // resolve if a symbol starts with '$' attribute is accessed, otherwise it is treated as a constant
-func resolve(sym string, bag attribute.Bag) (ret interface{}, err error) {
+func resolve(sym string, bag attribute.Bag) (interface{}, error) {
 	if !strings.HasPrefix(sym, "$") {
 		return sym, nil
 	}
@@ -59,6 +59,7 @@ func resolve(sym string, bag attribute.Bag) (ret interface{}, err error) {
 	}
 
 	var found bool
+	var ret interface{}
 
 	if ret, found = attribute.Value(bag, sym[1:]); !found {
 		return false, fmt.Errorf("unresolved attribute %s", sym[1:])

--- a/pkg/expr/identity_test.go
+++ b/pkg/expr/identity_test.go
@@ -25,6 +25,8 @@ import (
 
 	"strings"
 
+	"fmt"
+
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/mixer/pkg/attribute"
 )
@@ -199,19 +201,19 @@ func TestEvalPredicate(t *testing.T) {
 			t.Errorf("[%d] Unexpected error %s", idx, err.Error())
 		}
 		val, err := id.EvalPredicate(c.in, bag)
-		if c.err != "" && err == nil {
-			t.Errorf("[%d] Expected err on case '%+v' but got none. val=#%v", idx, c, val)
-		}
-		if c.err == "" && err != nil {
-			t.Errorf("[%d] Failed to eval mapExpression '%s' in bag: %v; with err: %v", idx, c.in, bag, err)
-		}
-		if c.err != "" && err != nil {
-			if !strings.Contains(err.Error(), c.err) {
-				t.Errorf("[%d] Got :%s\nWant: %s", idx, err, c.err)
+		if c.err != "" { // error is expected
+			errStr := fmt.Sprintf("%s", err)
+			if !strings.Contains(errStr, c.err) {
+				t.Errorf("[%d] Got :%s\nWant: %s", idx, errStr, c.err)
 			}
-		}
-		if c.err == "" && val != c.out {
-			t.Errorf("[%d] Expected val '%v' for key '%s', actual '%v'", idx, c.out, c.in, val)
+		} else { // no error expected
+			if err == nil {
+				if val != c.out {
+					t.Errorf("[%d] Expected val '%v' for key '%s', actual '%v'", idx, c.out, c.in, val)
+				}
+			} else {
+				t.Errorf("[%d] Unexpected error %s evaluating mapExpression '%s'", idx, c.in, err)
+			}
 		}
 	}
 }

--- a/pkg/expr/identity_test.go
+++ b/pkg/expr/identity_test.go
@@ -23,6 +23,8 @@ import (
 	"bytes"
 	"time"
 
+	"strings"
+
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/mixer/pkg/attribute"
 )
@@ -143,38 +145,73 @@ func TestEvalPredicate(t *testing.T) {
 		attrs *mixerpb.Attributes
 		in    string
 		out   interface{}
-		err   bool
+		err   string
 	}{
 		// We cannot test ByteAttributes here because you cannot compare []byte using '==' or '!='
 		{attrs: &mixerpb.Attributes{
 			Dictionary:       dictionary{1: "foo", 2: "bar"},
 			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
-		}, in: "bar", out: "bar", err: true},
-		{attrs: &mixerpb.Attributes{Dictionary: dictionary{4: "i64"}, Int64Attributes: map[int32]int64{4: 37}}, in: "i64", out: int64(0), err: true},
-		{attrs: &mixerpb.Attributes{Dictionary: dictionary{17: "dbl"}, DoubleAttributes: map[int32]float64{17: 5.9}}, in: "dbl", out: 0, err: true},
+		}, in: "badExpr1", out: "bar", err: "invalid expression"},
 		{attrs: &mixerpb.Attributes{
-			Dictionary:       dictionary{0: "bool", 1: "str"},
-			BoolAttributes:   map[int32]bool{0: true},
-			StringAttributes: map[int32]string{1: "foo"},
-		}, in: "bool", out: true, err: false},
-		{attrs: &mixerpb.Attributes{Dictionary: dictionary{5: "time"}, TimestampAttributes: map[int32]*ts.Timestamp{5: ts1}}, in: "time", out: nil, err: true},
-		{attrs: &mixerpb.Attributes{Dictionary: dictionary{2: "a"}, BoolAttributes: map[int32]bool{2: true}}, in: "b", out: false, err: true},
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "badExpr2==", out: false, err: ""},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "$badExpr3==", out: "bar", err: "unresolved attribute"},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "==$badExpr3", out: "bar", err: "unresolved attribute"},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "==$", out: "bar", err: "empty attribute name"},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "$bar==bar", out: true, err: ""},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "$bar==foo", out: false, err: ""},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "$bar==foo", out: false, err: ""},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "bar"},
+		}, in: "$bar == $foo", out: false, err: ""},
+		{attrs: &mixerpb.Attributes{
+			Dictionary:       dictionary{1: "foo", 2: "bar"},
+			StringAttributes: map[int32]string{1: "foo", 2: "foo"},
+		}, in: "$bar == $foo", out: true, err: ""},
 	}
-	for _, c := range cases {
+	for idx, c := range cases {
 		bag, err := attribute.NewManager().NewTracker().StartRequest(c.attrs)
 		if err != nil {
 			t.Errorf("Failed to create bag for case: %v; err: %v", c, err)
 		}
 		id := NewIdentityEvaluator()
+		if err = id.Validate(c.in); err != nil {
+			t.Errorf("[%d] Unexpected error %s", idx, err.Error())
+		}
 		val, err := id.EvalPredicate(c.in, bag)
-		if c.err && err == nil {
-			t.Errorf("Expected err on case '%+v' but got none.", c)
+		if c.err != "" && err == nil {
+			t.Errorf("[%d] Expected err on case '%+v' but got none. val=#%v", idx, c, val)
 		}
-		if !c.err && err != nil {
-			t.Errorf("Failed to eval mapExpression '%s' in bag: %v; with err: %v", c.in, bag, err)
+		if c.err == "" && err != nil {
+			t.Errorf("[%d] Failed to eval mapExpression '%s' in bag: %v; with err: %v", idx, c.in, bag, err)
 		}
-		if !c.err && val != c.out {
-			t.Errorf("Expected val '%v' for key '%s', actual '%v'", c.out, c.in, val)
+		if c.err != "" && err != nil {
+			if !strings.Contains(err.Error(), c.err) {
+				t.Errorf("[%d] Got :%s\nWant: %s", idx, err, c.err)
+			}
+		}
+		if c.err == "" && val != c.out {
+			t.Errorf("[%d] Expected val '%v' for key '%s', actual '%v'", idx, c.out, c.in, val)
 		}
 	}
 }


### PR DESCRIPTION
Single attribute is evaluated for equality
'$' is used as an attribute designator

selector: $service_name == abcd
or
selector: $request_status_code == 200

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/217)
<!-- Reviewable:end -->
