### PR TITLE
Switch memQuota's dedup window from int32 to google.protobuf.Duration.

### DIFF
--- a/adapter/memQuota/BUILD
+++ b/adapter/memQuota/BUILD
@@ -11,6 +11,8 @@ go_library(
     deps = [
         "//adapter/memQuota/config:go_default_library",
         "//pkg/adapter:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
     ],
 )
 

--- a/adapter/memQuota/config/BUILD
+++ b/adapter/memQuota/config/BUILD
@@ -2,9 +2,18 @@ load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogo_proto_library")
 
 gogo_proto_library(
     name = "go_default_library",
+    imports = [
+        "external/com_github_google_protobuf/src",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
     protos = [
         "config.proto",
     ],
     verbose = 0,
     visibility = ["//adapter/memQuota:__pkg__"],
+    deps = [
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+    ],
 )

--- a/adapter/memQuota/config/config.proto
+++ b/adapter/memQuota/config/config.proto
@@ -16,9 +16,11 @@ syntax = "proto3";
 
 package adapter.memQuota.config;
 
+import "google/protobuf/duration.proto";
+
 option go_package="config";
 
 message Params {
 	// Minimum number of seconds that deduplication is possible for a given operation.
-	int32 min_deduplication_window_seconds = 1;
+	google.protobuf.Duration min_deduplication_duration = 1;
 }

--- a/adapter/memQuota/rollingWindow.go
+++ b/adapter/memQuota/rollingWindow.go
@@ -25,7 +25,7 @@ type rollingWindow struct {
 	currentSlot int
 
 	// the tick count associated with the current slot
-	currentSlotTick int32
+	currentSlotTick int64
 
 	// the total # of units currently available in the window
 	avail int64
@@ -39,14 +39,14 @@ type rollingWindow struct {
 // The ticksPerWindow parameter determines the number of quantized time intervals within the window.
 // When quota is allocated, it belongs to the current tick. As time marches on,
 // the quota associated with older ticks is reclaimed.
-func newRollingWindow(limit int64, ticksInWindow int32) *rollingWindow {
+func newRollingWindow(limit int64, ticksInWindow int64) *rollingWindow {
 	return &rollingWindow{
 		avail: limit,
 		slots: make([]int64, ticksInWindow),
 	}
 }
 
-func (w *rollingWindow) alloc(amount int64, currentTick int32) bool {
+func (w *rollingWindow) alloc(amount int64, currentTick int64) bool {
 	w.roll(currentTick)
 
 	if amount > w.avail {
@@ -61,7 +61,7 @@ func (w *rollingWindow) alloc(amount int64, currentTick int32) bool {
 	return true
 }
 
-func (w *rollingWindow) release(amount int64, currentTick int32) int64 {
+func (w *rollingWindow) release(amount int64, currentTick int64) int64 {
 	w.roll(currentTick)
 
 	// we release from the leading edge of the window moving back in time
@@ -91,7 +91,7 @@ func (w *rollingWindow) release(amount int64, currentTick int32) int64 {
 	return total
 }
 
-func (w *rollingWindow) roll(currentTick int32) {
+func (w *rollingWindow) roll(currentTick int64) {
 	// how many ticks has the window moved since we were last here?
 	behind := int(currentTick - w.currentSlotTick)
 	if behind > len(w.slots) {

--- a/adapter/memQuota/rollingWindow_test.go
+++ b/adapter/memQuota/rollingWindow_test.go
@@ -21,7 +21,7 @@ import (
 func TestAlloc(t *testing.T) {
 	cases := []struct {
 		amount int64
-		tick   int32
+		tick   int64
 		avail  int64
 		result bool
 	}{
@@ -58,9 +58,9 @@ func TestAlloc(t *testing.T) {
 func TestRelease(t *testing.T) {
 	cases := []struct {
 		allocAmount   int64
-		allocTick     int32
+		allocTick     int64
 		releaseAmount int64
-		releaseTick   int32
+		releaseTick   int64
 		releaseResult int64
 		avail         int64
 	}{


### PR DESCRIPTION
Also, increase memQuota adapter test coverage to 100%. Covering this last line
of functionality made me realize my rolling window counters would overflow, so
I bumped these to 64 bits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/247)
<!-- Reviewable:end -->
