### PR TITLE
Change Close() ordering in attempt to avoid flakiness in test.

### DIFF
--- a/adapter/prometheus/server_test.go
+++ b/adapter/prometheus/server_test.go
@@ -42,14 +42,11 @@ func TestServer(t *testing.T) {
 		t.Fatalf("Failed to retrieve '%s' path: %v", metricsPath, err)
 	}
 
-	defer func() {
-		err := resp.Body.Close()
-		t.Logf("Error closing response body: %v", err)
-	}()
-
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("http.GET => %v, wanted '%v'", resp.StatusCode, http.StatusOK)
 	}
+
+	_ = resp.Body.Close()
 
 	if err := s.Close(); err != nil {
 		t.Errorf("Failed to close server properly: %v", err)


### PR DESCRIPTION
There are apparently known issus with net.Listener on Linux systems still accepting connections even after Close(). If this approach doesn't fix the issue with the test, I suggest that we just remove the final check in the test and live with slightly less coverage. When we move to 1.8 in (relatively) short-order, graceful shutdown, etc., will be possible and should change the nature of this test anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/240)
<!-- Reviewable:end -->
