### PR TITLE
Regularize metric aspect API.

### DIFF
--- a/pkg/adapter/BUILD
+++ b/pkg/adapter/BUILD
@@ -11,6 +11,7 @@ go_library(
         "builder.go",
         "configError.go",
         "denials.go",
+        "labels.go",
         "lists.go",
         "metrics.go",
         "quotas.go",

--- a/pkg/adapter/labels.go
+++ b/pkg/adapter/labels.go
@@ -1,0 +1,67 @@
+// Copyright 2017 The Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"fmt"
+
+	dpb "istio.io/api/mixer/v1/config/descriptor"
+)
+
+// LabelType defines the set of known label types that can be generated
+// by the mixer.
+type LabelType int
+
+// Supported types of labels.
+const (
+	String LabelType = iota
+	Int64
+	Float64
+	Bool
+	Time
+	Duration
+	IPAddress
+	EmailAddress
+	URI
+	DNSName
+)
+
+// LabelTypeFromProto translates from ValueType to LabelType.
+func LabelTypeFromProto(pbt dpb.ValueType) (LabelType, error) {
+	switch pbt {
+	case dpb.STRING:
+		return String, nil
+	case dpb.BOOL:
+		return Bool, nil
+	case dpb.INT64:
+		return Int64, nil
+	case dpb.DOUBLE:
+		return Float64, nil
+	case dpb.TIMESTAMP:
+		return Time, nil
+	case dpb.DNS_NAME:
+		return DNSName, nil
+	case dpb.DURATION:
+		return Duration, nil
+	case dpb.EMAIL_ADDRESS:
+		return EmailAddress, nil
+	case dpb.IP_ADDRESS:
+		return IPAddress, nil
+	case dpb.URI:
+		return URI, nil
+	default:
+		return 0, fmt.Errorf("unsupported proto ValueType %v", pbt)
+	}
+}

--- a/pkg/adapter/metrics.go
+++ b/pkg/adapter/metrics.go
@@ -28,20 +28,6 @@ const (
 	Counter                   // records increasing cumulative values
 )
 
