### PR TITLE
Add response_code to request_latency definition.

### DIFF
--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -82,6 +82,7 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 				{Name: "target", ValueType: dpb.STRING},
 				{Name: "service", ValueType: dpb.STRING},
 				{Name: "method", ValueType: dpb.STRING},
+				{Name: "response_code", ValueType: dpb.INT64},
 			},
 		},
 	}

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -27,6 +27,7 @@ rules:
           target: target.name | "unknown"
           service: api.name | "unknown"
           method: api.method | "unknown"
+          response_code: response.http.code | 200
   - kind: access-logs
     params:
       logName: "access_log"


### PR DESCRIPTION
This will align request_count and request_latency schemas for now.
That enables easier computation of latency over times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/312)
<!-- Reviewable:end -->
