### PR TITLE
Modify travis docker scripts to use bazel cache.

### DIFF
--- a/docker/gcloud_build.sh
+++ b/docker/gcloud_build.sh
@@ -4,6 +4,11 @@ set -ex
 
 gcloud docker --authorize-only
 
-bazel run //docker:mixer gcr.io/$PROJECT/mixer:experiment
+if [ -z $BAZEL_OUTBASE ]
+then
+    bazel run //docker:mixer gcr.io/$PROJECT/mixer:experiment
+else
+    bazel --output_base=$BAZEL_OUTBASE run //docker:mixer gcr.io/$PROJECT/mixer:experiment
+fi
 
 gcloud docker -- push gcr.io/$PROJECT/mixer:experiment

--- a/docker/travis_gcloud.sh
+++ b/docker/travis_gcloud.sh
@@ -2,6 +2,7 @@
 set -ev
 
 export PROJECT="istio-testing"
+export BAZEL_OUTBASE=$HOME/bazel/outbase
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 	openssl aes-256-cbc -K $encrypted_2f660428f0db_key -iv $encrypted_2f660428f0db_iv -in $PROJECT.json.enc -out $PROJECT.json -d


### PR DESCRIPTION
This is meant to address the long build times on merges and close out work on issue #195.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/230)
<!-- Reviewable:end -->
