### PR TITLE
Clean up metrics related code

### DIFF
--- a/adapter/prometheus/prometheus.go
+++ b/adapter/prometheus/prometheus.go
@@ -136,6 +136,9 @@ func (p *prom) Record(vals []adapter.Value) error {
 func (*prom) Close() error { return nil }
 
 func newCounterVec(name, desc string, labels map[string]adapter.LabelType) *prometheus.CounterVec {
+	if desc == "" {
+		desc = name
+	}
 	c := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: safeName(name),
@@ -147,6 +150,9 @@ func newCounterVec(name, desc string, labels map[string]adapter.LabelType) *prom
 }
 
 func newGaugeVec(name, desc string, labels map[string]adapter.LabelType) *prometheus.GaugeVec {
+	if desc == "" {
+		desc = name
+	}
 	c := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: safeName(name),

--- a/adapter/prometheus/prometheus.go
+++ b/adapter/prometheus/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/adapter/prometheus/prometheus_test.go
+++ b/adapter/prometheus/prometheus_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/adapter/prometheus/server.go
+++ b/adapter/prometheus/server.go
@@ -61,10 +61,9 @@ func (s *serverInst) Start(logger adapter.Logger) error {
 	}
 
 	http.Handle(metricsPath, promhttp.Handler())
-
 	go func() {
-		err := srv.Serve(listener.(*net.TCPListener))
-		if err != nil {
+		logger.Infof("serving prometheus metrics on %s", s.addr)
+		if err := srv.Serve(listener.(*net.TCPListener)); err != nil {
 			_ = logger.Errorf("prometheus HTTP server error: %v", err)
 		}
 	}()

--- a/adapter/prometheus/server.go
+++ b/adapter/prometheus/server.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/adapter/prometheus/server_test.go
+++ b/adapter/prometheus/server_test.go
@@ -19,19 +19,13 @@ import (
 	"net/http"
 	"testing"
 
-	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/adapter/test"
 )
-
-type testLogger struct {
-	adapter.Logger
-}
-
-func (t testLogger) Errorf(format string, args ...interface{}) error { return nil }
 
 func TestServer(t *testing.T) {
 	testAddr := "127.0.0.1:9992"
 	s := newServer(testAddr)
-	if err := s.Start(testLogger{}); err != nil {
+	if err := s.Start(test.NewEnv(t).Logger()); err != nil {
 		t.Fatalf("Start() failed unexpectedly: %v", err)
 	}
 

--- a/adapter/prometheus/server_test.go
+++ b/adapter/prometheus/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -207,11 +207,10 @@ func TestAccessLoggerWrapper_Execute(t *testing.T) {
 		mapper      expr.Evaluator
 		wantEntries []adapter.LogEntry
 	}{
-
-		{"empty bag with defaults", commonExec, &test.Bag{}, &test.Evaluator{}, []adapter.LogEntry{emptyEntry}},
-		{"attrs in bag", commonExec, &test.Bag{Strs: map[string]string{"originIp": "127.0.0.1"}}, &test.Evaluator{}, []adapter.LogEntry{sourceEntry}},
-		{"attrs from inputs", commonExecWithInputs, &test.Bag{}, &test.Evaluator{}, []adapter.LogEntry{sourceEntry}},
-		{"custom - no attrs", customEmpty, &test.Bag{}, &test.Evaluator{}, nil},
+		{"empty bag with defaults", commonExec, &test.Bag{}, test.NewIDEval(), []adapter.LogEntry{emptyEntry}},
+		{"attrs in bag", commonExec, &test.Bag{Strs: map[string]string{"originIp": "127.0.0.1"}}, test.NewIDEval(), []adapter.LogEntry{sourceEntry}},
+		{"attrs from inputs", commonExecWithInputs, &test.Bag{}, test.NewIDEval(), []adapter.LogEntry{sourceEntry}},
+		{"custom - no attrs", customEmpty, &test.Bag{}, test.NewIDEval(), nil},
 	}
 
 	for _, v := range tests {
@@ -253,7 +252,7 @@ func TestAccessLoggerWrapper_ExecuteFailures(t *testing.T) {
 		bag    attribute.Bag
 		mapper expr.Evaluator
 	}{
-		{"LogAccess() error", logErrExec, &test.Bag{}, &test.Evaluator{}},
+		{"LogAccess() error", logErrExec, &test.Bag{}, test.NewIDEval()},
 	}
 
 	for _, v := range tests {

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -207,10 +207,10 @@ func TestAccessLoggerWrapper_Execute(t *testing.T) {
 		mapper      expr.Evaluator
 		wantEntries []adapter.LogEntry
 	}{
-		{"empty bag with defaults", commonExec, &test.Bag{}, test.NewIDEval(), []adapter.LogEntry{emptyEntry}},
+		{"empty bag with defaults", commonExec, test.NewBag(), test.NewIDEval(), []adapter.LogEntry{emptyEntry}},
 		{"attrs in bag", commonExec, &test.Bag{Strs: map[string]string{"originIp": "127.0.0.1"}}, test.NewIDEval(), []adapter.LogEntry{sourceEntry}},
-		{"attrs from inputs", commonExecWithInputs, &test.Bag{}, test.NewIDEval(), []adapter.LogEntry{sourceEntry}},
-		{"custom - no attrs", customEmpty, &test.Bag{}, test.NewIDEval(), nil},
+		{"attrs from inputs", commonExecWithInputs, test.NewBag(), test.NewIDEval(), []adapter.LogEntry{sourceEntry}},
+		{"custom - no attrs", customEmpty, test.NewBag(), test.NewIDEval(), nil},
 	}
 
 	for _, v := range tests {
@@ -252,7 +252,7 @@ func TestAccessLoggerWrapper_ExecuteFailures(t *testing.T) {
 		bag    attribute.Bag
 		mapper expr.Evaluator
 	}{
-		{"LogAccess() error", logErrExec, &test.Bag{}, test.NewIDEval()},
+		{"LogAccess() error", logErrExec, test.NewBag(), test.NewIDEval()},
 	}
 
 	for _, v := range tests {

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -179,17 +179,17 @@ func TestLoggerManager_Execute(t *testing.T) {
 		mapper      expr.Evaluator
 		wantEntries []adapter.LogEntry
 	}{
-		{"no descriptors", noDescriptorExec, &test.Bag{}, &test.Evaluator{}, nil},
-		{"no payload", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value"}}, &test.Evaluator{}, []adapter.LogEntry{defaultEntry}},
-		{"severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "info"}}, &test.Evaluator{}, []adapter.LogEntry{infoEntry}},
-		{"bad severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "500"}}, &test.Evaluator{}, []adapter.LogEntry{defaultEntry}},
-		{"payload not found", payloadExec, &test.Bag{Strs: map[string]string{"key": "value"}}, &test.Evaluator{}, []adapter.LogEntry{defaultEntry}},
-		{"with payload", payloadExec, &test.Bag{Strs: map[string]string{"key": "value", "payload": "test"}}, &test.Evaluator{}, []adapter.LogEntry{textPayloadEntry}},
-		{"with json payload", jsonPayloadExec, jsonBag, &test.Evaluator{}, []adapter.LogEntry{jsonPayloadEntry}},
-		{"with payload from inputs", withInputsExec, &test.Bag{Strs: map[string]string{"key": "value"}}, &test.Evaluator{}, []adapter.LogEntry{inputsEntry}},
-		{"with non-default time", payloadExec, &test.Bag{Times: map[string]time.Time{"ts": time.Now()}}, &test.Evaluator{}, []adapter.LogEntry{defaultEntry}},
-		{"with non-default time and format", withTimestampFormatExec, tsBag, &test.Evaluator{}, []adapter.LogEntry{timeEntry}},
-		{"with inputs", withInputsExec, &test.Bag{Strs: map[string]string{"key": "value", "payload": "test"}}, &test.Evaluator{}, []adapter.LogEntry{inputsEntry}},
+		{"no descriptors", noDescriptorExec, &test.Bag{}, test.NewIDEval(), nil},
+		{"no payload", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
+		{"severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "info"}}, test.NewIDEval(), []adapter.LogEntry{infoEntry}},
+		{"bad severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "500"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
+		{"payload not found", payloadExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
+		{"with payload", payloadExec, &test.Bag{Strs: map[string]string{"key": "value", "payload": "test"}}, test.NewIDEval(), []adapter.LogEntry{textPayloadEntry}},
+		{"with json payload", jsonPayloadExec, jsonBag, test.NewIDEval(), []adapter.LogEntry{jsonPayloadEntry}},
+		{"with payload from inputs", withInputsExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval(), []adapter.LogEntry{inputsEntry}},
+		{"with non-default time", payloadExec, &test.Bag{Times: map[string]time.Time{"ts": time.Now()}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
+		{"with non-default time and format", withTimestampFormatExec, tsBag, test.NewIDEval(), []adapter.LogEntry{timeEntry}},
+		{"with inputs", withInputsExec, &test.Bag{Strs: map[string]string{"key": "value", "payload": "test"}}, test.NewIDEval(), []adapter.LogEntry{inputsEntry}},
 	}
 
 	for _, v := range executeShouldSucceed {
@@ -234,8 +234,8 @@ func TestLoggerManager_ExecuteFailures(t *testing.T) {
 		bag    attribute.Bag
 		mapper expr.Evaluator
 	}{
-		{"log failure", errorExec, &test.Bag{Strs: map[string]string{"key": "value"}}, &test.Evaluator{}},
-		{"json payload failure", jsonErrorExec, jsonPayloadBag, &test.Evaluator{}},
+		{"log failure", errorExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval()},
+		{"json payload failure", jsonErrorExec, jsonPayloadBag, test.NewIDEval()},
 	}
 
 	for _, v := range executeShouldFail {

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ func TestLoggerManager_Execute(t *testing.T) {
 		mapper      expr.Evaluator
 		wantEntries []adapter.LogEntry
 	}{
-		{"no descriptors", noDescriptorExec, &test.Bag{}, test.NewIDEval(), nil},
+		{"no descriptors", noDescriptorExec, test.NewBag(), test.NewIDEval(), nil},
 		{"no payload", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
 		{"severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "info"}}, test.NewIDEval(), []adapter.LogEntry{infoEntry}},
 		{"bad severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "500"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},

--- a/pkg/aspect/inventory.go
+++ b/pkg/aspect/inventory.go
@@ -98,12 +98,14 @@ func Inventory() ManagerInventory {
 		CheckMethod: {
 			NewDenialsManager(),
 			NewListsManager(),
+			NewMetricsManager(),
 			NewQuotasManager(),
 		},
 
 		ReportMethod: {
 			NewApplicationLogsManager(),
 			NewAccessLogsManager(),
+			NewMetricsManager(),
 		},
 
 		QuotaMethod: {},

--- a/pkg/aspect/inventory.go
+++ b/pkg/aspect/inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/genproto/googleapis/rpc/code"
 
@@ -40,6 +41,7 @@ type (
 	}
 
 	metricsWrapper struct {
+		name     string
 		aspect   adapter.MetricsAspect
 		metadata map[string]*metricInfo // metric name -> info
 	}
@@ -58,9 +60,10 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 	// TODO: sync these schemas with the new standardized metric schemas.
 	desc := []*dpb.MetricDescriptor{
 		{
-			Name:  "request_count",
-			Kind:  dpb.COUNTER,
-			Value: dpb.INT64,
+			Name:        "request_count",
+			Kind:        dpb.COUNTER,
+			Value:       dpb.INT64,
+			Description: "request count by source, target, service, and code",
 			Labels: []*dpb.LabelDescriptor{
 				{Name: "source", ValueType: dpb.STRING},
 				{Name: "target", ValueType: dpb.STRING},
@@ -69,9 +72,10 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 			},
 		},
 		{
-			Name:  "request_latency",
-			Kind:  dpb.COUNTER, // TODO: nail this down; as is we'll have to do post-processing
-			Value: dpb.DURATION,
+			Name:        "request_latency",
+			Kind:        dpb.COUNTER, // TODO: nail this down; as is we'll have to do post-processing
+			Value:       dpb.DURATION,
+			Description: "request latency by source, target, and service",
 			Labels: []*dpb.LabelDescriptor{
 				{Name: "source", ValueType: dpb.STRING},
 				{Name: "target", ValueType: dpb.STRING},
@@ -104,12 +108,12 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 			labels:     metric.Labels,
 		}
 	}
-
-	asp, err := a.(adapter.MetricsBuilder).NewMetricsAspect(env, c.Builder.Params.(adapter.AspectConfig), defs)
+	b := a.(adapter.MetricsBuilder)
+	asp, err := b.NewMetricsAspect(env, c.Builder.Params.(adapter.AspectConfig), defs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct metrics aspect with config '%v' and err: %s", c, err)
 	}
-	return &metricsWrapper{asp, metadata}, nil
+	return &metricsWrapper{b.Name(), asp, metadata}, nil
 }
 
 func (*metricsManager) Kind() Kind                          { return MetricsKind }
@@ -164,6 +168,10 @@ func (w *metricsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator) (*O
 	if len(values) > 0 {
 		out = &Output{Code: code.Code_OK}
 	}
+	if glog.V(4) {
+		glog.V(4).Infof("completed execution of metric adapter '%s' for %d values", w.name, len(values))
+	}
+
 	return out, result.ErrorOrNil()
 }
 
@@ -201,9 +209,10 @@ func definitionFromProto(desc *dpb.MetricDescriptor) (*adapter.MetricDefinition,
 			desc.Name, desc.Kind, err)
 	}
 	return &adapter.MetricDefinition{
-		Name:   desc.Name,
-		Kind:   kind,
-		Labels: labels,
+		Name:        desc.Name,
+		Description: desc.Description,
+		Kind:        kind,
+		Labels:      labels,
 	}, nil
 }
 

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Istio Authors.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -23,34 +23,14 @@ import (
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
-	"istio.io/mixer/pkg/adapter/test"
+	atest "istio.io/mixer/pkg/adapter/test"
 	aconfig "istio.io/mixer/pkg/aspect/config"
+	"istio.io/mixer/pkg/aspect/test"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
 	pb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
-
-// TODO: consolidate these with //pkg/aspect/test
-type fakeBag struct {
-	attribute.Bag
-}
-
-type fakeEval struct {
-	expr.PredicateEvaluator
-	expr.Validator
-
-	body func(string, attribute.Bag) (interface{}, error)
-}
-
-func (f *fakeEval) Eval(expression string, attrs attribute.Bag) (interface{}, error) {
-	return f.body(expression, attrs)
-}
-
-func (f *fakeEval) EvalString(expression string, attrs attribute.Bag) (string, error) {
-	r, err := f.body(expression, attrs)
-	return r.(string), err
-}
 
 type fakeaspect struct {
 	adapter.Aspect
@@ -69,8 +49,13 @@ func (a *fakeaspect) Record(v []adapter.Value) error {
 
 type fakeBuilder struct {
 	adapter.Builder
+	name string
 
 	body func() (adapter.MetricsAspect, error)
+}
+
+func (b *fakeBuilder) Name() string {
+	return b.name
 }
 
 func (b *fakeBuilder) NewMetricsAspect(env adapter.Env, config adapter.AspectConfig, metrics []adapter.MetricDefinition) (adapter.MetricsAspect, error) {
@@ -103,10 +88,10 @@ func TestMetricsManager_NewAspect(t *testing.T) {
 		// the params we use here don't matter because we're faking the aspect
 		Builder: &pb.Adapter{Params: &aconfig.MetricsParams{}},
 	}
-	builder := &fakeBuilder{body: func() (adapter.MetricsAspect, error) {
+	builder := &fakeBuilder{name: "test", body: func() (adapter.MetricsAspect, error) {
 		return &fakeaspect{body: func([]adapter.Value) error { return nil }}, nil
 	}}
-	if _, err := NewMetricsManager().NewAspect(conf, builder, test.NewEnv(t)); err != nil {
+	if _, err := NewMetricsManager().NewAspect(conf, builder, atest.NewEnv(t)); err != nil {
 		t.Errorf("NewAspect(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -122,7 +107,7 @@ func TestMetricsManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.MetricsAspect, error) {
 			return nil, fmt.Errorf(errString)
 		}}
-	_, err := NewMetricsManager().NewAspect(conf, builder, test.NewEnv(t))
+	_, err := NewMetricsManager().NewAspect(conf, builder, atest.NewEnv(t))
 	if err == nil {
 		t.Error("NewMetricsManager().NewAspect(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}
@@ -134,7 +119,7 @@ func TestMetricsManager_NewAspect_PropagatesError(t *testing.T) {
 func TestMetricsWrapper_Execute(t *testing.T) {
 	// TODO: all of these test values are hardcoded to match the metric definitions hardcoded in metricsManager
 	// (since things have to line up for us to test them), they can be made dynamic when we get the ability to set the definitions
-	goodEval := &fakeEval{body: func(exp string, _ attribute.Bag) (interface{}, error) {
+	goodEval := test.NewFakeEval(func(exp string, _ attribute.Bag) (interface{}, error) {
 		switch exp {
 		case "value":
 			return 1, nil
@@ -147,18 +132,18 @@ func TestMetricsWrapper_Execute(t *testing.T) {
 		default:
 			return nil, fmt.Errorf("default case for exp = %s", exp)
 		}
-	}}
-	errEval := &fakeEval{body: func(_ string, _ attribute.Bag) (interface{}, error) {
+	})
+	errEval := test.NewFakeEval(func(_ string, _ attribute.Bag) (interface{}, error) {
 		return nil, fmt.Errorf("expected")
-	}}
-	labelErrEval := &fakeEval{body: func(exp string, _ attribute.Bag) (interface{}, error) {
+	})
+	labelErrEval := test.NewFakeEval(func(exp string, _ attribute.Bag) (interface{}, error) {
 		switch exp {
 		case "value":
 			return 1, nil
 		default:
 			return nil, fmt.Errorf("expected")
 		}
-	}}
+	})
 
 	goodMd := map[string]*metricInfo{
 		"request_count": {
@@ -197,11 +182,11 @@ func TestMetricsWrapper_Execute(t *testing.T) {
 	cases := []struct {
 		mdin      map[string]*metricInfo
 		recordErr error
-		eval      *fakeEval
+		eval      expr.Evaluator
 		out       map[string]o
 		errString string
 	}{
-		{make(map[string]*metricInfo), nil, &fakeEval{}, make(map[string]o), ""},
+		{make(map[string]*metricInfo), nil, test.NewIDEval(), make(map[string]o), ""},
 		{goodMd, nil, errEval, make(map[string]o), "expected"},
 		{goodMd, nil, labelErrEval, make(map[string]o), "expected"},
 		{goodMd, nil, goodEval, map[string]o{"request_count": {1, []string{"source", "target"}}}, ""},
@@ -218,7 +203,7 @@ func TestMetricsWrapper_Execute(t *testing.T) {
 				}},
 				metadata: c.mdin,
 			}
-			_, err := wrapper.Execute(&fakeBag{}, c.eval)
+			_, err := wrapper.Execute(test.NewBag(), c.eval)
 
 			errString := ""
 			if err != nil {

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Istio Authors.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/aspect/test/bag.go
+++ b/pkg/aspect/test/bag.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,14 @@ type Bag struct {
 
 	Strs  map[string]string
 	Times map[string]time.Time
+}
+
+// NewBag creates a new bag for testing.
+func NewBag() *Bag {
+	return &Bag{
+		Strs:  make(map[string]string),
+		Times: make(map[string]time.Time),
+	}
 }
 
 // String returns the named attribute if it exists.


### PR DESCRIPTION
Clean up metrics related code: actually install the metrics manager in our inventory, populate some metric descriptor fields that were being skipped previously, fix some newly broken tests, and consolidate some of the duplicated test classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/273)
<!-- Reviewable:end -->
