### PR TITLE
Fill-in QuotaResponse for Quota API calls.

### DIFF
--- a/pkg/adapter/quotas.go
+++ b/pkg/adapter/quotas.go
@@ -22,10 +22,10 @@ type (
 		Aspect
 
 		// Alloc allocates the specified amount or fails when not available.
-		Alloc(QuotaArgs) (int64, error)
+		Alloc(QuotaArgs) (QuotaResult, error)
 
 		// AllocBestEffort allocates from 0 to the specified amount, based on availability.
-		AllocBestEffort(QuotaArgs) (int64, error)
+		AllocBestEffort(QuotaArgs) (QuotaResult, error)
 
 		// ReleaseBestEffort releases from 0 to the specified amount, based on current usage.
 		ReleaseBestEffort(QuotaArgs) (int64, error)
@@ -77,5 +77,14 @@ type (
 
 		// Labels determine the identity of the quota cell.
 		Labels map[string]interface{}
+	}
+
+	// QuotaResult provides return values from quota allocation calls
+	QuotaResult struct {
+		// The amount of time until which the returned quota expires, this is 0 for non-expiring quotas.
+		Expiration time.Duration
+
+		// The total amount of quota returned, may be less than requested.
+		Amount int64
 	}
 )

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
+	ptypes "github.com/gogo/protobuf/types"
 	"github.com/golang/glog"
