### PR TITLE
Update how aspect managers return results.

### DIFF
--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -19,7 +19,9 @@ go_library(
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",
+        "//pkg/status:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
     ],
 )
 

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
+	"istio.io/mixer/pkg/status"
 )
 
 // Manager manages all aspects - provides uniform interface to
@@ -111,51 +112,45 @@ func newManager(r builderFinder, m map[aspect.Kind]aspect.Manager, exp expr.Eval
 }
 
 // Execute iterates over cfgs and performs the actions described by the combined config using the attribute bag on each config.
-// It returns the first error it encounters or the output of every combined config execution.
-func (m *Manager) Execute(ctx context.Context, cfgs []*config.Combined, attrs attribute.Bag, ma aspect.APIMethodArgs) ([]*aspect.Output, error) {
+func (m *Manager) Execute(ctx context.Context, cfgs []*config.Combined, attrs attribute.Bag, ma aspect.APIMethodArgs) aspect.Output {
 	// TODO: pool these arrays, we'll be making many and len(cfg) is constant for the life of the configuration.
-	outputs := make([]*aspect.Output, len(cfgs))
+	results := make([]result, len(cfgs))
 	for i, cfg := range cfgs {
-		out, err := m.execute(ctx, cfg, attrs, ma)
-		if err != nil {
-			return nil, err // we could return outputs (the results so far) too.
-		}
-		outputs[i] = out
+		results[i] = result{cfg, m.execute(ctx, cfg, attrs, ma)}
 	}
-	return outputs, nil
+	return combineResults(results)
 }
 
 // execute performs action described in the combined config using the attribute bag
-func (m *Manager) execute(ctx context.Context, cfg *config.Combined, attrs attribute.Bag, ma aspect.APIMethodArgs) (out *aspect.Output, err error) {
+func (m *Manager) execute(ctx context.Context, cfg *config.Combined, attrs attribute.Bag, ma aspect.APIMethodArgs) (out aspect.Output) {
 	var mgr aspect.Manager
 	var found bool
 
 	kind, found := aspect.ParseKind(cfg.Aspect.Kind)
 	if !found {
-		return nil, fmt.Errorf("invalid aspect %#v", cfg.Aspect.Kind)
+		return aspect.Output{Status: status.WithError(fmt.Errorf("invalid aspect %#v", cfg.Aspect.Kind))}
 	}
 
 	mgr, found = m.managers[kind]
 	if !found {
-		return nil, fmt.Errorf("could not find aspect manager %#v", cfg.Aspect.Kind)
+		return aspect.Output{Status: status.WithError(fmt.Errorf("could not find aspect manager %#v", cfg.Aspect.Kind))}
 	}
 
 	var adp adapter.Builder
 	if adp, found = m.builders.FindBuilder(cfg.Builder.Impl); !found {
-		return nil, fmt.Errorf("could not find registered adapter %#v", cfg.Builder.Impl)
+		return aspect.Output{Status: status.WithError(fmt.Errorf("could not find registered adapter %#v", cfg.Builder.Impl))}
 	}
 
 	// Both cacheGet and asp.Execute call adapter-supplied code, so we need to guard against both panicking.
 	defer func() {
 		if r := recover(); r != nil {
-			out = nil
-			err = fmt.Errorf("adapter '%s' panicked with '%v'", adp.Name(), r)
+			out = aspect.Output{Status: status.WithError(fmt.Errorf("adapter '%s' panicked with '%v'", adp.Name(), r))}
 		}
 	}()
 
-	var asp aspect.Wrapper
-	if asp, err = m.cacheGet(cfg, mgr, adp); err != nil {
-		return nil, err
+	asp, err := m.cacheGet(cfg, mgr, adp)
+	if err != nil {
+		return aspect.Output{Status: status.WithError(err)}
 	}
 
 	// TODO: plumb  ctx through asp.Execute

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/mixer/pkg/config"
 	configpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
+	"istio.io/mixer/pkg/status"
 )
 
 type (
@@ -59,7 +60,7 @@ type (
 	}
 
 	testAspect struct {
-		body func() (*aspect.Output, error)
+		body func() aspect.Output
 	}
 
 	fakewrapper struct {
@@ -74,7 +75,7 @@ type (
 
 func (f *fakeadp) Name() string { return f.name }
 
-func (f *fakewrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma aspect.APIMethodArgs) (output *aspect.Output, err error) {
+func (f *fakewrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma aspect.APIMethodArgs) (output aspect.Output) {
 	f.called++
 	return
 }
@@ -84,7 +85,7 @@ func (m *fakemgr) Kind() aspect.Kind {
 	return m.kind
 }
 
-func newTestManager(name string, throwOnNewAspect bool, body func() (*aspect.Output, error)) testManager {
+func newTestManager(name string, throwOnNewAspect bool, body func() aspect.Output) testManager {
 	return testManager{name, throwOnNewAspect, testAspect{body}}
 }
 func (testManager) Close() error                                                { return nil }
@@ -105,7 +106,7 @@ func (m testManager) NewDenyChecker(env adapter.Env, c adapter.AspectConfig) (ad
 }
 
 func (testAspect) Close() error { return nil }
-func (t testAspect) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma aspect.APIMethodArgs) (*aspect.Output, error) {
+func (t testAspect) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma aspect.APIMethodArgs) aspect.Output {
 	return t.body()
 }
 func (testAspect) Deny() rpc.Status { return rpc.Status{Code: int32(rpc.INTERNAL)} }
@@ -184,10 +185,8 @@ func TestManager(t *testing.T) {
 			mgr = newFakeMgrReg(tt.wrapper)
 		}
 		m := newManager(r, mgr, mapper, nil)
-		errStr := ""
-		if _, err := m.Execute(context.Background(), tt.cfg, attrs, nil); err != nil {
-			errStr = err.Error()
-		}
+		out := m.Execute(context.Background(), tt.cfg, attrs, nil)
+		errStr := out.Message()
 		if !strings.Contains(errStr, tt.errString) {
 			t.Errorf("[%d] expected: '%s' \ngot: '%s'", idx, tt.errString, errStr)
 		}
@@ -207,7 +206,7 @@ func TestManager(t *testing.T) {
 
 		// call again
 		// check for cache
-		_, _ = m.Execute(context.Background(), tt.cfg, attrs, nil)
+		_ = m.Execute(context.Background(), tt.cfg, attrs, nil)
 		if tt.wrapper.called != 2 {
 			t.Errorf("[%d] Expected 2nd wrapper call", idx)
 		}
@@ -253,10 +252,8 @@ func TestManager_BulkExecute(t *testing.T) {
 		mgr := newFakeMgrReg(&fakewrapper{})
 		m := newManager(r, mgr, mapper, nil)
 
-		errStr := ""
-		if _, err := m.Execute(context.Background(), c.cfgs, attrs, nil); err != nil {
-			errStr = err.Error()
-		}
+		out := m.Execute(context.Background(), c.cfgs, attrs, nil)
+		errStr := out.Message()
 		if !strings.Contains(errStr, c.errString) {
 			t.Errorf("[%d] got: '%s' want: '%s'", idx, c.errString, errStr)
 		}
@@ -275,12 +272,12 @@ func TestRecovery_AspectExecute(t *testing.T) {
 func testRecovery(t *testing.T, name string, throwOnNewAspect bool, throwOnExecute bool, want string) {
 	var cacheThrow testManager
 	if throwOnExecute {
-		cacheThrow = newTestManager(name, throwOnNewAspect, func() (*aspect.Output, error) {
+		cacheThrow = newTestManager(name, throwOnNewAspect, func() aspect.Output {
 			panic("panic")
 		})
 	} else {
-		cacheThrow = newTestManager(name, throwOnNewAspect, func() (*aspect.Output, error) {
-			return nil, fmt.Errorf("empty")
+		cacheThrow = newTestManager(name, throwOnNewAspect, func() aspect.Output {
+			return aspect.Output{Status: status.WithError(fmt.Errorf("empty"))}
 		})
 	}
 	mreg := map[aspect.Kind]aspect.Manager{
@@ -299,12 +296,12 @@ func testRecovery(t *testing.T, name string, throwOnNewAspect bool, throwOnExecu
 		},
 	}
 
-	_, err := m.Execute(context.Background(), cfg, nil, nil)
-	if err == nil {
-		t.Error("Aspect threw, but got no err from manager.Execute")
+	out := m.Execute(context.Background(), cfg, nil, nil)
+	if out.IsOK() {
+		t.Error("Aspect panicked, but got no error from manager.Execute")
 	}
 
-	if !strings.Contains(err.Error(), want) {
-		t.Errorf("Expected err from panic with message containing '%s', got: %v", want, err)
+	if !strings.Contains(out.Message(), want) {
+		t.Errorf("Expected err from panic with message containing '%s', got: %v", want, out.Message())
 	}
 }

--- a/pkg/adapterManager/parallelManager_test.go
+++ b/pkg/adapterManager/parallelManager_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/config"
 	configpb "istio.io/mixer/pkg/config/proto"
+	"istio.io/mixer/pkg/status"
 )
 
 func TestExecute(t *testing.T) {
@@ -39,8 +40,8 @@ func TestExecute(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		mngr := newTestManager(c.name, false, func() (*aspect.Output, error) {
-			return &aspect.Output{Code: c.inCode}, c.inErr
+		mngr := newTestManager(c.name, false, func() aspect.Output {
+			return aspect.Output{Status: status.New(c.inCode)}
 		})
 		mreg := map[aspect.Kind]aspect.Manager{
 			aspect.DenialsKind: mngr,
@@ -55,12 +56,12 @@ func TestExecute(t *testing.T) {
 			{&configpb.Adapter{Name: c.name}, &configpb.Aspect{Kind: c.name}},
 		}
 
-		o, err := m.Execute(context.Background(), cfg, nil, nil)
-		if c.inErr != nil && err == nil {
-			t.Errorf("m.Execute(...) = %v; want err: %v", err, c.inErr)
+		o := m.Execute(context.Background(), cfg, nil, nil)
+		if c.inErr != nil && o.IsOK() {
+			t.Errorf("m.Execute(...) want err: %v", c.inErr)
 		}
-		if c.inErr == nil && !(len(o) > 0 && o[0].Code == rpc.OK) {
-			t.Errorf("m.Execute(...) = %v; wanted len(o) == 1 && o[0].Code == rpc.OK", o)
+		if c.inErr == nil && !o.IsOK() {
+			t.Errorf("m.Execute(...) = %v; wanted o.Status.Code == rpc.OK", o)
 		}
 	}
 }
@@ -74,7 +75,7 @@ func TestExecute_Cancellation(t *testing.T) {
 	cfg := []*config.Combined{
 		{&configpb.Adapter{Name: ""}, &configpb.Aspect{Kind: ""}},
 	}
-	if _, err := handler.Execute(ctx, cfg, &fakebag{}, nil); err == nil {
+	if out := handler.Execute(ctx, cfg, &fakebag{}, nil); out.IsOK() {
 		t.Error("handler.Execute(canceledContext, ...) = _, nil; wanted any err")
 	}
 
@@ -85,9 +86,9 @@ func TestExecute_TimeoutWaitingForResults(t *testing.T) {
 	blockChan := make(chan struct{})
 
 	name := "blocked"
-	mngr := newTestManager(name, false, func() (*aspect.Output, error) {
+	mngr := newTestManager(name, false, func() aspect.Output {
 		<-blockChan
-		return &aspect.Output{Code: rpc.OK}, nil
+		return aspect.Output{Status: status.OK}
 	})
 	mreg := map[aspect.Kind]aspect.Manager{
 		aspect.DenialsKind: mngr,
@@ -107,7 +108,7 @@ func TestExecute_TimeoutWaitingForResults(t *testing.T) {
 		&configpb.Adapter{Name: name},
 		&configpb.Aspect{Kind: name},
 	}}
-	if _, err := m.Execute(ctx, cfg, &fakebag{}, nil); err == nil {
+	if out := m.Execute(ctx, cfg, &fakebag{}, nil); out.IsOK() {
 		t.Error("handler.Execute(canceledContext, ...) = _, nil; wanted any err")
 	}
 	close(blockChan)

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//pkg/config:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
+        "//pkg/status:go_default_library",
         "//pkg/tracing:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_glog//:go_default_library",

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -26,6 +26,7 @@ import (
 
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/status"
 	"istio.io/mixer/pkg/tracing"
 )
 
@@ -106,17 +107,21 @@ func (ts *testState) cleanupTestState() {
 }
 
 func (ts *testState) Check(ctx context.Context, tracker attribute.Tracker, request *mixerpb.CheckRequest, response *mixerpb.CheckResponse) {
+	s := status.New(rpc.UNIMPLEMENTED)
 	response.RequestIndex = request.RequestIndex
-	response.Result = newStatus(rpc.UNIMPLEMENTED)
+	response.Result = &s
 }
 
 func (ts *testState) Report(ctx context.Context, tracker attribute.Tracker, request *mixerpb.ReportRequest, response *mixerpb.ReportResponse) {
+	s := status.New(rpc.UNIMPLEMENTED)
 	response.RequestIndex = request.RequestIndex
-	response.Result = newStatus(rpc.UNIMPLEMENTED)
+	response.Result = &s
 }
 
 func (ts *testState) Quota(ctx context.Context, tracker attribute.Tracker, request *mixerpb.QuotaRequest, response *mixerpb.QuotaResponse) {
+	s := status.New(rpc.UNIMPLEMENTED)
 	response.RequestIndex = request.RequestIndex
+	response.Result = &s
 	response.Amount = 0
 }
 

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/status"
 )
 
 // Handler holds pointers to the functions that implement
@@ -52,7 +53,7 @@ type Handler interface {
 // Executor executes any aspect as described by config.Combined.
 type Executor interface {
 	// Execute takes a set of configurations and Executes all of them.
-	Execute(ctx context.Context, cfgs []*config.Combined, attrs attribute.Bag, ma aspect.APIMethodArgs) ([]*aspect.Output, error)
+	Execute(ctx context.Context, cfgs []*config.Combined, attrs attribute.Bag, ma aspect.APIMethodArgs) aspect.Output
 }
 
 // handlerState holds state and configuration for the handler.
@@ -75,12 +76,12 @@ func NewHandler(aspectExecutor Executor, methodMap map[aspect.APIMethod]config.A
 
 // execute performs common functions shared across the api surface.
 func (h *handlerState) execute(ctx context.Context, tracker attribute.Tracker, attrs *mixerpb.Attributes,
-	method aspect.APIMethod, ma aspect.APIMethodArgs) *rpc.Status {
+	method aspect.APIMethod, ma aspect.APIMethodArgs) rpc.Status {
 	ab, err := tracker.StartRequest(attrs)
 	if err != nil {
 		msg := fmt.Sprintf("Unable to process attribute update: %v", err)
 		glog.Error(msg)
-		return newStatusWithMessage(rpc.INVALID_ARGUMENT, msg)
+		return status.WithInvalidArgument(msg)
 	}
 	defer tracker.EndRequest()
 
@@ -92,31 +93,21 @@ func (h *handlerState) execute(ctx context.Context, tracker attribute.Tracker, a
 		// config has NOT been loaded yet
 		const msg = "Configuration is not available"
 		glog.Error(msg)
-		return newStatusWithMessage(rpc.INTERNAL, msg)
+		return status.WithInternal(msg)
 	}
 	cfg := untypedCfg.(config.Resolver)
 	cfgs, err := cfg.Resolve(ab, h.methodMap[method])
 	if err != nil {
 		msg := fmt.Sprintf("unable to resolve config: %v", err)
 		glog.Error(msg)
-		return newStatusWithMessage(rpc.INTERNAL, msg)
+		return status.WithInternal(msg)
 	}
 
 	if glog.V(2) {
 		glog.Infof("Resolved [%d] ==> %v ", len(cfgs), cfgs)
 	}
 
-	outs, err := h.aspectExecutor.Execute(ctx, cfgs, ab, ma)
-	if err != nil {
-		return newStatusWithMessage(rpc.INTERNAL, err.Error())
-	}
-
-	for _, out := range outs {
-		if out.Code != rpc.OK {
-			return newStatus(out.Code)
-		}
-	}
-	return newStatus(rpc.OK)
+	return h.aspectExecutor.Execute(ctx, cfgs, ab, ma).Status
 }
 
 // Check performs 'check' function corresponding to the mixer api.
@@ -125,8 +116,9 @@ func (h *handlerState) Check(ctx context.Context, tracker attribute.Tracker, req
 		glog.Infof("Check [%x]", request.RequestIndex)
 	}
 
+	s := h.execute(ctx, tracker, request.AttributeUpdate, aspect.CheckMethod, &aspect.CheckMethodArgs{})
 	response.RequestIndex = request.RequestIndex
-	response.Result = h.execute(ctx, tracker, request.AttributeUpdate, aspect.CheckMethod, &aspect.CheckMethodArgs{})
+	response.Result = &s
 
 	if glog.V(2) {
 		glog.Infof("Check [%x] <-- %s", request.RequestIndex, response)
@@ -139,8 +131,9 @@ func (h *handlerState) Report(ctx context.Context, tracker attribute.Tracker, re
 		glog.Infof("Report [%x]", request.RequestIndex)
 	}
 
+	s := h.execute(ctx, tracker, request.AttributeUpdate, aspect.ReportMethod, &aspect.ReportMethodArgs{})
 	response.RequestIndex = request.RequestIndex
-	response.Result = h.execute(ctx, tracker, request.AttributeUpdate, aspect.ReportMethod, &aspect.ReportMethodArgs{})
+	response.Result = &s
 
 	if glog.V(2) {
 		glog.Infof("Report [%x] <-- %s", request.RequestIndex, response)
@@ -169,14 +162,6 @@ func (h *handlerState) Quota(ctx context.Context, tracker attribute.Tracker, req
 	if glog.V(2) {
 		glog.Infof("Quota [%x] <-- %s", request.RequestIndex, response)
 	}
-}
-
-func newStatus(c rpc.Code) *rpc.Status {
-	return &rpc.Status{Code: int32(c)}
-}
-
-func newStatusWithMessage(c rpc.Code, message string) *rpc.Status {
-	return &rpc.Status{Code: int32(c), Message: message}
 }
 
 // ConfigChange listens for config change notifications.

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",
+        "//pkg/status:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestNewAccessLoggerManager(t *testing.T) {
-	m := NewAccessLogsManager()
+	m := newAccessLogsManager()
 	if m.Kind() != AccessLogsKind {
 		t.Errorf("Wrong kind of adapter; got %v, want %v", m.Kind(), AccessLogsKind)
 	}
@@ -85,7 +85,7 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 		{"custom", &aconfig.AccessLogsParams{}, customStruct, customExec},
 	}
 
-	m := NewAccessLogsManager()
+	m := newAccessLogsManager()
 
 	for _, v := range newAspectShouldSucceed {
 		c := config.Combined{
@@ -132,7 +132,7 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 		{"badTemplateCfg", badTemplateCfg, okLogger},
 	}
 
-	m := NewAccessLogsManager()
+	m := newAccessLogsManager()
 	for _, v := range failureCases {
 		if _, err := m.NewAspect(v.cfg, v.adptr, test.Env{}); err == nil {
 			t.Errorf("NewAspect()[%s]: expected error for bad adapter (%T)", v.name, v.adptr)
@@ -149,7 +149,7 @@ func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
 		&aconfig.AccessLogsParams{LogFormat: aconfig.CUSTOM, CustomLogTemplate: "{{.test}}"},
 	}
 
-	m := NewAccessLogsManager()
+	m := newAccessLogsManager()
 	for _, v := range configs {
 		if err := m.ValidateConfig(v); err != nil {
 			t.Errorf("ValidateConfig(%v) => unexpected error: %v", v, err)
@@ -162,7 +162,7 @@ func TestAccessLoggerManager_ValidateConfigFailures(t *testing.T) {
 		&aconfig.AccessLogsParams{LogFormat: aconfig.CUSTOM, CustomLogTemplate: "{{.test"},
 	}
 
-	m := NewAccessLogsManager()
+	m := newAccessLogsManager()
 	for _, v := range configs {
 		if err := m.ValidateConfig(v); err == nil {
 			t.Errorf("ValidateConfig(%v): expected error", v)
@@ -217,8 +217,8 @@ func TestAccessLoggerWrapper_Execute(t *testing.T) {
 		l := &test.Logger{}
 		v.exec.aspect = l
 
-		if _, err := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); err != nil {
-			t.Errorf("Execute(): should not have received error for %s (%v)", v.name, err)
+		if out := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); !out.IsOK() {
+			t.Errorf("Execute(): should not have received error for %s (%v)", v.name, out.Message())
 		}
 		if l.EntryCount != len(v.wantEntries) {
 			t.Errorf("Execute(): got %d entries, wanted %d for %s", l.EntryCount, len(v.wantEntries), v.name)
@@ -256,7 +256,7 @@ func TestAccessLoggerWrapper_ExecuteFailures(t *testing.T) {
 	}
 
 	for _, v := range tests {
-		if _, err := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); err == nil {
+		if out := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); out.IsOK() {
 			t.Errorf("Execute(): expected error for %s", v.name)
 		}
 	}

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -41,7 +41,7 @@ type (
 )
 
 func TestNewLoggerManager(t *testing.T) {
-	m := NewApplicationLogsManager()
+	m := newApplicationLogsManager()
 	if m.Kind() != ApplicationLogsKind {
 		t.Error("Wrong kind of manager")
 	}
@@ -70,7 +70,7 @@ func TestLoggerManager_NewLogger(t *testing.T) {
 		{"override", &aconfig.ApplicationLogsParams{LogName: "istio_log", TimestampFormat: "2006-Jan-02"}, overrideExec},
 	}
 
-	m := NewApplicationLogsManager()
+	m := newApplicationLogsManager()
 
 	for _, v := range newAspectShouldSucceed {
 		c := config.Combined{
@@ -109,7 +109,7 @@ func TestLoggerManager_NewLoggerFailures(t *testing.T) {
 		{defaultCfg, errLogger},
 	}
 
-	m := NewApplicationLogsManager()
+	m := newApplicationLogsManager()
 	for _, v := range failureCases {
 		if _, err := m.NewAspect(v.cfg, v.adptr, test.Env{}); err == nil {
 			t.Errorf("NewAspect(): expected error for bad adapter (%T)", v.adptr)
@@ -196,8 +196,8 @@ func TestLoggerManager_Execute(t *testing.T) {
 		l := &test.Logger{}
 		v.exec.aspect = l
 
-		if _, err := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); err != nil {
-			t.Errorf("Execute(): should not have received error for %s (%v)", v.name, err)
+		if out := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); !out.IsOK() {
+			t.Errorf("Execute(): should not have received error for %s (%v)", v.name, out.Message())
 		}
 		if l.EntryCount != len(v.wantEntries) {
 			t.Errorf("Execute(): got %d entries, wanted %d for %s", l.EntryCount, len(v.wantEntries), v.name)
@@ -239,14 +239,14 @@ func TestLoggerManager_ExecuteFailures(t *testing.T) {
 	}
 
 	for _, v := range executeShouldFail {
-		if _, err := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); err == nil {
+		if out := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); out.IsOK() {
 			t.Errorf("Execute(): should have received error for %s", v.name)
 		}
 	}
 }
 
 func TestLoggerManager_DefaultConfig(t *testing.T) {
-	m := NewApplicationLogsManager()
+	m := newApplicationLogsManager()
 	got := m.DefaultConfig()
 	want := &aconfig.ApplicationLogsParams{LogName: "istio_log", TimestampFormat: time.RFC3339}
 	if !proto.Equal(got, want) {
@@ -255,7 +255,7 @@ func TestLoggerManager_DefaultConfig(t *testing.T) {
 }
 
 func TestLoggerManager_ValidateConfig(t *testing.T) {
-	m := NewApplicationLogsManager()
+	m := newApplicationLogsManager()
 	if err := m.ValidateConfig(&ptypes.Empty{}); err != nil {
 		t.Errorf("ValidateConfig(): unexpected error: %v", err)
 	}

--- a/pkg/aspect/denialsManager.go
+++ b/pkg/aspect/denialsManager.go
@@ -15,8 +15,6 @@
 package aspect
 
 import (
-	rpc "github.com/googleapis/googleapis/google/rpc"
-
 	"istio.io/mixer/pkg/adapter"
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
@@ -32,8 +30,8 @@ type (
 	}
 )
 
-// NewDenialsManager returns a manager for the denials aspect.
-func NewDenialsManager() Manager {
+// newDenialsManager returns a manager for the denials aspect.
+func newDenialsManager() Manager {
 	return denialsManager{}
 }
 
@@ -56,9 +54,8 @@ func (denialsManager) Kind() Kind                                               
 func (denialsManager) DefaultConfig() adapter.AspectConfig                              { return &aconfig.DenialsParams{} }
 func (denialsManager) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) { return }
 
-func (a *denialsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) (*Output, error) {
-	status := a.aspect.Deny()
-	return &Output{Code: rpc.Code(status.Code)}, nil
+func (a *denialsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) Output {
+	return Output{Status: a.aspect.Deny()}
 }
 
 func (a *denialsWrapper) Close() error { return a.aspect.Close() }

--- a/pkg/aspect/denialsManager_test.go
+++ b/pkg/aspect/denialsManager_test.go
@@ -17,5 +17,5 @@ package aspect
 import "testing"
 
 func TestDenyCheckerManager(t *testing.T) {
-	_ = NewDenialsManager()
+	_ = newDenialsManager()
 }

--- a/pkg/aspect/inventory.go
+++ b/pkg/aspect/inventory.go
@@ -21,19 +21,19 @@ type ManagerInventory map[APIMethod][]Manager
 func Inventory() ManagerInventory {
 	return ManagerInventory{
 		CheckMethod: {
-			NewDenialsManager(),
-			NewListsManager(),
-			NewQuotasManager(), // TODO: Remove once proxy uses the Quota method
+			newDenialsManager(),
+			newListsManager(),
+			newQuotasManager(), // TODO: Remove once proxy uses the Quota method
 		},
 
 		ReportMethod: {
-			NewApplicationLogsManager(),
-			NewAccessLogsManager(),
-			NewMetricsManager(),
+			newApplicationLogsManager(),
+			newAccessLogsManager(),
+			newMetricsManager(),
 		},
 
 		QuotaMethod: {
-			NewQuotasManager(),
+			newQuotasManager(),
 		},
 	}
 }

--- a/pkg/aspect/listsManager_test.go
+++ b/pkg/aspect/listsManager_test.go
@@ -17,5 +17,5 @@ package aspect
 import "testing"
 
 func TestListCheckerManager(t *testing.T) {
-	_ = NewListsManager()
+	_ = newListsManager()
 }

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -26,14 +26,15 @@ import (
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
+	"istio.io/mixer/pkg/status"
 )
 
 type (
-
 	// Output captures the output from invoking an aspect.
 	Output struct {
 		// status code
-		Code rpc.Code
+		Status rpc.Status
+
 		//TODO attribute mutator
 		//If any attributes should change in the context for the next call
 		//context remains immutable during the call
@@ -56,6 +57,16 @@ type (
 		io.Closer
 
 		// Execute dispatches to the adapter.
-		Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) (*Output, error)
+		Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) Output
 	}
 )
+
+// IsOK returns whether the Output represents success or failure
+func (o Output) IsOK() bool {
+	return status.IsOK(o.Status)
+}
+
+// Message returns te the message string of the Output's embedded Status struct
+func (o Output) Message() string {
+	return o.Status.Message
+}

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -65,7 +65,7 @@ func (b *fakeBuilder) NewMetricsAspect(env adapter.Env, config adapter.AspectCon
 }
 
 func TestNewMetricsManager(t *testing.T) {
-	m := NewMetricsManager()
+	m := newMetricsManager()
 	if m.Kind() != MetricsKind {
 		t.Errorf("m.Kind() = %s wanted %s", m.Kind(), MetricsKind)
 	}
@@ -93,7 +93,7 @@ func TestMetricsManager_NewAspect(t *testing.T) {
 	builder := &fakeBuilder{name: "test", body: func() (adapter.MetricsAspect, error) {
 		return &fakeaspect{body: func([]adapter.Value) error { return nil }}, nil
 	}}
-	if _, err := NewMetricsManager().NewAspect(conf, builder, atest.NewEnv(t)); err != nil {
+	if _, err := newMetricsManager().NewAspect(conf, builder, atest.NewEnv(t)); err != nil {
 		t.Errorf("NewAspect(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -109,9 +109,9 @@ func TestMetricsManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.MetricsAspect, error) {
 			return nil, fmt.Errorf(errString)
 		}}
-	_, err := NewMetricsManager().NewAspect(conf, builder, atest.NewEnv(t))
+	_, err := newMetricsManager().NewAspect(conf, builder, atest.NewEnv(t))
 	if err == nil {
-		t.Error("NewMetricsManager().NewAspect(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
+		t.Error("newMetricsManager().NewAspect(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}
 	if !strings.Contains(err.Error(), errString) {
 		t.Errorf("NewAspect(conf, builder, test.NewEnv(t)) = _, %v; wanted err %s", err, errString)
@@ -205,14 +205,11 @@ func TestMetricsWrapper_Execute(t *testing.T) {
 				}},
 				metadata: c.mdin,
 			}
-			_, err := wrapper.Execute(test.NewBag(), c.eval, &ReportMethodArgs{})
+			out := wrapper.Execute(test.NewBag(), c.eval, &ReportMethodArgs{})
 
-			errString := ""
-			if err != nil {
-				errString = err.Error()
-			}
+			errString := out.Message()
 			if !strings.Contains(errString, c.errString) {
-				t.Errorf("wrapper.Execute(&fakeBag{}, eval) = _, %v; wanted err containing %s", err, c.errString)
+				t.Errorf("wrapper.Execute(&fakeBag{}, eval) = _, %v; wanted error containing %s", out.Message(), c.errString)
 			}
 
 			if len(receivedValues) != len(c.out) {

--- a/pkg/status/BUILD
+++ b/pkg/status/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "status.go",
+    ],
+    deps = [
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
+    ],
+)
+
+go_test(
+    name = "small_tests",
+    size = "small",
+    srcs = [
+        "status_test.go",
+    ],
+    library = ":go_default_library",
+)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,68 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package status provides utility functions for RPC status objects.
+package status
+
+import (
+	rpc "github.com/googleapis/googleapis/google/rpc"
+)
+
+// OK represents a status with a code of rpc.OK
+var OK = rpc.Status{Code: int32(rpc.OK)}
+
+// New returns an initialized status with the given error code.
+func New(c rpc.Code) rpc.Status {
+	return rpc.Status{Code: int32(c)}
+}
+
+// WithMessage returns an initialized status with the given error code and message
+func WithMessage(c rpc.Code, message string) rpc.Status {
+	return rpc.Status{Code: int32(c), Message: message}
+}
+
+// WithError returns an initialized status with the rpc.INTERNAL error code and the error's message.
+func WithError(err error) rpc.Status {
+	return rpc.Status{Code: int32(rpc.INTERNAL), Message: err.Error()}
+}
+
+// WithInternal returns an initialized status with the rpc.INTERNAL error code and the error's message.
+func WithInternal(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.INTERNAL), Message: message}
+}
+
+// WithInvalidArgument returns an initialized status with the rpc.INVALID_ARGUMENT code and the given message.
+func WithInvalidArgument(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.INVALID_ARGUMENT), Message: message}
+}
+
+// WithPermissionDenied returns an initialized status with the rpc.PERMISSION_DENIED code and the given message.
+func WithPermissionDenied(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.PERMISSION_DENIED), Message: message}
+}
+
+// WithResourceExhausted returns an initialized status with the rpc.PERMISSION_DENIED code and the given message.
+func WithResourceExhausted(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.RESOURCE_EXHAUSTED), Message: message}
+}
+
+// WithDeadlineExceeded returns an initialized status with the rpc.DEADLINE_EXCEEDED code and the given message.
+func WithDeadlineExceeded(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.DEADLINE_EXCEEDED), Message: message}
+}
+
+// IsOK returns true is the given status has the code rpc.OK
+func IsOK(status rpc.Status) bool {
+	return status.Code == int32(rpc.OK)
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"testing"
+
+	rpc "github.com/googleapis/googleapis/google/rpc"
+)
+
+func TestStatus(t *testing.T) {
+	if !IsOK(OK) {
+		t.Error("Expecting the OK status to actually be, well, you know, OK...")
+	}
+
+	s := New(rpc.ABORTED)
+	if s.Code != int32(rpc.ABORTED) {
+		t.Errorf("Got %v, expected rpc.ABORTED", s.Code)
+	}
+
+	s = WithMessage(rpc.ABORTED, "Aborted!")
+	if s.Code != int32(rpc.ABORTED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.ABORTED Aborted!", s.Code, s.Message)
+	}
+
+	s = WithInternal("Aborted!")
+	if s.Code != int32(rpc.INTERNAL) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.INTERNAL Aborted!", s.Code, s.Message)
+	}
+
+	s = WithPermissionDenied("Aborted!")
+	if s.Code != int32(rpc.PERMISSION_DENIED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.PERMISSION_DENIED Aborted!", s.Code, s.Message)
+	}
+
+	s = WithInvalidArgument("Aborted!")
+	if s.Code != int32(rpc.INVALID_ARGUMENT) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.INVALID_ARGUMENT Aborted!", s.Code, s.Message)
+	}
+
+	s = WithResourceExhausted("Aborted!")
+	if s.Code != int32(rpc.RESOURCE_EXHAUSTED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.RESOURCE_EXHAUSTED Aborted!", s.Code, s.Message)
+	}
+
+	s = WithDeadlineExceeded("Aborted!")
+	if s.Code != int32(rpc.DEADLINE_EXCEEDED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.DEADLINE_EXCEEDED Aborted!", s.Code, s.Message)
+	}
+}


### PR DESCRIPTION
- Aspect managers no longer return both an Output and an error
since that was confusing. They now just return Output structs.

- Have the Output struct hold an rpc.Status instead of an rpc.Code
which allows richer error returns (since rpc.Status has a Message field)

- Make the parallel aspect dispatch code wait for all async work to complete
before returning instead of early-aborting on errors. This is so when, for
example, a Check call is denied, all the failure causes are returned in
one shot.

- Given the ability for Output to hold a Status object, this fixes the
Denials aspect manager to successfully pass-on status message text from
config.

- Make the aspect manager's various NewXXX into newXXX since they don't need
to be exposed out of the aspect package.

- Added the status package with utility functions to manipulate rpc.Status
structs

- Switched some code patterns to use structs rather than pointers in order to
avoid allocs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/328)
<!-- Reviewable:end -->
