### PR TITLE
Tag docker images with date (and build number).

### DIFF
--- a/docker/gcloud_build.sh
+++ b/docker/gcloud_build.sh
@@ -16,4 +16,7 @@ else
     bazel --output_base=$BAZEL_OUTBASE run //docker:mixer gcr.io/$PROJECT/mixer:$DOCKER_TAG
 fi
 
+docker tag gcr.io/$PROJECT/mixer:$DOCKER_TAG gcr.io/$PROJECT/mixer:latest
+
 gcloud docker -- push gcr.io/$PROJECT/mixer:$DOCKER_TAG
+gcloud docker -- push gcr.io/$PROJECT/mixer:latest

--- a/docker/gcloud_build.sh
+++ b/docker/gcloud_build.sh
@@ -4,11 +4,16 @@ set -ex
 
 gcloud docker --authorize-only
 
-if [ -z $BAZEL_OUTBASE ]
+if [ -z $DOCKER_TAG ]
 then
-    bazel run //docker:mixer gcr.io/$PROJECT/mixer:experiment
-else
-    bazel --output_base=$BAZEL_OUTBASE run //docker:mixer gcr.io/$PROJECT/mixer:experiment
+    export DOCKER_TAG=experiment
 fi
 
-gcloud docker -- push gcr.io/$PROJECT/mixer:experiment
+if [ -z $BAZEL_OUTBASE ]
+then
+    bazel run //docker:mixer gcr.io/$PROJECT/mixer:$DOCKER_TAG
+else
+    bazel --output_base=$BAZEL_OUTBASE run //docker:mixer gcr.io/$PROJECT/mixer:$DOCKER_TAG
+fi
+
+gcloud docker -- push gcr.io/$PROJECT/mixer:$DOCKER_TAG

--- a/docker/travis_gcloud.sh
+++ b/docker/travis_gcloud.sh
@@ -4,6 +4,9 @@ set -ev
 export PROJECT="istio-testing"
 export BAZEL_OUTBASE=$HOME/bazel/outbase
 
+today=$(date +%F)
+export DOCKER_TAG=$today-${TRAVIS_BUILD_NUMBER}
+
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 	openssl aes-256-cbc -K $encrypted_2f660428f0db_key -iv $encrypted_2f660428f0db_iv -in $PROJECT.json.enc -out $PROJECT.json -d
 


### PR DESCRIPTION
Since bazel strips out the date information (to give us repeatable builds!), this
will add a helpful way to distinguish between images, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/251)
<!-- Reviewable:end -->
