### PR TITLE
Add mechanism for passing metrics descriptor info to adapters.

### DIFF
--- a/adapter/prometheus/prometheus.go
+++ b/adapter/prometheus/prometheus.go
@@ -54,8 +54,7 @@ func (f *factory) Close() error {
 	return f.srv.Close()
 }
 
-func (f *factory) NewMetricsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.MetricsAspect, error) {
-
+func (f *factory) NewMetricsAspect(env adapter.Env, cfg adapter.AspectConfig, metrics []adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	var serverErr error
 	f.once.Do(func() { serverErr = f.srv.Start(env.Logger()) })
 	if serverErr != nil {

--- a/pkg/adapter/metrics.go
+++ b/pkg/adapter/metrics.go
@@ -19,11 +19,21 @@ import (
 	"time"
 )
 
+// Metric kinds supported by mixer.
 const (
-	// GAUGE is used to record instantaneous (non-cumulative) measurement
-	GAUGE Kind = iota
-	// COUNTER is used to record increasing cumulative values.
-	COUNTER
+	Gauge   Kind = iota // records instantaneous (non-cumulative) measurements
+	Counter             // records increasing cumulative values
+)
+
+// Label kinds supported by mixer.
+const (
+	String LabelKind = iota
+	Int64
+	Float64
+	Bool
+	Time
+	IPAddress
+	URL
 )
 
 type (
@@ -61,7 +71,7 @@ type (
 	}
 
 	// Kind defines the set of known metrics types that can be generated
-	// by istio.
+	// by the mixer.
 	Kind int
 
 	// MetricsBuilder builds instances of the Metrics aspect.
@@ -80,9 +90,13 @@ type (
 		// Kind provides type information about the metric.
 		Kind Kind
 		// Labels are the names of keys for dimensional data that will
-		// generated at runtime and passed along with metric values.
-		Labels []string
+		// be generated at runtime and passed along with metric values.
+		Labels map[string]LabelKind
 	}
+
+	// LabelKind defines the set of known label types that can be generated
+	// by the mixer.
+	LabelKind int
 )
 
 // String returns the string-valued metric value for a metrics.Value.

--- a/pkg/adapter/metrics.go
+++ b/pkg/adapter/metrics.go
@@ -69,7 +69,19 @@ type (
 		Builder
 
 		// NewMetricsAspect returns a new instance of the Metrics aspect.
-		NewMetricsAspect(env Env, config AspectConfig) (MetricsAspect, error)
+		NewMetricsAspect(env Env, config AspectConfig, metrics []MetricDefinition) (MetricsAspect, error)
+	}
+
+	// MetricDefinition provides the basic description of a metric schema
+	// for which metrics adapters will be sent Values at runtime.
+	MetricDefinition struct {
+		// Name is the canonical name of the metric.
+		Name string
+		// Kind provides type information about the metric.
+		Kind Kind
+		// Labels are the names of keys for dimensional data that will
+		// generated at runtime and passed along with metric values.
+		Labels []string
 	}
 )
 

--- a/pkg/adapter/metrics.go
+++ b/pkg/adapter/metrics.go
@@ -33,7 +33,9 @@ const (
 	Bool
 	Time
 	IPAddress
-	URL
+	EmailAddress
+	URI
+	DNSName
 )
 
 type (


### PR DESCRIPTION
This PR creates a basic MetricDefinition type and alters the NewMetrics() signature to pass in a list of definitions at build time.

Metrics backends will likely need to know what metrics they will be receiving values for before those values come streaming in. Prometheus, for example, will want to register metrics once up front, and then create observations against that registry when values are passed in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/231)
<!-- Reviewable:end -->
