### PR TITLE
Configure grafana image to allow anonymous access

### DIFF
--- a/deploy/kube/conf/Dockerfile
+++ b/deploy/kube/conf/Dockerfile
@@ -5,6 +5,11 @@ from grafana/grafana:4.1.2
 RUN apt-get update
 RUN apt-get install -y curl
 
+# allow anonymous access
+ENV GF_AUTH_DISABLE_LOGIN_FORM=true
+ENV GF_AUTH_ANONYMOUS_ENABLED=true
+ENV GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+
 COPY ./start.sh /start.sh
 COPY ./grafana-dashboard.json /grafana-dashboard.json
 COPY ./import_dashboard.sh ./import_dashboard.sh


### PR DESCRIPTION
This is required for using kube proxy (instead of exposing IP addr -- helpful for demos/gcpnext).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/330)
<!-- Reviewable:end -->
