### PR TITLE
Introduce basic k8s configs for the mixer, prometheus, and grafana

### DIFF
--- a/deploy/kube/README.md
+++ b/deploy/kube/README.md
@@ -3,7 +3,7 @@
 These configurations stand up an instance of the mixer, a Prometheus instance that scrapes metrics the mixer exposes, and
 a Grafana instance to render those metrics. These are intended for development and local testing, not a real production
 deployment. The easiest way to stand up these deployments is to run (from the Istio mixer root directory):
-```bash
+```shell
 $ kubectl create configmap prometheus-config --from-file=testdata/prometheus.yaml
 $ kubectl create configmap mixer-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml
 $ kubectl apply -f ./deploy/kube/
@@ -12,7 +12,7 @@ $ kubectl apply -f ./deploy/kube/
 If you're using something like [minikube](https://github.com/kubernetes/minikube) to test locally, you can call the
 mixer server with our test client (`mixc`), providing some attribute values:
 
-```bash
+```shell
 $ MIXS=$(minikube service mixer --url --format "{{.IP}}:{{.Port}}" | head -n 1)
 $ bazel run //cmd/client:mixc -- check -m $MIXS -a source.name=source,target.name=target,api.name=myapi,response.code=200,response.latency=100,client.id=$USER
 ```
@@ -30,12 +30,12 @@ configurations are expected to be mounted in two files at `/etc/opt/mixer/`. We 
 provide these configurations. Usually this configmap is created from the `//testdata/` directory by:
 
 <a name="configmap_command"></a>
-```bash
+```shell
 $ kubectl create configmap mixer-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml
 ```
 A file can be created to capture this configmap by running:
 
-```bash
+```shell
 $ kubectl get configmap mixer-config -o yaml > ./mixer-config.yaml
 ```
 We do not check in this file because we consider the yaml files in `//testdata` the source of truth for this config.
@@ -49,7 +49,7 @@ TODO: create a sample grafana config and link it here
 
 If you're using minikube to test these deployments locally, get to the UI by running:
 
-```bash
+```shell
 $ minikube service grafana
 ```
 
@@ -61,7 +61,7 @@ source is at `http://prometheus:9090/` (no auth required, access via proxy).
 works with these deployments is stored in `//testdata/`. Prometheus expects its config to be mounted at
 `/etc/opt/mixer/prometheus.yaml`. We use a configmap named `prometheus-config` to provide these configurations. Usually
 this configmap is created from the `//testdata` directory by:
-```bash
+```shell
 $ kubectl create configmap prometheus-config --from-file=testdata/prometheus.yaml
 ```
 
@@ -108,20 +108,20 @@ the mixer server by allowing a developer to push docker images locally rather th
 registry (`kubectl apply -f ./deploy/kube/localregistry.yaml`), and update `mixer.yaml` to use the image
 `localhost:5000/mixer`. After the registry server is running, expose it locally by executing:
 
-```bash
+```shell
 $ kubectl port-forward --namespace kube-system $POD 5000:5000
 ```
 
 If you're testing locally with minikube, `$POD` can be set with:
 
