### PR TITLE
Fixed bug in attribute tracker around invalid attribute updates.

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -88,14 +88,14 @@ func (h *handlerState) execute(ctx context.Context, tracker attribute.Tracker, a
 	// get a new context with the attribute bag attached
 	ctx = attribute.NewContext(ctx, ab)
 
-	untypedCfg := h.cfg.Load()
-	if untypedCfg == nil {
-		// config has NOT been loaded yet
-		const msg = "Configuration is not available"
+	cfg := h.cfg.Load().(config.Resolver)
+	if cfg == nil {
+		// config has not been loaded yet
+		const msg = "Configuration is not yet available"
 		glog.Error(msg)
 		return status.WithInternal(msg)
 	}
-	cfg := untypedCfg.(config.Resolver)
+
 	cfgs, err := cfg.Resolve(ab, h.methodMap[method])
 	if err != nil {
 		msg := fmt.Sprintf("unable to resolve config: %v", err)

--- a/pkg/attribute/dictionaries.go
+++ b/pkg/attribute/dictionaries.go
@@ -28,7 +28,7 @@ import (
 
 type dictionary map[int32]string
 
-type dictionaryEntry struct {
+type refCountedDictionary struct {
 	// immutable dictionary
 	dictionary dictionary
 
@@ -42,7 +42,7 @@ type dictionaryEntry struct {
 // memory consumption and improves processor cache efficiency.
 type dictionaries struct {
 	sync.Mutex
-	entries []dictionaryEntry
+	entries []refCountedDictionary
 }
 
 // See if two dictionaries are identical
@@ -87,7 +87,7 @@ func (d *dictionaries) Intern(dict dictionary) dictionary {
 		}
 	}
 
-	d.entries = append(d.entries, dictionaryEntry{dict, 1})
+	d.entries = append(d.entries, refCountedDictionary{dict, 1})
 	return dict
 }
 


### PR DESCRIPTION
- The attribute tracker would get confused if a new dictionary was
supplied with a mixer API request, along with a bogus attribute
update message. When this happened, the new dictionary was consumed
and used, even though the attribute update failed. This would leave
the end-to-end protocol in a confused state until a new
dictionary was pushed.

This fixes issue #340

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/341)
<!-- Reviewable:end -->
