### PR TITLE
Remove the golang genproto dependency from WORKSPACE.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,6 +62,7 @@ gogoslick_proto_library(
     name = "google/rpc",
     protos = [
         "google/rpc/status.proto",
+        "google/rpc/code.proto",
     ],
     importmap = {
         "google/protobuf/any.proto": "github.com/gogo/protobuf/types",
@@ -95,6 +96,11 @@ filegroup(
     name = "status_proto",
     srcs = [ "google/rpc/status.proto" ],
 )
+
+filegroup(
+    name = "code_proto",
+    srcs = [ "google/rpc/code.proto" ],
+)
 """
 
 new_git_repository(
@@ -102,12 +108,6 @@ new_git_repository(
     build_file_content = GOOGLEAPIS_BUILD_FILE,
     commit = "13ac2436c5e3d568bd0e938f6ed58b77a48aba15", # Oct 21, 2016 (only release pre-dates sha)
     remote = "https://github.com/googleapis/googleapis.git",
-)
-
-new_go_repository(
-    name = "com_github_google_go_genproto",
-    commit = "b3e7c2fb04031add52c4817f53f43757ccbf9c18", # Dec 15, 2016 (no releases)
-    importpath = "google.golang.org/genproto",
 )
 
 new_go_repository(

--- a/adapter/denyChecker/BUILD
+++ b/adapter/denyChecker/BUILD
@@ -10,7 +10,6 @@ go_library(
     deps = [
         "//adapter/denyChecker/config:go_default_library",
         "//pkg/adapter:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
     ],
 )

--- a/adapter/denyChecker/denyChecker.go
+++ b/adapter/denyChecker/denyChecker.go
@@ -16,7 +16,6 @@ package denyChecker
 
 import (
 	rpc "github.com/googleapis/googleapis/google/rpc"
-	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/adapter/denyChecker/config"
 	"istio.io/mixer/pkg/adapter"
@@ -30,7 +29,7 @@ type (
 var (
 	name = "denyChecker"
 	desc = "Denies every check request"
-	conf = &config.Params{Error: &rpc.Status{Code: int32(code.Code_FAILED_PRECONDITION)}}
+	conf = &config.Params{Error: &rpc.Status{Code: int32(rpc.FAILED_PRECONDITION)}}
 )
 
 // Register records the builders exposed by this adapter.

--- a/adapter/denyChecker/denyChecker_test.go
+++ b/adapter/denyChecker/denyChecker_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	rpc "github.com/googleapis/googleapis/google/rpc"
-	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/adapter/denyChecker/config"
 	"istio.io/mixer/pkg/adapter/test"
@@ -33,22 +32,22 @@ func TestAll(t *testing.T) {
 	}
 
 	s := a.Deny()
-	if s.Code != int32(code.Code_FAILED_PRECONDITION) {
-		t.Errorf("a.Deny returned %d, expected %d", s.Code, int32(code.Code_FAILED_PRECONDITION))
+	if s.Code != int32(rpc.FAILED_PRECONDITION) {
+		t.Errorf("a.Deny returned %d, expected %d", s.Code, int32(rpc.FAILED_PRECONDITION))
 	}
 
 	if err = a.Close(); err != nil {
 		t.Errorf("a.Close failed: %v", err)
 	}
 
-	a, err = b.NewDenialsAspect(nil, &config.Params{Error: &rpc.Status{Code: int32(code.Code_INVALID_ARGUMENT)}})
+	a, err = b.NewDenialsAspect(nil, &config.Params{Error: &rpc.Status{Code: int32(rpc.INVALID_ARGUMENT)}})
 	if err != nil {
 		t.Errorf("Unable to create aspect: %v", err)
 	}
 
 	s = a.Deny()
-	if s.Code != int32(code.Code_INVALID_ARGUMENT) {
-		t.Errorf("a.Deny returned %d, expected %d", s.Code, int32(code.Code_INVALID_ARGUMENT))
+	if s.Code != int32(rpc.INVALID_ARGUMENT) {
+		t.Errorf("a.Deny returned %d, expected %d", s.Code, int32(rpc.INVALID_ARGUMENT))
 	}
 
 	if err = a.Close(); err != nil {

--- a/adapter/stdioLogger/BUILD
+++ b/adapter/stdioLogger/BUILD
@@ -21,6 +21,5 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//pkg/adapter/test:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/status:go_default_library",
     ],
 )

--- a/cmd/client/BUILD
+++ b/cmd/client/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//pkg/tracing:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_istio_api//:mixer/v1",
         "@com_github_opentracing_basictracer//:go_default_library",

--- a/cmd/client/util.go
+++ b/cmd/client/util.go
@@ -24,7 +24,6 @@ import (
 	ptypes "github.com/gogo/protobuf/types"
 	rpc "github.com/googleapis/googleapis/google/rpc"
 	bt "github.com/opentracing/basictracer-go"
-	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc"
 
 	mixerpb "istio.io/api/mixer/v1"
@@ -277,7 +276,7 @@ func decodeStatus(status *rpc.Status) string {
 		return "<invalid status>"
 	}
 
-	result, ok := code.Code_name[status.Code]
+	result, ok := rpc.Code_name[status.Code]
 	if !ok {
 		result = fmt.Sprintf("Code %d", status.Code)
 	}

--- a/cmd/client/util_test.go
+++ b/cmd/client/util_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	rpc "github.com/googleapis/googleapis/google/rpc"
-	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/pkg/attribute"
 )
@@ -165,10 +164,10 @@ func TestAttributeErrorHandling(t *testing.T) {
 func TestDecodeStatus(t *testing.T) {
 	// just making sure all paths work properly
 	cases := []rpc.Status{
-		{Code: int32(code.Code_ALREADY_EXISTS)},
+		{Code: int32(rpc.ALREADY_EXISTS)},
 		{Code: 123456},
 
-		{Code: int32(code.Code_ALREADY_EXISTS), Message: "FOO"},
+		{Code: int32(rpc.ALREADY_EXISTS), Message: "FOO"},
 		{Code: 123456, Message: "FOO"},
 	}
 

--- a/pkg/adapter/BUILD
+++ b/pkg/adapter/BUILD
@@ -19,7 +19,6 @@ go_library(
     ],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],

--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -33,7 +33,6 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_istio_api//:mixer/v1/config",
         "@com_github_istio_api//:mixer/v1/config/descriptor",

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	rpc "github.com/googleapis/googleapis/google/rpc"
-	"google.golang.org/genproto/googleapis/rpc/code"
 
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/aspect"
@@ -109,7 +108,7 @@ func (testAspect) Close() error { return nil }
 func (t testAspect) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma aspect.APIMethodArgs) (*aspect.Output, error) {
 	return t.body()
 }
-func (testAspect) Deny() rpc.Status { return rpc.Status{Code: int32(code.Code_INTERNAL)} }
+func (testAspect) Deny() rpc.Status { return rpc.Status{Code: int32(rpc.INTERNAL)} }
 
 func (m *fakemgr) NewAspect(cfg *config.Combined, adp adapter.Builder, env adapter.Env) (aspect.Wrapper, error) {
 	m.called++

--- a/pkg/adapterManager/parallelManager_test.go
+++ b/pkg/adapterManager/parallelManager_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/config"
@@ -30,12 +30,12 @@ import (
 func TestExecute(t *testing.T) {
 	cases := []struct {
 		name     string
-		inCode   code.Code
+		inCode   rpc.Code
 		inErr    error
-		wantCode code.Code
+		wantCode rpc.Code
 	}{
-		{aspect.DenialsKindName, code.Code_OK, nil, code.Code_OK},
-		{"error", code.Code_UNKNOWN, fmt.Errorf("expected"), code.Code_UNKNOWN},
+		{aspect.DenialsKindName, rpc.OK, nil, rpc.OK},
+		{"error", rpc.UNKNOWN, fmt.Errorf("expected"), rpc.UNKNOWN},
 	}
 
 	for _, c := range cases {
@@ -59,8 +59,8 @@ func TestExecute(t *testing.T) {
 		if c.inErr != nil && err == nil {
 			t.Errorf("m.Execute(...) = %v; want err: %v", err, c.inErr)
 		}
-		if c.inErr == nil && !(len(o) > 0 && o[0].Code == code.Code_OK) {
-			t.Errorf("m.Execute(...) = %v; wanted len(o) == 1 && o[0].Code == code.Code_OK", o)
+		if c.inErr == nil && !(len(o) > 0 && o[0].Code == rpc.OK) {
+			t.Errorf("m.Execute(...) = %v; wanted len(o) == 1 && o[0].Code == rpc.OK", o)
 		}
 	}
 }
@@ -87,7 +87,7 @@ func TestExecute_TimeoutWaitingForResults(t *testing.T) {
 	name := "blocked"
 	mngr := newTestManager(name, false, func() (*aspect.Output, error) {
 		<-blockChan
-		return &aspect.Output{Code: code.Code_OK}, nil
+		return &aspect.Output{Code: rpc.OK}, nil
 	})
 	mreg := map[aspect.Kind]aspect.Manager{
 		aspect.DenialsKind: mngr,

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -20,7 +20,6 @@ go_library(
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_istio_api//:mixer/v1",
         "@com_github_istio_api//:mixer/v1/config",

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"testing"
 
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 	"google.golang.org/grpc"
 
 	mixerpb "istio.io/api/mixer/v1"
@@ -104,12 +104,12 @@ func (ts *testState) cleanupTestState() {
 
 func (ts *testState) Check(ctx context.Context, tracker attribute.Tracker, request *mixerpb.CheckRequest, response *mixerpb.CheckResponse) {
 	response.RequestIndex = request.RequestIndex
-	response.Result = newStatus(code.Code_UNIMPLEMENTED)
+	response.Result = newStatus(rpc.UNIMPLEMENTED)
 }
 
 func (ts *testState) Report(ctx context.Context, tracker attribute.Tracker, request *mixerpb.ReportRequest, response *mixerpb.ReportResponse) {
 	response.RequestIndex = request.RequestIndex
-	response.Result = newStatus(code.Code_UNIMPLEMENTED)
+	response.Result = newStatus(rpc.UNIMPLEMENTED)
 }
 
 func (ts *testState) Quota(ctx context.Context, tracker attribute.Tracker, request *mixerpb.QuotaRequest, response *mixerpb.QuotaResponse) {

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/mixer/pkg/aspect"
@@ -57,7 +57,7 @@ func TestAspectManagerErrorsPropagated(t *testing.T) {
 	h.ConfigChange(&fakeresolver{[]*config.Combined{nil, nil}, nil})
 
 	s := h.execute(context.Background(), attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, aspect.CheckMethod, nil)
-	if s.Code != int32(code.Code_INTERNAL) {
-		t.Errorf("execute(..., invalidConfig, ...) returned %v, wanted status with code %v", s, code.Code_INTERNAL)
+	if s.Code != int32(rpc.INTERNAL) {
+		t.Errorf("execute(..., invalidConfig, ...) returned %v, wanted status with code %v", s, rpc.INTERNAL)
 	}
 }

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -28,7 +28,7 @@ go_library(
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_google_go_genproto//googleapis/rpc/code:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_istio_api//:mixer/v1",
         "@com_github_istio_api//:mixer/v1/config",

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -19,7 +19,7 @@ import (
 	"text/template"
 	"time"
 
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	"istio.io/mixer/pkg/adapter"
 	aconfig "istio.io/mixer/pkg/aspect/config"
@@ -168,7 +168,7 @@ func (e *accessLogsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, 
 
 	if len(entry.Labels) == 0 {
 		// don't write empty access logs
-		return &Output{Code: code.Code_OK}, nil
+		return &Output{Code: rpc.OK}, nil
 	}
 
 	buf := new(bytes.Buffer)
@@ -179,5 +179,5 @@ func (e *accessLogsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, 
 	if err := e.aspect.LogAccess([]adapter.LogEntry{entry}); err != nil {
 		return nil, err
 	}
-	return &Output{Code: code.Code_OK}, nil
+	return &Output{Code: rpc.OK}, nil
 }

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
@@ -163,7 +163,7 @@ func (e *applicationLogsWrapper) Execute(attrs attribute.Bag, mapper expr.Evalua
 			return nil, err
 		}
 	}
-	return &Output{Code: code.Code_OK}, nil
+	return &Output{Code: rpc.OK}, nil
 }
 
 type attrBagFn func(bag attribute.Bag, name string) (interface{}, bool)

--- a/pkg/aspect/denialsManager.go
+++ b/pkg/aspect/denialsManager.go
@@ -15,7 +15,7 @@
 package aspect
 
 import (
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	"istio.io/mixer/pkg/adapter"
 	aconfig "istio.io/mixer/pkg/aspect/config"
@@ -58,7 +58,7 @@ func (denialsManager) ValidateConfig(c adapter.AspectConfig) (ce *adapter.Config
 
 func (a *denialsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) (*Output, error) {
 	status := a.aspect.Deny()
-	return &Output{Code: code.Code(status.Code)}, nil
+	return &Output{Code: rpc.Code(status.Code)}, nil
 }
 
 func (a *denialsWrapper) Close() error { return a.aspect.Close() }

--- a/pkg/aspect/listsManager.go
+++ b/pkg/aspect/listsManager.go
@@ -17,7 +17,7 @@ package aspect
 import (
 	"fmt"
 
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	"istio.io/mixer/pkg/adapter"
 	aconfig "istio.io/mixer/pkg/aspect/config"
@@ -94,10 +94,10 @@ func (a *listsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma AP
 	if found, err = a.aspect.CheckList(symbol); err != nil {
 		return nil, err
 	}
-	rCode := code.Code_PERMISSION_DENIED
+	rCode := rpc.PERMISSION_DENIED
 
 	if found != a.params.Blacklist {
-		rCode = code.Code_OK
+		rCode = rpc.OK
 	}
 	return &Output{Code: rCode}, nil
 }

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -20,7 +20,7 @@ package aspect
 import (
 	"io"
 
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
@@ -33,7 +33,7 @@ type (
 	// Output captures the output from invoking an aspect.
 	Output struct {
 		// status code
-		Code code.Code
+		Code rpc.Code
 		//TODO attribute mutator
 		//If any attributes should change in the context for the next call
 		//context remains immutable during the call

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 	"github.com/hashicorp/go-multierror"
-	"google.golang.org/genproto/googleapis/rpc/code"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
@@ -167,7 +167,7 @@ func (w *metricsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma 
 	// return an OK alongside our errors (since presumably we're able to record at least a few).
 	var out *Output
 	if len(values) > 0 {
-		out = &Output{Code: code.Code_OK}
+		out = &Output{Code: rpc.OK}
 	}
 	if glog.V(4) {
 		glog.V(4).Infof("completed execution of metric adapter '%s' for %d values", w.name, len(values))

--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -20,7 +20,7 @@ import (
 	"sync/atomic"
 
 	ptypes "github.com/gogo/protobuf/types"
-	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
@@ -130,12 +130,12 @@ func (w *quotasWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma A
 
 	info, ok := w.metadata[qma.Quota]
 	if !ok {
-		return &Output{Code: code.Code_INVALID_ARGUMENT}, fmt.Errorf("unknown quota '%s'", qma.Quota)
+		return &Output{Code: rpc.INVALID_ARGUMENT}, fmt.Errorf("unknown quota '%s'", qma.Quota)
 	}
 
 	labels, err := evalAll(info.labels, attrs, mapper)
 	if err != nil {
-		return &Output{Code: code.Code_INTERNAL}, fmt.Errorf("failed to evaluate labels for quota '%s' with err: %s", qma.Quota, err)
+		return &Output{Code: rpc.INTERNAL}, fmt.Errorf("failed to evaluate labels for quota '%s' with err: %s", qma.Quota, err)
 	}
 
 	qa := adapter.QuotaArgs{
@@ -154,16 +154,16 @@ func (w *quotasWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma A
 	}
 
 	if err != nil {
-		return &Output{Code: code.Code_INTERNAL}, err
+		return &Output{Code: rpc.INTERNAL}, err
 	}
 
 	if amount == 0 {
-		return &Output{Code: code.Code_RESOURCE_EXHAUSTED}, nil
+		return &Output{Code: rpc.RESOURCE_EXHAUSTED}, nil
 	}
 
 	// TODO: need to return the allocated amount somehow in the Quota API's QuotaResponse message
 
-	return &Output{Code: code.Code_OK}, nil
+	return &Output{Code: rpc.OK}, nil
 }
 
 func (w *quotasWrapper) Close() error {


### PR DESCRIPTION
This CL transitions to using gogoslick for the google/rpc/code.proto
messages. In doing so, it also removes the remaining uses of the
standard golang generated code for protos from the codebase.

Tested with:

```shell
$ bazel clean
$ bazel test ...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/295)
<!-- Reviewable:end -->
