### PR TITLE
Update grafana to aggregate traffic across response code.

### DIFF
--- a/deploy/kube/conf/grafana-dashboard.json
+++ b/deploy/kube/conf/grafana-dashboard.json
@@ -80,9 +80,9 @@
               "step": 2
             },
             {
-              "expr": "rate(request_count{response_code!=\"200\",source=~\"$source\",target=~\"$target\",service=~\"$service\"}[30s])",
+              "expr": "sum(rate(request_count{source=~\"$source\",target=~\"$target\",service=~\"$service\"}[30s])) without (response_code)",
               "intervalFactor": 2,
-              "legendFormat": "{{ source }} -> {{ target }} : {{ response_code }}",
+              "legendFormat": "{{ source }} -> {{ target }} : ALL",
               "refId": "B",
               "step": 2
             }
@@ -398,5 +398,5 @@
   },
   "timezone": "browser",
   "title": "Istio Dashboard",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
Previous version of the dashboard showed all the traffic broken out by response code in the request pane. This would update the request pane to only show 200s and ALL. The errors pane would then show the errors breakdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/325)
<!-- Reviewable:end -->