-	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/mixer/pkg/aspect"
@@ -76,12 +77,12 @@ func NewHandler(aspectExecutor Executor, methodMap map[aspect.APIMethod]config.A
 
 // execute performs common functions shared across the api surface.
 func (h *handlerState) execute(ctx context.Context, tracker attribute.Tracker, attrs *mixerpb.Attributes,
-	method aspect.APIMethod, ma aspect.APIMethodArgs) rpc.Status {
+	method aspect.APIMethod, ma aspect.APIMethodArgs) aspect.Output {
 	ab, err := tracker.StartRequest(attrs)
 	if err != nil {
 		msg := fmt.Sprintf("Unable to process attribute update: %v", err)
 		glog.Error(msg)
-		return status.WithInvalidArgument(msg)
+		return aspect.Output{Status: status.WithInvalidArgument(msg)}
 	}
 	defer tracker.EndRequest()
 
@@ -93,21 +94,21 @@ func (h *handlerState) execute(ctx context.Context, tracker attribute.Tracker, a
 		// config has not been loaded yet
 		const msg = "Configuration is not yet available"
 		glog.Error(msg)
-		return status.WithInternal(msg)
+		return aspect.Output{Status: status.WithInternal(msg)}
 	}
 
 	cfgs, err := cfg.Resolve(ab, h.methodMap[method])
 	if err != nil {
 		msg := fmt.Sprintf("unable to resolve config: %v", err)
 		glog.Error(msg)
-		return status.WithInternal(msg)
+		return aspect.Output{Status: status.WithInternal(msg)}
 	}
 
 	if glog.V(2) {
 		glog.Infof("Resolved [%d] ==> %v ", len(cfgs), cfgs)
 	}
 
-	return h.aspectExecutor.Execute(ctx, cfgs, ab, ma).Status
+	return h.aspectExecutor.Execute(ctx, cfgs, ab, ma)
 }
 
 // Check performs 'check' function corresponding to the mixer api.
@@ -116,9 +117,14 @@ func (h *handlerState) Check(ctx context.Context, tracker attribute.Tracker, req
 		glog.Infof("Check [%x]", request.RequestIndex)
 	}
 
-	s := h.execute(ctx, tracker, request.AttributeUpdate, aspect.CheckMethod, &aspect.CheckMethodArgs{})
+	o := h.execute(ctx, tracker, request.AttributeUpdate, aspect.CheckMethod, &aspect.CheckMethodArgs{})
 	response.RequestIndex = request.RequestIndex
-	response.Result = &s
+	response.Result = &o.Status
+
+	// TODO: this value needs to initially come from config, and be modulated by the kind of attribute
+	//       that was used in the check and the in-used aspects (for example, maybe an auth check has a
+	//       30s TTL but a whitelist check has got a 120s TTL)
+	response.Expiration = ptypes.DurationProto(time.Duration(5) * time.Second)
 
 	if glog.V(2) {
 		glog.Infof("Check [%x] <-- %s", request.RequestIndex, response)
@@ -131,9 +137,9 @@ func (h *handlerState) Report(ctx context.Context, tracker attribute.Tracker, re
 		glog.Infof("Report [%x]", request.RequestIndex)
 	}
 
-	s := h.execute(ctx, tracker, request.AttributeUpdate, aspect.ReportMethod, &aspect.ReportMethodArgs{})
+	o := h.execute(ctx, tracker, request.AttributeUpdate, aspect.ReportMethod, &aspect.ReportMethodArgs{})
 	response.RequestIndex = request.RequestIndex
-	response.Result = &s
+	response.Result = &o.Status
 
 	if glog.V(2) {
 		glog.Infof("Report [%x] <-- %s", request.RequestIndex, response)
@@ -147,7 +153,7 @@ func (h *handlerState) Quota(ctx context.Context, tracker attribute.Tracker, req
 	}
 
 	response.RequestIndex = request.RequestIndex
-	status := h.execute(ctx, tracker, request.AttributeUpdate, aspect.QuotaMethod,
+	o := h.execute(ctx, tracker, request.AttributeUpdate, aspect.QuotaMethod,
 		&aspect.QuotaMethodArgs{
 			Quota:           request.Quota,
 			Amount:          request.Amount,
@@ -155,8 +161,11 @@ func (h *handlerState) Quota(ctx context.Context, tracker attribute.Tracker, req
 			BestEffort:      request.BestEffort,
 		})
 
-	if status.Code == int32(rpc.OK) {
-		response.Amount = 1
+	response.Result = &o.Status
+	if o.IsOK() {
+		resp := o.Response.(*aspect.QuotaMethodResp)
+		response.Amount = resp.Amount
+		response.Expiration = ptypes.DurationProto(resp.Expiration)
 	}
 
 	if glog.V(2) {

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -54,9 +54,9 @@ func TestAspectManagerErrorsPropagated(t *testing.T) {
 	h := &handlerState{aspectExecutor: f, methodMap: map[aspect.APIMethod]config.AspectSet{}}
 	h.ConfigChange(&fakeresolver{[]*config.Combined{nil, nil}, nil})
 
-	s := h.execute(context.Background(), attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, aspect.CheckMethod, nil)
-	if s.Code != int32(rpc.INTERNAL) {
-		t.Errorf("execute(..., invalidConfig, ...) returned %v, wanted status with code %v", s, rpc.INTERNAL)
+	o := h.execute(context.Background(), attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, aspect.CheckMethod, nil)
+	if o.Status.Code != int32(rpc.INTERNAL) {
+		t.Errorf("execute(..., invalidConfig, ...) returned %v, wanted status with code %v", o.Status, rpc.INTERNAL)
 	}
 }
 

--- a/pkg/aspect/apiMethod.go
+++ b/pkg/aspect/apiMethod.go
@@ -14,6 +14,8 @@
 
 package aspect
 
+import "time"
+
 // APIMethod constants are used to refer to the methods handled by api.Handler
 type APIMethod int
 
@@ -46,14 +48,27 @@ type (
 	// APIMethodArgs provides additional method-specific parameters
 	APIMethodArgs interface{}
 
+	// APIMethodResp provides additional method-specific output values
+	APIMethodResp interface{}
+
 	// CheckMethodArgs is supplied by invocations of the Check method.
 	CheckMethodArgs struct {
 		APIMethodArgs
 	}
 
+	// CheckMethodResp is returned by invocations of the Check method.
+	CheckMethodResp struct {
+		APIMethodResp
+	}
+
 	// ReportMethodArgs is supplied by invocations of the Report method.
 	ReportMethodArgs struct {
 		APIMethodArgs
+	}
+
+	// ReportMethodResp is returned by invocations of the Report method.
+	ReportMethodResp struct {
+		APIMethodResp
 	}
 
 	// QuotaMethodArgs is supplied by invocations of the Quota method.
@@ -75,5 +90,16 @@ type (
 		// false, the exact requested amount is returned or 0 if not enough quota
 		// was available.
 		BestEffort bool
+	}
+
+	// QuotaMethodResp is returned by invocations of the Quota method.
+	QuotaMethodResp struct {
+		APIMethodResp
+
+		// The amount of time until which the returned quota expires, this is 0 for non-expiring quotas.
+		Expiration time.Duration
+
+		// The total amount of quota returned, may be less than requested.
+		Amount int64
 	}
 )

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -35,6 +35,9 @@ type (
 		// status code
 		Status rpc.Status
 
+		// Additional method-specific returned state
+		Response APIMethodResp
+
 		//TODO attribute mutator
 		//If any attributes should change in the context for the next call
 		//context remains immutable during the call

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -38,7 +38,7 @@ import (
 type fakeQuotaAspect struct {
 	adapter.Aspect
 	closed bool
-	body   func(adapter.QuotaArgs) (int64, error)
+	body   func(adapter.QuotaArgs) (adapter.QuotaResult, error)
 }
 
 func (a *fakeQuotaAspect) Close() error {
@@ -46,11 +46,11 @@ func (a *fakeQuotaAspect) Close() error {
 	return nil
 }
 
-func (a fakeQuotaAspect) Alloc(qa adapter.QuotaArgs) (int64, error) {
+func (a fakeQuotaAspect) Alloc(qa adapter.QuotaArgs) (adapter.QuotaResult, error) {
 	return a.body(qa)
 }
 
-func (a fakeQuotaAspect) AllocBestEffort(qa adapter.QuotaArgs) (int64, error) {
+func (a fakeQuotaAspect) AllocBestEffort(qa adapter.QuotaArgs) (adapter.QuotaResult, error) {
 	return a.body(qa)
 }
 
@@ -201,9 +201,9 @@ func TestQuotaWrapper_Execute(t *testing.T) {
 		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			var receivedArgs adapter.QuotaArgs
 			wrapper := &quotasWrapper{
-				aspect: &fakeQuotaAspect{body: func(qa adapter.QuotaArgs) (int64, error) {
+				aspect: &fakeQuotaAspect{body: func(qa adapter.QuotaArgs) (adapter.QuotaResult, error) {
 					receivedArgs = qa
-					return c.allocAmount, c.allocErr
+					return adapter.QuotaResult{Amount: c.allocAmount, Expiration: time.Duration(0)}, c.allocErr
 				}},
 				metadata: c.mdin,
 			}


### PR DESCRIPTION
This weaves a method return value through the layer in a way similar to how I weaved method arguments through the layers. This change introduces a TTL at the quota adapter layer, needed for prefetching of rate limiting quotas.

Also note the lack of tests for the changes in api/handlers.go. That whole file has almost non-existent testing for the time being. I plan to rewrite this file nearly completely to support OOO evaluation of incoming mixer API calls. When I do the rewrite, I'll add a full complement of tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/339)
<!-- Reviewable:end -->