-// Label kinds supported by mixer.
-const (
-	String LabelType = iota
-	Int64
-	Float64
-	Bool
-	Time
-	Duration
-	IPAddress
-	EmailAddress
-	URI
-	DNSName
-)
-
 type (
 	// MetricsAspect handles metric reporting within the mixer.
 	MetricsAspect interface {
@@ -56,11 +42,8 @@ type (
 	// a Report() call to the mixer. It is synthesized by the mixer, based
 	// on mixer config and the attributes passed to Report().
 	Value struct {
-		// Name is the canonical name for the metric for which this
-		// value is being reported.
-		Name string
-		// Kind provides type information on the metric itself
-		Kind MetricKind
+		// The definition describing this metric.
+		Definition *MetricDefinition
 		// Labels provide metadata about the metric value. They are
 		// generated from the set of attributes provided by Report().
 		Labels map[string]interface{}
@@ -86,7 +69,7 @@ type (
 		Builder
 
 		// NewMetricsAspect returns a new instance of the Metrics aspect.
-		NewMetricsAspect(env Env, config AspectConfig, metrics []MetricDefinition) (MetricsAspect, error)
+		NewMetricsAspect(env Env, config AspectConfig, metrics map[string]*MetricDefinition) (MetricsAspect, error)
 	}
 
 	// MetricDefinition provides the basic description of a metric schema
@@ -94,7 +77,9 @@ type (
 	MetricDefinition struct {
 		// Name is the canonical name of the metric.
 		Name string
-		// Description provides information about this metric.
+		// Optional user-friendly name of the metric.
+		DisplayName string
+		// Optional user-friendly description of this metric.
 		Description string
 		// Kind provides type information about the metric.
 		Kind MetricKind
@@ -102,10 +87,6 @@ type (
 		// be generated at runtime and passed along with metric values.
 		Labels map[string]LabelType
 	}
-
-	// LabelType defines the set of known label types that can be generated
-	// by the mixer.
-	LabelType int
 )
 
 // String returns the string-valued metric value for a metrics.Value.
@@ -149,33 +130,5 @@ func MetricKindFromProto(pbk dpb.MetricDescriptor_MetricKind) (MetricKind, error
 		return Counter, nil
 	default:
 		return 0, fmt.Errorf("invalid proto MetricKind %v", pbk)
-	}
-}
-
-// LabelTypeFromProto translates from ValueType to LabelType.
-func LabelTypeFromProto(pbt dpb.ValueType) (LabelType, error) {
-	switch pbt {
-	case dpb.STRING:
-		return String, nil
-	case dpb.BOOL:
-		return Bool, nil
-	case dpb.INT64:
-		return Int64, nil
-	case dpb.DOUBLE:
-		return Float64, nil
-	case dpb.TIMESTAMP:
-		return Time, nil
-	case dpb.DNS_NAME:
-		return DNSName, nil
-	case dpb.DURATION:
-		return Duration, nil
-	case dpb.EMAIL_ADDRESS:
-		return EmailAddress, nil
-	case dpb.IP_ADDRESS:
-		return IPAddress, nil
-	case dpb.URI:
-		return URI, nil
-	default:
-		return 0, fmt.Errorf("invalid proto ValueType %v", pbt)
 	}
 }

--- a/pkg/adapter/metrics_test.go
+++ b/pkg/adapter/metrics_test.go
@@ -92,7 +92,7 @@ func TestFromPbType(t *testing.T) {
 		out       LabelType
 		errString string
 	}{
-		{dpb.VALUE_TYPE_UNSPECIFIED, 0, "invalid"},
+		{dpb.VALUE_TYPE_UNSPECIFIED, 0, "unsupported"},
 		{dpb.STRING, String, ""},
 		{dpb.INT64, Int64, ""},
 		{dpb.DOUBLE, Float64, ""},
@@ -113,7 +113,7 @@ func TestFromPbType(t *testing.T) {
 			}
 
 			if !strings.Contains(errString, c.errString) {
-				t.Errorf("LabelTypeFromProto(%v) = _, %v; wanted erro containing %s", c.in, err, c.errString)
+				t.Errorf("LabelTypeFromProto(%v) = _, %v; wanted error containing %s", c.in, err, c.errString)
 			}
 			if out != c.out {
 				t.Errorf("LabelTypeFromProto(%v) = %v; wanted %v", c.in, out, c.out)

--- a/pkg/adapterManager/registry_test.go
+++ b/pkg/adapterManager/registry_test.go
@@ -150,7 +150,7 @@ func TestRegisterQuota(t *testing.T) {
 
 type metricsBuilder struct{ testBuilder }
 
-func (metricsBuilder) NewMetricsAspect(adapter.Env, adapter.AspectConfig, []adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+func (metricsBuilder) NewMetricsAspect(adapter.Env, adapter.AspectConfig, map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -58,7 +58,8 @@ func (b *fakeBuilder) Name() string {
 	return b.name
 }
 
-func (b *fakeBuilder) NewMetricsAspect(env adapter.Env, config adapter.AspectConfig, metrics []adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+func (b *fakeBuilder) NewMetricsAspect(env adapter.Env, config adapter.AspectConfig,
+	metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	return b.body()
 }
 
@@ -147,7 +148,7 @@ func TestMetricsWrapper_Execute(t *testing.T) {
 
 	goodMd := map[string]*metricInfo{
 		"request_count": {
-			metricKind: adapter.Counter,
+			definition: &adapter.MetricDefinition{Kind: adapter.Counter, Name: "request_count"},
 			value:      "value",
 			labels: map[string]string{
 				"source":  "source",
@@ -158,14 +159,14 @@ func TestMetricsWrapper_Execute(t *testing.T) {
 	}
 	badGoodMd := map[string]*metricInfo{
 		"bad": {
-			metricKind: adapter.Counter,
+			definition: &adapter.MetricDefinition{Kind: adapter.Counter, Name: "bad"},
 			value:      "bad",
 			labels: map[string]string{
 				"bad": "bad",
 			},
 		},
 		"request_count": {
-			metricKind: adapter.Counter,
+			definition: &adapter.MetricDefinition{Kind: adapter.Counter, Name: "request_count"},
 			value:      "value",
 			labels: map[string]string{
 				"source":  "source",
@@ -217,7 +218,7 @@ func TestMetricsWrapper_Execute(t *testing.T) {
 				t.Errorf("wrapper.Execute(&fakeBag{}, eval) got vals %v, wanted at least %d", receivedValues, len(c.out))
 			}
 			for _, v := range receivedValues {
-				o, found := c.out[v.Name]
+				o, found := c.out[v.Definition.Name]
 				if !found {
 					t.Errorf("Got unexpected value %v, wanted only %v", v, c.out)
 				}


### PR DESCRIPTION
- A metric value now holds a pointer to a MetricDefinition instead
of merely having its name. This prevents individual adapters having
to maintain a map.

- Remove the Kind field from the metric value type, since it can be
obtained from the MetricDefinition instance.

- Pass a map of MetricDescription into the NewMetricsAspect method.
This enforces the uniqueness of names and avoids some code in some
adapters.

- Pass down the DisplayName and Description values from the
MetricDescriptor such that adapters can use those values when
configuring backends if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/275)
<!-- Reviewable:end -->
