### PR TITLE
Update to rules_go latest commit.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "com_github_istio_mixer")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "2c6fa767100b95799043451aa3ee221d9a9bbb55",
+    commit = "7828452850597b52b49ec603b23f8ad2bcb22aed",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "com_github_istio_mixer")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "7828452850597b52b49ec603b23f8ad2bcb22aed",
+    commit = "76c63b5cd0d47c1f2b47ab4953db96c574af1c1d",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 


### PR DESCRIPTION
This should alleviate issues with bazel 0.4.4 migration and help keep us somewhat current with the evolution of go support in bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/221)
<!-- Reviewable:end -->