-```bash
+```shell
 $ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
   -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
   | grep Running | head -1 | cut -f1 -d' ')
 ```
 
 Then you can build the mixer, create a docker image, and push it to the local registry, by running:
-```bash
+```shell
 $ bazel build ...:all
 $ bazel run //docker:mixer localhost:5000/mixer
 $ docker push localhost:5000/mixer

--- a/deploy/kube/README.md
+++ b/deploy/kube/README.md
@@ -1,8 +1,8 @@
 # Istio Mixer K8s Configuration
 
-Intended for our demo, these configurations stand up an instance of the mixer, a Prometheus instance that scapes metrics
-the mixer exposes, and a Grafana instance to render those metrics. The easiest way to stand up these deployments is to
-run (from the Istio mixer root directory):
+These configurations stand up an instance of the mixer, a Prometheus instance that scapes metrics the mixer exposes, and
+a Grafana instance to render those metrics. These are intended for a demo, not a real production setup. The easiest way
+to stand up these deployments is to run (from the Istio mixer root directory):
 
     $ kubectl create configmap testdata-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml --from-file=testdata/prometheus.yaml
     $ kubectl apply -f ./deploy/kube/

--- a/deploy/kube/README.md
+++ b/deploy/kube/README.md
@@ -1,77 +1,128 @@
 # Istio Mixer K8s Configuration
 
-These configurations stand up an instance of the mixer, a Prometheus instance that scapes metrics the mixer exposes, and
-a Grafana instance to render those metrics. These are intended for a demo, not a real production setup. The easiest way
-to stand up these deployments is to run (from the Istio mixer root directory):
-
-    $ kubectl create configmap testdata-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml --from-file=testdata/prometheus.yaml
-    $ kubectl apply -f ./deploy/kube/
+These configurations stand up an instance of the mixer, a Prometheus instance that scrapes metrics the mixer exposes, and
+a Grafana instance to render those metrics. These are intended for development and local testing, not a real production
+deployment. The easiest way to stand up these deployments is to run (from the Istio mixer root directory):
+```bash
+$ kubectl create configmap prometheus-config --from-file=testdata/prometheus.yaml
+$ kubectl create configmap mixer-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml
+$ kubectl apply -f ./deploy/kube/
+```
     
 If you're using something like [minikube](https://github.com/kubernetes/minikube) to test locally, you can call the
 mixer server with our test client (`mixc`), providing some attribute values:
 
-    $ MIXS=$(minikube service mixer --url --format "{{.IP}}:{{.Port}}")
-    $ bazel run //cmd/client:mixc -- check -m $MIXS -a source.name=source,target.name=target,api.name=myapi,response.code=200,response.latency=100,client.id=$USER
+```bash
+$ MIXS=$(minikube service mixer --url --format "{{.IP}}:{{.Port}}" | head -n 1)
+$ bazel run //cmd/client:mixc -- check -m $MIXS -a source.name=source,target.name=target,api.name=myapi,response.code=200,response.latency=100,client.id=$USER
+```
+
+<aside class="notice">
+Note: due to [Issue #272](https://github.com/istio/mixer/issues/272) a `Check` or `Report` call must be made to the mixer
+before Prometheus will be able to scrape metrics.
+</aside>
 
 ## mixer.yaml
-`mixer.yaml` describes a deployment and service for the mixer server binary. The deployment annotates the pods it
-creates with a `prometheus_port` annotation which is required by our Prometheus deployment (see [prometheus.yaml](#prometheus)
-below as well as the prometheus configuration in `//testdata/prometheus.yaml`).
-
-Two pieces of configuration are required to run the mixer: a global configuration and a service configuration. Example
-configurations can be found in the `//testdata` directory (`//` indicates the root of the Istio Mixer project directory).
-These configurations are expected to be mounted in two files at `/etc/opt/mixer/`. We use a configmap named `testdata-config`
-to provide these configurations. Usually this configmap is created from the `//testdata/` directory by:
+`mixer.yaml` describes a deployment and service for the mixer server binary. Two pieces of configuration are required to
+run the mixer: a global configuration and a service configuration. Example configurations can be found in the `//testdata`
+directory (`//` indicates the [root of the Istio Mixer project directory](https://github.com/istio/mixer). These
+configurations are expected to be mounted in two files at `/etc/opt/mixer/`. We use a configmap named `mixer-config` to
+provide these configurations. Usually this configmap is created from the `//testdata/` directory by:
 
 <a name="configmap_command"></a>
-
-    $ kubectl create configmap testdata-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml --from-file=testdata/prometheus.yaml
-
+```bash
+$ kubectl create configmap mixer-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml
+```
 A file can be created to capture this configmap by running:
 
-    $ kubectl get configmap testdata-config -o yaml > ./testdata-config.yaml
-
-We do not check in this file since we consider the yaml files in `//testdata` the source of truth for this config.
+```bash
+$ kubectl get configmap mixer-config -o yaml > ./mixer-config.yaml
+```
+We do not check in this file because we consider the yaml files in `//testdata` the source of truth for this config.
 
 ## grafana.yaml
 `grafana.yaml` describes a deployment and service for Grafana, based on the [`grafana/grafana` docker image](https://hub.docker.com/r/grafana/grafana/).
 The Grafana UI is exposed on port `3000`. This configuration stores Grafana's data in the `/data/grafana` dir, which we
 configure to be an ephemeral directory. To persist your Grafana configuration for longer than the lifetime of the `grafana`
-pod, map this directory to a real volume.
+pod, map this directory to a real volume. Note that it is possible to export your Grafana config and re-import it later.
+TODO: create a sample grafana config and link it here
 
 If you're using minikube to test these deployments locally, get to the UI by running:
 
-    $ minikube service grafana
-    
-We also need to add our Prometheus installation data source, which is at `http://prometheus:9090/` (no auth required,
-access via proxy).
+```bash
+$ minikube service grafana
+```
 
+We also need to add our Prometheus installation data source. If you're using the provided `prometheus.yaml`, the data
+source is at `http://prometheus:9090/` (no auth required, access via proxy).
 
 ## <a name="prometheus"></a> prometheus.yaml
-`prometheus.yaml` describes a deployment and service for a Prometheus collection server. Prometheus expects its config to
-be mounted at `/etc/opt/mixer/prometheus.yaml`. An example configuration that works with these deployments is stored in
-`//testdata/`. For simplicity we shove this into the same configmap the mixer serves from, and the [configmap command above](#configmap_command)
-includes the Prometheus configuration. 
+`prometheus.yaml` describes a deployment and service for a Prometheus collection server. An example configuration that
+works with these deployments is stored in `//testdata/`. Prometheus expects its config to be mounted at
+`/etc/opt/mixer/prometheus.yaml`. We use a configmap named `prometheus-config` to provide these configurations. Usually
+this configmap is created from the `//testdata` directory by:
+```bash
+$ kubectl create configmap prometheus-config --from-file=testdata/prometheus.yaml
+```
 
-When the mixer is configured with the `prometheus` adapter it hosts metrics on an HTTP server at port `42422` (this can
-be changed in the Prometheus adapter configuration). The `mixer.yaml` deployment annotates all mixer pods with this port
-number, and the Prometheus configuration at `//testdata/prometheus.yaml` uses it to compute the URL to scrape for metrics.
+The Prometheus configuration at `//testdata/prometheus.yaml` looks for a Kubernetes service named `mixer` with a port
+named `prometheus` to scrape. The Kubernetes service defined in `mixer.yaml` satisfies these requirements.
 
-## localregistry.yaml
-`localregistry.yaml` is a copy of Kubernete's local registry configuration, and is included to make it easier to test
-the mixer server. Run the registry (`kubectl apply -f ./deploy/kube/localregistry.yaml`), and update `mixer.yaml` to use
-the image `localhost:5000/mixer`. After the registry server is running, expose it locally by executing:
+#### Configuring the mixer to produce Prometheus metrics
+The mixer configuration in the `//testdata` directory is set up to run the prometheus adapter already. To insert it
+into your own mixer deployment the adapter needs to be registered in the global config:
 
-    $ kubectl port-forward --namespace kube-system $POD 5000:5000
+```yaml
+adapters:
+  - name: prometheus
+    kind: metrics
+    impl: prometheus
+    params: # the prometheus adapter doesn't take any parameters; see //adapter/prometheus/config/config.proto
+```
+         
+Then the metrics aspect must be configured so that the adapter can populate metric values from attributes at runtime:
+```yaml
+aspects:
+  - kind: metrics
+    adapter: "prometheus"
+    params:
+      metrics:
+      - descriptor: "request_count"
+        value: "1" # we want to increment this counter by 1 for each unique (source, target, service, response_code) tuple
+        labels:
+          source: "source.name"
+          target: "target.name"
+          service: "api.name"
+          response_code: "response.code"
+      - descriptor:  "request_latency"
+        value: "response.latency"
+        labels:
+          source: "source.name"
+          target: "target.name"
+          service: "api.name"
+```
+
+## OPTIONAL: Running a local registry for development
+`localregistry.yaml` is a copy of Kubernete's local registry addon, and is included to make it easier to test
+the mixer server by allowing a developer to push docker images locally rather than to some remote registry. Run the
+registry (`kubectl apply -f ./deploy/kube/localregistry.yaml`), and update `mixer.yaml` to use the image
+`localhost:5000/mixer`. After the registry server is running, expose it locally by executing:
+
+```bash
+$ kubectl port-forward --namespace kube-system $POD 5000:5000
+```
 
 If you're testing locally with minikube, `$POD` can be set with:
 
-    $ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
-      -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
-      | grep Running | head -1 | cut -f1 -d' ')
+```bash
+$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+  -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
+  | grep Running | head -1 | cut -f1 -d' ')
+```
 
 Then you can build the mixer, create a docker image, and push it to the local registry, by running:
-
-    $ bazel build ...:all
-    $ bazel run //docker:mixer localhost:5000/mixer
-    $ docker push localhost:5000/mixer
+```bash
+$ bazel build ...:all
+$ bazel run //docker:mixer localhost:5000/mixer
+$ docker push localhost:5000/mixer
+```

--- a/deploy/kube/README.md
+++ b/deploy/kube/README.md
@@ -4,13 +4,14 @@ Intended for our demo, these configurations stand up an instance of the mixer, a
 the mixer exposes, and a Grafana instance to render those metrics. The easiest way to stand up these deployments is to
 run (from the Istio mixer root directory):
 
+    $ kubectl create configmap testdata-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml --from-file=testdata/prometheus.yaml
     $ kubectl apply -f ./deploy/kube/
     
 If you're using something like [minikube](https://github.com/kubernetes/minikube) to test locally, you can call the
 mixer server with our test client (`mixc`), providing some attribute values:
 
-    $ MIXS=$(minikube service mixer --url)    
-    $ bazel run //cmd/client/mixc -- check -m $MIXS -a source.name=source,target.name=target,api.name=myapi,response.code=200,response.latency=100,client.id=$USER
+    $ MIXS=$(minikube service mixer --url --format "{{.IP}}:{{.Port}}")
+    $ bazel run //cmd/client:mixc -- check -m $MIXS -a source.name=source,target.name=target,api.name=myapi,response.code=200,response.latency=100,client.id=$USER
 
 ## mixer.yaml
 `mixer.yaml` describes a deployment and service for the mixer server binary. The deployment annotates the pods it
@@ -24,7 +25,7 @@ to provide these configurations. Usually this configmap is created from the `//t
 
 <a name="configmap_command"></a>
 
-    $ kubectl create configmap testdata-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml --from-file=testdata/prometheusconfig.yaml
+    $ kubectl create configmap testdata-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml --from-file=testdata/prometheus.yaml
 
 A file can be created to capture this configmap by running:
 
@@ -37,6 +38,14 @@ We do not check in this file since we consider the yaml files in `//testdata` th
 The Grafana UI is exposed on port `3000`. This configuration stores Grafana's data in the `/data/grafana` dir, which we
 configure to be an ephemeral directory. To persist your Grafana configuration for longer than the lifetime of the `grafana`
 pod, map this directory to a real volume.
+
+If you're using minikube to test these deployments locally, get to the UI by running:
+
+    $ minikube service grafana
+    
+We also need to add our Prometheus installation data source, which is at `http://prometheus:9090/` (no auth required,
+access via proxy).
+
 
 ## <a name="prometheus"></a> prometheus.yaml
 `prometheus.yaml` describes a deployment and service for a Prometheus collection server. Prometheus expects its config to

--- a/deploy/kube/README.md
+++ b/deploy/kube/README.md
@@ -1,0 +1,68 @@
+# Istio Mixer K8s Configuration
+
+Intended for our demo, these configurations stand up an instance of the mixer, a Prometheus instance that scapes metrics
+the mixer exposes, and a Grafana instance to render those metrics. The easiest way to stand up these deployments is to
+run (from the Istio mixer root directory):
+
+    $ kubectl apply -f ./deploy/kube/
+    
+If you're using something like [minikube](https://github.com/kubernetes/minikube) to test locally, you can call the
+mixer server with our test client (`mixc`), providing some attribute values:
+
+    $ MIXS=$(minikube service mixer --url)    
+    $ bazel run //cmd/client/mixc -- check -m $MIXS -a source.name=source,target.name=target,api.name=myapi,response.code=200,response.latency=100,client.id=$USER
+
+## mixer.yaml
+`mixer.yaml` describes a deployment and service for the mixer server binary. The deployment annotates the pods it
+creates with a `prometheus_port` annotation which is required by our Prometheus deployment (see [prometheus.yaml](#prometheus)
+below as well as the prometheus configuration in `//testdata/prometheus.yaml`).
+
+Two pieces of configuration are required to run the mixer: a global configuration and a service configuration. Example
+configurations can be found in the `//testdata` directory (`//` indicates the root of the Istio Mixer project directory).
+These configurations are expected to be mounted in two files at `/etc/opt/mixer/`. We use a configmap named `testdata-config`
+to provide these configurations. Usually this configmap is created from the `//testdata/` directory by:
+
+<a name="configmap_command"></a>
+
+    $ kubectl create configmap testdata-config --from-file=testdata/globalconfig.yml --from-file=testdata/serviceconfig.yml --from-file=testdata/prometheusconfig.yaml
+
+A file can be created to capture this configmap by running:
+
+    $ kubectl get configmap testdata-config -o yaml > ./testdata-config.yaml
+
+We do not check in this file since we consider the yaml files in `//testdata` the source of truth for this config.
+
+## grafana.yaml
+`grafana.yaml` describes a deployment and service for Grafana, based on the [`grafana/grafana` docker image](https://hub.docker.com/r/grafana/grafana/).
+The Grafana UI is exposed on port `3000`. This configuration stores Grafana's data in the `/data/grafana` dir, which we
+configure to be an ephemeral directory. To persist your Grafana configuration for longer than the lifetime of the `grafana`
+pod, map this directory to a real volume.
+
+## <a name="prometheus"></a> prometheus.yaml
+`prometheus.yaml` describes a deployment and service for a Prometheus collection server. Prometheus expects its config to
+be mounted at `/etc/opt/mixer/prometheus.yaml`. An example configuration that works with these deployments is stored in
+`//testdata/`. For simplicity we shove this into the same configmap the mixer serves from, and the [configmap command above](#configmap_command)
+includes the Prometheus configuration. 
+
+When the mixer is configured with the `prometheus` adapter it hosts metrics on an HTTP server at port `42422` (this can
+be changed in the Prometheus adapter configuration). The `mixer.yaml` deployment annotates all mixer pods with this port
+number, and the Prometheus configuration at `//testdata/prometheus.yaml` uses it to compute the URL to scrape for metrics.
+
+## localregistry.yaml
+`localregistry.yaml` is a copy of Kubernete's local registry configuration, and is included to make it easier to test
+the mixer server. Run the registry (`kubectl apply -f ./deploy/kube/localregistry.yaml`), and update `mixer.yaml` to use
+the image `localhost:5000/mixer`. After the registry server is running, expose it locally by executing:
+
+    $ kubectl port-forward --namespace kube-system $POD 5000:5000
+
+If you're testing locally with minikube, `$POD` can be set with:
+
+    $ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+      -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
+      | grep Running | head -1 | cut -f1 -d' ')
+
+Then you can build the mixer, create a docker image, and push it to the local registry, by running:
+
+    $ bazel build ...:all
+    $ bazel run //docker:mixer localhost:5000/mixer
+    $ docker push localhost:5000/mixer

--- a/deploy/kube/README.md
+++ b/deploy/kube/README.md
@@ -84,22 +84,24 @@ Then the metrics aspect must be configured so that the adapter can populate metr
 ```yaml
 aspects:
   - kind: metrics
-    adapter: "prometheus"
+    adapter: prometheus
     params:
       metrics:
-      - descriptor: "request_count"
+      - descriptor: request_count
         value: "1" # we want to increment this counter by 1 for each unique (source, target, service, response_code) tuple
         labels:
-          source: "source.name"
-          target: "target.name"
-          service: "api.name"
-          response_code: "response.code"
-      - descriptor:  "request_latency"
-        value: "response.latency"
+          source: source.name
+          target: target.name
+          service: api.name | "unknown"
+          method: api.method | "unknown"
+          response_code: response.http.code
+      - descriptor:  request_latency
+        value: response.latency
         labels:
-          source: "source.name"
-          target: "target.name"
-          service: "api.name"
+          source: source.name
+          target: target.name
+          service: api.name | "unknown"
+          method: api.method | "unknown"
 ```
 
 ## OPTIONAL: Running a local registry for development

--- a/deploy/kube/grafana.yaml
+++ b/deploy/kube/grafana.yaml
@@ -39,8 +39,7 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - name: "grafana"
+  - name: http
     port: 3000
-    targetPort: 3000
   selector:
     app: grafana

--- a/deploy/kube/grafana.yaml
+++ b/deploy/kube/grafana.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana
+        ports:
+        - containerPort: 3000
+        env:
+        - name: GRAFANA_PORT
+          value: "3000"
+        - name: GF_AUTH_BASIC_ENABLED
+          value: "false"
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: Admin
+        - name: GF_PATHS_DATA
+          value: /data/grafana
+        volumeMounts:
+        - mountPath: /data/grafana
+          name: grafana-data
+      volumes:
+      - name: grafana-data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  type: NodePort
+  ports:
+  - name: "grafana"
+    port: 3000
+    targetPort: 3000
+  selector:
+    app: grafana

--- a/deploy/kube/localregistry.yaml
+++ b/deploy/kube/localregistry.yaml
@@ -1,0 +1,88 @@
+# after creating the local registry, to push images to it you need to open up a port to the pod's registry:
+# $ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+#               -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
+#               | grep Running | head -1 | cut -f1 -d' ')
+# $ kubectl port-forward --namespace kube-system $POD 5000:5000
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kube-registry-v0
+  namespace: kube-system
+  labels:
+    k8s-app: kube-registry
+    version: v0
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kube-registry
+    version: v0
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-registry
+        version: v0
+    spec:
+      containers:
+      - name: registry
+        image: registry:2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: REGISTRY_HTTP_ADDR
+          value: :5000
+        - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+          value: /var/lib/registry
+        volumeMounts:
+        - name: image-store
+          mountPath: /var/lib/registry
+        ports:
+        - containerPort: 5000
+          name: registry
+          protocol: TCP
+      volumes:
+      - name: image-store
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-registry
+  namespace: kube-system
+  labels:
+    k8s-app: kube-registry
+    kubernetes.io/name: "KubeRegistry"
+spec:
+  selector:
+    k8s-app: kube-registry
+  ports:
+  - name: registry
+    port: 5000
+    protocol: TCP
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-registry-proxy
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-registry-proxy
+    image: gcr.io/google_containers/kube-registry-proxy:0.3
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50Mi
+    env:
+    - name: REGISTRY_HOST
+      value: kube-registry.kube-system.svc.cluster.local
+    - name: REGISTRY_PORT
+      value: "5000"
+    - name: FORWARD_PORT
+      value: "5000"
+    ports:
+    - name: registry
+      containerPort: 5000
+      hostPort: 5000

--- a/deploy/kube/mixer.yaml
+++ b/deploy/kube/mixer.yaml
@@ -8,24 +8,24 @@ spec:
     metadata:
       labels:
         app: mixer
-      annotations:
-        prometheus_port: "42422"
     spec:
       containers:
       - name: mixer
         image: gcr.io/istio-testing/mixer:latest
         ports:
-          - containerPort: 42422 # prometheus http endpoint
+          - containerPort: 9091
+          - containerPort: 42422
         volumeMounts:
         - mountPath: /etc/opt/mixer
           name: config
-        args: [
-          "-v=4",
-        ]
+        args:
+          - --globalConfigFile=/etc/opt/mixer/globalconfig.yml
+          - --serviceConfigFile=/etc/opt/mixer/serviceconfig.yml
+          - -v=4
       volumes:
       - name: config
         configMap:
-          name: testdata-config
+          name: mixer-config
 ---
 apiVersion: v1
 kind: Service
@@ -34,8 +34,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - name: "api"
+  - name: grpc
     port: 9091
-    targetPort: 9091
+  - name: prometheus
+    port: 42422
   selector:
     app: mixer

--- a/deploy/kube/mixer.yaml
+++ b/deploy/kube/mixer.yaml
@@ -1,0 +1,41 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mixer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mixer
+      annotations:
+        prometheus_port: "42422"
+    spec:
+      containers:
+      - name: mixer
+        image: gcr.io/istio-testing/mixer:latest
+        ports:
+          - containerPort: 42422 # prometheus http endpoint
+        volumeMounts:
+        - mountPath: /etc/opt/mixer
+          name: config
+        args: [
+          "-v=4",
+        ]
+      volumes:
+      - name: config
+        configMap:
+          name: testdata-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mixer
+spec:
+  type: NodePort
+  ports:
+  - name: "api"
+    port: 9091
+    targetPort: 9091
+  selector:
+    app: mixer

--- a/deploy/kube/prometheus.yaml
+++ b/deploy/kube/prometheus.yaml
@@ -1,0 +1,43 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus
+        volumeMounts:
+          - mountPath: /prometheus
+            name: data-prom
+          - mountPath: /etc/opt/mixer
+            name: config
+        ports:
+          - containerPort: 9090
+        args: [
+          "-config.file=/etc/opt/mixer/prometheus.yaml"
+        ]
+      volumes:
+      - name: data-prom
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: testdata-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  type: NodePort
+  ports:
+  - name: "prometheus"
+    port: 9090
+    targetPort: 9090
+  selector:
+    app: prometheus

--- a/deploy/kube/prometheus.yaml
+++ b/deploy/kube/prometheus.yaml
@@ -19,15 +19,14 @@ spec:
             name: config
         ports:
           - containerPort: 9090
-        args: [
-          "-config.file=/etc/opt/mixer/prometheus.yaml"
-        ]
+        args:
+          - -config.file=/etc/opt/mixer/prometheus.yaml
       volumes:
       - name: data-prom
         emptyDir: {}
       - name: config
         configMap:
-          name: testdata-config
+          name: prometheus-config
 ---
 apiVersion: v1
 kind: Service
@@ -36,8 +35,7 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - name: "prometheus"
+  - name: http
     port: 9090
-    targetPort: 9090
   selector:
     app: prometheus

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -25,7 +25,10 @@ docker_build(
         "--logtostderr",
         "--v=2",
     ],
-    ports = ["9091"],
+    ports = [
+        "9091",
+        "42422",
+    ],
     repository = "istio",
     tags = ["manual"],
     tars = [

--- a/pkg/aspect/inventory.go
+++ b/pkg/aspect/inventory.go
@@ -98,7 +98,6 @@ func Inventory() ManagerInventory {
 		CheckMethod: {
 			NewDenialsManager(),
 			NewListsManager(),
-			NewMetricsManager(),
 			NewQuotasManager(),
 		},
 

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -67,8 +67,8 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 			Labels: []*dpb.LabelDescriptor{
 				{Name: "source", ValueType: dpb.STRING},
 				{Name: "target", ValueType: dpb.STRING},
-				{Name: "method", ValueType: dpb.STRING},
 				{Name: "service", ValueType: dpb.STRING},
+				{Name: "method", ValueType: dpb.STRING},
 				{Name: "response_code", ValueType: dpb.INT64},
 			},
 		},

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -67,6 +67,7 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 			Labels: []*dpb.LabelDescriptor{
 				{Name: "source", ValueType: dpb.STRING},
 				{Name: "target", ValueType: dpb.STRING},
+				{Name: "method", ValueType: dpb.STRING},
 				{Name: "service", ValueType: dpb.STRING},
 				{Name: "response_code", ValueType: dpb.INT64},
 			},
@@ -80,6 +81,7 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 				{Name: "source", ValueType: dpb.STRING},
 				{Name: "target", ValueType: dpb.STRING},
 				{Name: "service", ValueType: dpb.STRING},
+				{Name: "method", ValueType: dpb.STRING},
 			},
 		},
 	}

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -9,5 +9,9 @@ adapters:
     impl: stdioLogger
     params:
       logStream: 0 # STDERR
+  - name: prometheus
+    kind: metrics
+    impl: prometheus
+    params:
   - name: default
     impl: denyChecker

--- a/testdata/prometheus.yaml
+++ b/testdata/prometheus.yaml
@@ -3,20 +3,14 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: 'prometheus'
+  - job_name: 'mixer'
     scrape_interval: 5s
 
-    static_configs:
-    # tell it to use http://mixer; we use relabeling to assign the port
-    - targets: ["mixer"]
-
     kubernetes_sd_configs:
-    - role: pod
+    - role: service
 
     relabel_configs:
-    # we read the pod annotations "prometheus_port" from kubernetes, and concat it with the address
-    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_port]
-      action: replace
-      regex: ([^:]+)(?::\d+)?;(\d+)
-      replacement: $1:$2
-      target_label: __address__
+    # only select k8s services named "mixer" with a port named "prometheus"
+    - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_service_port_name]
+      action: keep
+      regex: mixer;prometheus

--- a/testdata/prometheus.yaml
+++ b/testdata/prometheus.yaml
@@ -1,0 +1,22 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+
+    static_configs:
+    # tell it to use http://mixer; we use relabeling to assign the port
+    - targets: ["mixer"]
+
+    kubernetes_sd_configs:
+    - role: pod
+
+    relabel_configs:
+    # we read the pod annotations "prometheus_port" from kubernetes, and concat it with the address
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+      target_label: __address__

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -11,14 +11,14 @@ rules:
     adapter: "prometheus"
     params:
       metrics:
-      - descriptor_: "request_count"
+      - descriptor: "request_count"
         value: "1"
         labels:
           source: "source.name"
           target: "target.name"
           service: "api.name"
           response_code: "response.code"
-      - descriptor_:  "request_latency"
+      - descriptor:  "request_latency"
         value: "response.latency"
         labels:
           source: "source.name"

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -8,24 +8,25 @@ rules:
   - kind: quotas
     params:
   - kind: metrics
-    adapter: "prometheus"
+    adapter: prometheus
     params:
       metrics:
-      - descriptor: "request_count"
-        value: "1" # we want to increment the request_count counter by 1 each time
+      - descriptor: request_count
+        # we want to increment this counter by 1 for each unique (source, target, service, method, response_code) tuple
+        value: "1"
         labels:
-          source: "source.name"
-          target: "target.name"
-          service: "api.name"
-          method: "api.method"
-          response_code: "response.http.code"
-      - descriptor:  "request_latency"
-        value: "response.latency"
+          source: source.name
+          target: target.name
+          service: api.name | "unknown"
+          method: api.method | "unknown"
+          response_code: response.http.code
+      - descriptor:  request_latency
+        value: response.latency
         labels:
-          source: "source.name"
-          target: "target.name"
-          service: "api.name"
-          method: "api.method"
+          source: source.name
+          target: target.name
+          service: api.name | "unknown"
+          method: api.method | "unknown"
   - kind: access-logs
     params:
       logName: "access_log"

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -17,13 +17,15 @@ rules:
           source: "source.name"
           target: "target.name"
           service: "api.name"
-          response_code: "response.code"
+          method: "api.method"
+          response_code: "response.http.code"
       - descriptor:  "request_latency"
         value: "response.latency"
         labels:
           source: "source.name"
           target: "target.name"
           service: "api.name"
+          method: "api.method"
   - kind: access-logs
     params:
       logName: "access_log"

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -7,6 +7,23 @@ rules:
   aspects:
   - kind: quotas
     params:
+  - kind: metrics
+    adapter: "prometheus"
+    params:
+      metrics:
+      - descriptor_: "request_count"
+        value: "1"
+        labels:
+          source: "source.name"
+          target: "target.name"
+          service: "api.name"
+          response_code: "response.code"
+      - descriptor_:  "request_latency"
+        value: "response.latency"
+        labels:
+          source: "source.name"
+          target: "target.name"
+          service: "api.name"
   - kind: access-logs
     params:
       logName: "access_log"

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -12,7 +12,7 @@ rules:
     params:
       metrics:
       - descriptor: "request_count"
-        value: "1"
+        value: "1" # we want to increment the request_count counter by 1 each time
         labels:
           source: "source.name"
           target: "target.name"


### PR DESCRIPTION
We add configs for running the mixer via k8s, as well as prometheus and grafana. These have been tests e2e together. We also add a README that describes running these configs and how to interact with the deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/274)
<!-- Reviewable:end -->
