### PR TITLE
Update ApplicationLogsManager

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,7 +158,7 @@ new_git_or_local_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
     path = "../api",
-    commit = "36787dfa214fb9ba24ce2bfaa54d07ab887141f0", # Feb 27, 2017 (no releases)
+    commit = "8e2d3e7c4a5670d6559105e22ae0a2f2e20b90a2", # Mar 6, 2017 (no releases)
     remote = "https://github.com/istio/api.git",
     # Change this to True to use ../api directory
     use_local = False,

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -57,7 +57,7 @@ type (
 )
 
 const (
-	// TEXT describes a log entry whose TextPayload should be set.
+	// Text describes a log entry whose TextPayload should be set.
 	Text PayloadFormat = iota
 	// JSON describes a log entry whose StructPayload should be set.
 	JSON

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -17,7 +17,11 @@ package aspect
 import (
 	"encoding/json"
 	"fmt"
+	"text/template"
 	"time"
+
+	"github.com/golang/glog"
+	"github.com/hashicorp/go-multierror"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
@@ -25,48 +29,37 @@ import (
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
+	"istio.io/mixer/pkg/pool"
 	"istio.io/mixer/pkg/status"
 )
 
 type (
+	// PayloadFormat describes the format of the LogEntry's payload.
+	PayloadFormat int
+
 	applicationLogsManager struct{}
 
+	logInfo struct {
+		format    PayloadFormat
+		severity  string
+		timestamp string
+		tmpl      *template.Template
+		tmplExprs map[string]string
+		labels    map[string]string
+	}
+
 	applicationLogsWrapper struct {
-		logName            string
-		descriptors        []dpb.LogEntryDescriptor // describe entries to gen
-		inputs             map[string]string        // map from param to expr
-		severityAttribute  string
-		timestampAttribute string
-		timestampFmt       string
-		aspect             adapter.ApplicationLogsAspect
-		defaultTimeFn      func() time.Time
+		name     string
+		aspect   adapter.ApplicationLogsAspect
+		metadata map[string]*logInfo // descriptor_name -> info
 	}
 )
 
-var (
-	defaultLog = dpb.LogEntryDescriptor{
-		Name:             "default",
-		DisplayName:      "Default Log Entry",
-		Description:      "Placeholder log descriptor",
-		PayloadAttribute: "logMessage",
-		Attributes: []string{
-			"serviceName",
-			"peerId",
-			"operationId",
-			"operationName",
-			"apiKey",
-			"url",
-			"location",
-			"apiName",
-			"apiVersion",
-			"apiMethod",
-			"requestSize",
-			"responseSize",
-			"responseTime",
-			"originIp",
-			"originHost",
-		},
-	}
+const (
+	// TEXT describes a log entry whose TextPayload should be set.
+	TEXT = iota
+	// JSON describes a log entry whose StructPayload should be set.
+	JSON
 )
 
 // newApplicationLogsManager returns a manager for the application logs aspect.
@@ -75,29 +68,56 @@ func newApplicationLogsManager() Manager {
 }
 
 func (applicationLogsManager) NewAspect(c *config.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
-	aspect, err := a.(adapter.ApplicationLogsBuilder).NewApplicationLogsAspect(env, c.Builder.Params.(adapter.AspectConfig))
+	// TODO: look up actual descriptors by name and build an array
+	cfg := c.Aspect.Params.(*aconfig.ApplicationLogsParams)
+
+	desc := []*dpb.LogEntryDescriptor{
+		{
+			Name:        "default",
+			DisplayName: "Default Log Entry",
+			Description: "Placeholder log descriptor",
+		},
+	}
+
+	metadata := make(map[string]*logInfo)
+	for _, d := range desc {
+		l, found := findLog(cfg.Logs, d.Name)
+		if !found {
+			env.Logger().Warningf("No application log found for descriptor %s, skipping it", d.Name)
+			continue
+		}
+
+		// TODO: remove this error handling once validate config is given descriptors to validate
+		t, err := template.New(d.Name).Parse(d.LogTemplate)
+		if err != nil {
+			env.Logger().Warningf("log descriptors %s's template '%s' failed to parse with err: %s", d.Name, d.LogTemplate, err)
+		}
+
+		metadata[d.Name] = &logInfo{
+			format:    payloadFormatFromProto(d.PayloadFormat),
+			severity:  l.Severity,
+			timestamp: l.Timestamp,
+			tmpl:      t,
+			tmplExprs: l.TemplateExpressions,
+			labels:    l.Labels,
+		}
+	}
+
+	asp, err := a.(adapter.ApplicationLogsBuilder).NewApplicationLogsAspect(env, c.Builder.Params.(adapter.AspectConfig))
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: look up actual descriptors by name and build an array
-	logCfg := c.Aspect.Params.(*aconfig.ApplicationLogsParams)
-
 	return &applicationLogsWrapper{
-		logCfg.LogName,
-		[]dpb.LogEntryDescriptor{defaultLog},
-		c.Aspect.GetInputs(),
-		logCfg.SeverityAttribute,
-		logCfg.TimestampAttribute,
-		logCfg.TimestampFormat,
-		aspect,
-		time.Now,
+		name:     cfg.LogName,
+		aspect:   asp,
+		metadata: metadata,
 	}, nil
 }
 
 func (applicationLogsManager) Kind() Kind { return ApplicationLogsKind }
 func (applicationLogsManager) DefaultConfig() adapter.AspectConfig {
-	return &aconfig.ApplicationLogsParams{LogName: "istio_log", TimestampFormat: time.RFC3339}
+	return &aconfig.ApplicationLogsParams{LogName: "istio_log"}
 }
 
 // TODO: validation of timestamp format
@@ -108,107 +128,100 @@ func (applicationLogsManager) ValidateConfig(c adapter.AspectConfig) (ce *adapte
 func (e *applicationLogsWrapper) Close() error { return e.aspect.Close() }
 
 func (e *applicationLogsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) Output {
+	result := &multierror.Error{}
 	var entries []adapter.LogEntry
 
-	// TODO: would be nice if we could use a mutable.Bag here and could pass it around
-	// labels holds the generated attributes from mapper
-	labels := make(map[string]interface{})
-	for attr, exp := range e.inputs {
-		if val, err := mapper.Eval(exp, attrs); err == nil {
-			labels[attr] = val
+	for name, md := range e.metadata {
+		labels, err := evalAll(md.labels, attrs, mapper)
+		if err != nil {
+			result = multierror.Append(result, fmt.Errorf("failed to eval labels for log entry '%s' with err: %s", name, err))
+			continue
 		}
-	}
 
-	for _, d := range e.descriptors {
+		templateVals, err := evalAll(md.tmplExprs, attrs, mapper)
+		if err != nil {
+			result = multierror.Append(result, fmt.Errorf("failed to eval template values for log entry '%s' with err: %s", name, err))
+			continue
+		}
+
+		buf := pool.GetBuffer()
+		err = md.tmpl.Execute(buf, templateVals)
+		if err != nil {
+			pool.PutBuffer(buf)
+			result = multierror.Append(result, fmt.Errorf(
+				"failed to construct payload string for log entry '%s' with template execution err: %s", name, err))
+			continue
+		}
+
+		sevStr, err := mapper.EvalString(md.severity, attrs)
+		if err != nil {
+			result = multierror.Append(result,
+				fmt.Errorf("failed to eval severity for log entry '%s', continuing with DEFAULT severity. Eval err: %s", name, err))
+			sevStr = ""
+		}
+		// If we can't parse the string we'll get the default severity, so we don't care about the success return.
+		severity, _ := adapter.SeverityByName(sevStr)
+
+		et, err := mapper.Eval(md.timestamp, attrs)
+		if err != nil {
+			result = multierror.Append(result,
+				fmt.Errorf("failed to eval time for log entry '%s', continuing with time.Now(). Eval err: %s", name, err))
+			et = time.Now()
+		}
+		t, _ := et.(time.Time) // we don't check the cast because expression type checking ensures we get a time.
+
 		entry := adapter.LogEntry{
-			LogName:   e.logName,
-			Labels:    make(map[string]interface{}),
-			Severity:  severityVal(e.severityAttribute, attrs, labels),
-			Timestamp: timeVal(e.timestampAttribute, attrs, labels, e.defaultTimeFn()).Format(e.timestampFmt),
+			LogName:   e.name,
+			Labels:    labels,
+			Timestamp: t.String(),
+			Severity:  severity,
 		}
 
-		payloadStr := stringVal(d.PayloadAttribute, attrs, labels, "")
-		switch d.PayloadFormat {
-		case dpb.TEXT:
-			entry.TextPayload = payloadStr
-		case dpb.JSON:
-			err := json.Unmarshal([]byte(payloadStr), &entry.StructPayload)
-			if err != nil {
-				return Output{Status: status.WithError(fmt.Errorf("could not unmarshal json payload: %v", err))}
-			}
-		}
-
-		for _, a := range d.Attributes {
-			if a == d.PayloadAttribute {
+		switch md.format {
+		case TEXT:
+			entry.TextPayload = buf.String()
+		case JSON:
+			if err := json.Unmarshal(buf.Bytes(), &entry.StructPayload); err != nil {
+				result = multierror.Append(result, fmt.Errorf("failed to unmarshall json payload for log entry %s with err: %s", name, err))
 				continue
 			}
-			if val, ok := labels[a]; ok {
-				entry.Labels[a] = val
-				continue
-			}
-			if val, found := attribute.Value(attrs, a); found {
-				entry.Labels[a] = val
-			}
-
-			// TODO: do we want to error for attributes that cannot
-			// be found?
 		}
+		pool.PutBuffer(buf)
 
 		entries = append(entries, entry)
 	}
-
 	if len(entries) > 0 {
 		if err := e.aspect.Log(entries); err != nil {
 			return Output{Status: status.WithError(err)}
 		}
 	}
+
+	err := result.ErrorOrNil()
+	if glog.V(4) {
+		glog.Infof("completed execution of application logging adapter '%s' for %d entries with errs: %v", e.name, len(entries), err)
+	}
+	if err != nil {
+		return Output{Status: status.WithError(err)}
+	}
 	return Output{Status: status.OK}
 }
 
-type attrBagFn func(bag attribute.Bag, name string) (interface{}, bool)
-
-var (
-	strFn  = func(bag attribute.Bag, name string) (interface{}, bool) { return bag.String(name) }
-	timeFn = func(bag attribute.Bag, name string) (interface{}, bool) { return bag.Time(name) }
-)
-
-func stringVal(attrName string, attrs attribute.Bag, labels map[string]interface{}, dfault string) string {
-	if v, ok := value(attrName, attrs, strFn, labels).(string); ok {
-		return v
-	}
-	return dfault
-}
-
-func severityVal(attrName string, attrs attribute.Bag, labels map[string]interface{}) adapter.Severity {
-	if name, ok := value(attrName, attrs, strFn, labels).(string); ok {
-		if s, found := adapter.SeverityByName(name); found {
-			return s
+func findLog(defs []*aconfig.ApplicationLogsParams_ApplicationLog, name string) (*aconfig.ApplicationLogsParams_ApplicationLog, bool) {
+	for _, def := range defs {
+		if def.DescriptorName == name {
+			return def, true
 		}
 	}
-	return adapter.Default
+	return nil, false
 }
 
-func timeVal(attrName string, attrs attribute.Bag, labels map[string]interface{}, dfault time.Time) time.Time {
-	if v, ok := value(attrName, attrs, timeFn, labels).(time.Time); ok {
-		return v
+func payloadFormatFromProto(format dpb.LogEntryDescriptor_PayloadFormat) PayloadFormat {
+	switch format {
+	case dpb.JSON:
+		return JSON
+	case dpb.TEXT:
+		fallthrough
+	default:
+		return TEXT
 	}
-	return dfault
-}
-
-func value(attrName string, attrBag attribute.Bag, fn attrBagFn, labels map[string]interface{}) interface{} {
-	if attrName == "" {
-		return nil
-	}
-
-	// check generated labels first, then attributes
-	if v, ok := labels[attrName]; ok {
-		return v
-	}
-
-	if v, ok := fn(attrBag, attrName); ok {
-		return v
-	}
-
-	// TODO: errors needed here? As of now, this causes default vals to be returned
-	return nil
 }

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -253,7 +253,7 @@ func TestLogWrapper_Execute(t *testing.T) {
 			if l.EntryCount != len(tt.wantEntries) {
 				t.Fatalf("Execute(): got %d entries, wanted %d for %s", l.EntryCount, len(tt.wantEntries), tt.name)
 			}
-			if !reflect.DeepEqual(l.Logs, tt.wantEntries) {
+			if !deepEqualIgnoreOrder(l.Logs, tt.wantEntries) {
 				t.Fatalf("Execute(): got %v, wanted %v for %s", l.Logs, tt.wantEntries, tt.name)
 			}
 		})
@@ -378,4 +378,20 @@ func TestPayloadFormatFromProto(t *testing.T) {
 			}
 		})
 	}
+}
+
+// We can't actually nail down which entries correspond to each other as there's no unique identifier per entry.
+// We'll do the n^2 compare-everything-to-everything method. Keep actual and expected small!
+func deepEqualIgnoreOrder(actual, expected []adapter.LogEntry) bool {
+	for _, e := range expected {
+		result := false
+		for _, a := range actual {
+			result = result || reflect.DeepEqual(e, a)
+		}
+		// bail early: we found no match for this e
+		if !result {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -15,8 +15,10 @@
 package aspect
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"text/template"
 	"time"
 
 	ptypes "github.com/gogo/protobuf/types"
@@ -24,6 +26,7 @@ import (
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
+	atest "istio.io/mixer/pkg/adapter/test"
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/aspect/test"
 	"istio.io/mixer/pkg/attribute"
@@ -40,6 +43,15 @@ type (
 	}
 )
 
+func evalErrOnStr(s string) expr.Evaluator {
+	return test.NewFakeEval(func(e string, _ attribute.Bag) (interface{}, error) {
+		if e == s {
+			return "", fmt.Errorf("expected error for %s", s)
+		}
+		return e, nil
+	})
+}
+
 func TestNewLoggerManager(t *testing.T) {
 	m := newApplicationLogsManager()
 	if m.Kind() != ApplicationLogsKind {
@@ -50,205 +62,293 @@ func TestNewLoggerManager(t *testing.T) {
 func TestLoggerManager_NewLogger(t *testing.T) {
 	tl := &test.Logger{}
 	defaultExec := &applicationLogsWrapper{
-		logName:      "istio_log",
-		timestampFmt: time.RFC3339,
-		aspect:       tl,
-		inputs:       map[string]string{},
-		descriptors:  []dpb.LogEntryDescriptor{defaultLog},
+		name:   "istio_log",
+		aspect: tl,
+		metadata: map[string]*logInfo{
+			"default": {},
+		},
 	}
 
 	overrideExec := &applicationLogsWrapper{
-		logName:      "istio_log",
-		timestampFmt: "2006-Jan-02",
-		aspect:       tl,
-		inputs:       map[string]string{},
-		descriptors:  []dpb.LogEntryDescriptor{defaultLog},
+		name:   "istio_log",
+		aspect: tl,
+		metadata: map[string]*logInfo{
+			"default": {},
+		},
+	}
+
+	emptyExec := &applicationLogsWrapper{
+		name:     "istio_log",
+		aspect:   tl,
+		metadata: make(map[string]*logInfo),
 	}
 
 	newAspectShouldSucceed := []aspectTestCase{
-		{"empty", &aconfig.ApplicationLogsParams{LogName: "istio_log", TimestampFormat: time.RFC3339}, defaultExec},
-		{"override", &aconfig.ApplicationLogsParams{LogName: "istio_log", TimestampFormat: "2006-Jan-02"}, overrideExec},
+		{"empty", &aconfig.ApplicationLogsParams{
+			LogName: "istio_log",
+			Logs: []*aconfig.ApplicationLogsParams_ApplicationLog{
+				{
+					DescriptorName: "default",
+					TimeFormat:     time.RFC3339,
+				},
+			}}, defaultExec},
+		{"override", &aconfig.ApplicationLogsParams{
+			LogName: "istio_log",
+			Logs: []*aconfig.ApplicationLogsParams_ApplicationLog{
+				{
+					DescriptorName: "default",
+					TimeFormat:     "2006-Jan-02",
+				},
+			}}, overrideExec},
+		// TODO: should this be an error? An aspect with no logInfo objects will never do any work.
+		{"no descriptors", &aconfig.ApplicationLogsParams{
+			LogName: "istio_log",
+			Logs: []*aconfig.ApplicationLogsParams_ApplicationLog{
+				{
+					DescriptorName: "no descriptor with this name",
+					TimeFormat:     time.RFC3339,
+				},
+			}}, emptyExec},
 	}
 
 	m := newApplicationLogsManager()
 
-	for _, v := range newAspectShouldSucceed {
-		c := config.Combined{
-			Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
-			Aspect:  &configpb.Aspect{Params: v.params, Inputs: map[string]string{}},
-		}
-		asp, err := m.NewAspect(&c, tl, test.Env{})
-		if err != nil {
-			t.Errorf("NewAspect(): should not have received error for %s (%v)", v.name, err)
-		}
-		got := asp.(*applicationLogsWrapper)
-		got.defaultTimeFn = nil // ignore time fns in equality comp
-		if !reflect.DeepEqual(got, v.want) {
-			t.Errorf("%s NewAspect() => %v (%T), want %v (%T)", v.name, got, got, v.want, v.want)
-		}
+	for idx, v := range newAspectShouldSucceed {
+		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
+			c := config.Combined{
+				Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
+				Aspect:  &configpb.Aspect{Params: v.params, Inputs: map[string]string{}},
+			}
+			asp, err := m.NewAspect(&c, tl, atest.NewEnv(t))
+			if err != nil {
+				t.Fatalf("NewAspect(): should not have received error for %s (%v)", v.name, err)
+			}
+			got := asp.(*applicationLogsWrapper)
+			// We ignore templates because reflect.DeepEqual doesn't seem to work with them.
+			for key := range got.metadata {
+				got.metadata[key].tmpl = nil
+			}
+			if !reflect.DeepEqual(got, v.want) {
+				t.Errorf("NewAspect() = %#+v, wanted %#+v", got, v.want)
+			}
+		})
 	}
 }
 
 func TestLoggerManager_NewLoggerFailures(t *testing.T) {
 
-	defaultCfg := &config.Combined{
-		Builder: &configpb.Adapter{
-			Params: &ptypes.Empty{},
-		},
-		Aspect: &configpb.Aspect{
-			Params: &aconfig.ApplicationLogsParams{LogName: "istio_log", TimestampFormat: time.RFC3339},
+	defaultCfg := &aconfig.ApplicationLogsParams{
+		LogName: "istio_log",
+		Logs: []*aconfig.ApplicationLogsParams_ApplicationLog{
+			{
+				DescriptorName: "default",
+				TimeFormat:     time.RFC3339,
+			},
 		},
 	}
 
 	errLogger := &test.Logger{DefaultCfg: &ptypes.Empty{}, ErrOnNewAspect: true}
 
 	failureCases := []struct {
-		cfg   *config.Combined
+		name  string
+		cfg   *aconfig.ApplicationLogsParams
 		adptr adapter.Builder
 	}{
-		{defaultCfg, errLogger},
+		{"new aspect error", defaultCfg, errLogger},
 	}
 
 	m := newApplicationLogsManager()
-	for _, v := range failureCases {
-		if _, err := m.NewAspect(v.cfg, v.adptr, test.Env{}); err == nil {
-			t.Errorf("NewAspect(): expected error for bad adapter (%T)", v.adptr)
-		}
+	for idx, v := range failureCases {
+		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
+			cfg := &config.Combined{
+				Builder: &configpb.Adapter{
+					Params: &ptypes.Empty{},
+				},
+				Aspect: &configpb.Aspect{
+					Params: v.cfg,
+				},
+			}
+
+			if _, err := m.NewAspect(cfg, v.adptr, atest.NewEnv(t)); err == nil {
+				t.Fatalf("NewAspect(): expected error for bad adapter (%T)", v.adptr)
+			}
+		})
 	}
 }
 
-func TestLoggerManager_Execute(t *testing.T) {
-	testTime, _ := time.Parse("2006-Jan-02", "2011-Aug-14")
-	noPayloadDesc := dpb.LogEntryDescriptor{
-		Name:       "test",
-		Attributes: []string{"attr"},
-	}
-	payloadDesc := dpb.LogEntryDescriptor{
-		Name:             "test",
-		Attributes:       []string{"attr", "payload"},
-		PayloadAttribute: "payload",
-	}
-	jsonPayloadDesc := dpb.LogEntryDescriptor{
-		Name:             "test",
-		Attributes:       []string{"key"},
-		PayloadAttribute: "payload",
-		PayloadFormat:    dpb.JSON,
-	}
-	withInputsDesc := dpb.LogEntryDescriptor{
-		Name:             "test",
-		Attributes:       []string{"key"},
-		PayloadAttribute: "attr",
+func TestLogWrapper_Execute(t *testing.T) {
+	tmpl, _ := template.New("test").Parse("{{.test}}")
+	jsontmpl, _ := template.New("test").Parse(`{"value": "{{.test}}"}`)
+
+	textLogInfo := logInfo{
+		format:    TEXT,
+		severity:  "DEFAULT",
+		timestamp: "timestamp",
+		tmpl:      tmpl,
+		tmplExprs: map[string]string{"test": "value"},
+		labels:    map[string]string{"label1": "label1val"},
 	}
 
-	noDescriptorExec := &applicationLogsWrapper{"istio_log", []dpb.LogEntryDescriptor{}, map[string]string{}, "severity", "ts", "", nil, time.Now}
-	noPayloadExec := &applicationLogsWrapper{"istio_log",
-		[]dpb.LogEntryDescriptor{noPayloadDesc}, map[string]string{"attr": "val"}, "severity", "ts", "", nil, time.Now}
-	payloadExec := &applicationLogsWrapper{"istio_log",
-		[]dpb.LogEntryDescriptor{payloadDesc}, map[string]string{"attr": "val"}, "severity", "ts", "", nil, time.Now}
-	jsonPayloadExec := &applicationLogsWrapper{"istio_log", []dpb.LogEntryDescriptor{jsonPayloadDesc},
-		map[string]string{"attr": "val"}, "severity", "ts", "", nil, time.Now}
-	withInputsExec := &applicationLogsWrapper{"istio_log",
-		[]dpb.LogEntryDescriptor{withInputsDesc}, map[string]string{"attr": "val"}, "severity", "ts", "", nil, time.Now}
-	withTimestampFormatExec := &applicationLogsWrapper{
-		"istio_log",
-		[]dpb.LogEntryDescriptor{noPayloadDesc},
-		map[string]string{"attr": "val"},
-		"severity",
-		"ts",
-		"2006-Jan-02",
-		nil,
-		time.Now,
+	noDescriptors := &applicationLogsWrapper{
+		name:     "name",
+		metadata: make(map[string]*logInfo),
 	}
 
-	jsonBag := &test.Bag{Strs: map[string]string{"key": "value", "payload": `{"obj":{"val":54},"question":true}`}}
-	tsBag := &test.Bag{Times: map[string]time.Time{"ts": testTime}}
+	textPayload := &applicationLogsWrapper{
+		name: "name",
+		metadata: map[string]*logInfo{
+			"text": &textLogInfo,
+		},
+	}
+	textPayloadEntry := adapter.LogEntry{
+		LogName:     "name",
+		Labels:      map[string]interface{}{"label1": "label1val"},
+		TextPayload: "value",
+		Timestamp:   time.Time{}.String(),
+		Severity:    adapter.Default,
+	}
 
-	structPayload := map[string]interface{}{"obj": map[string]interface{}{"val": float64(54)}, "question": true}
+	jsonLogInfo := textLogInfo
+	jsonLogInfo.format = JSON
+	jsonLogInfo.tmpl = jsontmpl
 
-	defaultEntry := test.NewLogEntry("istio_log", map[string]interface{}{"attr": "val"}, "", adapter.Default, "", nil)
-	infoEntry := test.NewLogEntry("istio_log", map[string]interface{}{"attr": "val"}, "", adapter.Info, "", nil)
-	textPayloadEntry := test.NewLogEntry("istio_log", map[string]interface{}{"attr": "val"}, "", adapter.Default, "test", nil)
-	jsonPayloadEntry := test.NewLogEntry("istio_log", map[string]interface{}{"key": "value"}, "", adapter.Default, "", structPayload)
-	inputsEntry := test.NewLogEntry("istio_log", map[string]interface{}{"key": "value"}, "", adapter.Default, "val", nil)
-	timeEntry := test.NewLogEntry("istio_log", map[string]interface{}{"attr": "val"}, "2011-Aug-14", adapter.Default, "", nil)
+	jsonPayload := &applicationLogsWrapper{
+		name: "name",
+		metadata: map[string]*logInfo{
+			"json": &jsonLogInfo,
+		},
+	}
+	jsonPayloadEntry := textPayloadEntry
+	jsonPayloadEntry.TextPayload = ""
+	jsonPayloadEntry.StructPayload = map[string]interface{}{"value": "value"}
 
-	executeShouldSucceed := []struct {
+	multipleLogs := &applicationLogsWrapper{
+		name: "name",
+		metadata: map[string]*logInfo{
+			"json": jsonPayload.metadata["json"],
+			"text": textPayload.metadata["text"],
+		},
+	}
+
+	tests := []struct {
 		name        string
 		exec        *applicationLogsWrapper
 		bag         attribute.Bag
 		mapper      expr.Evaluator
 		wantEntries []adapter.LogEntry
 	}{
-		{"no descriptors", noDescriptorExec, test.NewBag(), test.NewIDEval(), nil},
-		{"no payload", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
-		{"severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "info"}}, test.NewIDEval(), []adapter.LogEntry{infoEntry}},
-		{"bad severity", noPayloadExec, &test.Bag{Strs: map[string]string{"key": "value", "severity": "500"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
-		{"payload not found", payloadExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
-		{"with payload", payloadExec, &test.Bag{Strs: map[string]string{"key": "value", "payload": "test"}}, test.NewIDEval(), []adapter.LogEntry{textPayloadEntry}},
-		{"with json payload", jsonPayloadExec, jsonBag, test.NewIDEval(), []adapter.LogEntry{jsonPayloadEntry}},
-		{"with payload from inputs", withInputsExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval(), []adapter.LogEntry{inputsEntry}},
-		{"with non-default time", payloadExec, &test.Bag{Times: map[string]time.Time{"ts": time.Now()}}, test.NewIDEval(), []adapter.LogEntry{defaultEntry}},
-		{"with non-default time and format", withTimestampFormatExec, tsBag, test.NewIDEval(), []adapter.LogEntry{timeEntry}},
-		{"with inputs", withInputsExec, &test.Bag{Strs: map[string]string{"key": "value", "payload": "test"}}, test.NewIDEval(), []adapter.LogEntry{inputsEntry}},
+		{"no descriptors", noDescriptors, test.NewBag(), test.NewIDEval(), nil},
+		{"text payload", textPayload, test.NewBag(), test.NewIDEval(), []adapter.LogEntry{textPayloadEntry}},
+		{"json payload", jsonPayload, test.NewBag(), test.NewIDEval(), []adapter.LogEntry{jsonPayloadEntry}},
+		{"multiple logs", multipleLogs, test.NewBag(), test.NewIDEval(), []adapter.LogEntry{jsonPayloadEntry, textPayloadEntry}},
 	}
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			l := &test.Logger{}
+			tt.exec.aspect = l
 
-	for _, v := range executeShouldSucceed {
-		l := &test.Logger{}
-		v.exec.aspect = l
-
-		if out := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); !out.IsOK() {
-			t.Errorf("Execute(): should not have received error for %s (%v)", v.name, out.Message())
-		}
-		if l.EntryCount != len(v.wantEntries) {
-			t.Errorf("Execute(): got %d entries, wanted %d for %s", l.EntryCount, len(v.wantEntries), v.name)
-		}
-		if !reflect.DeepEqual(l.Logs, v.wantEntries) {
-			t.Errorf("Execute(): got %v, wanted %v for %s", l.Logs, v.wantEntries, v.name)
-		}
+			if out := tt.exec.Execute(tt.bag, tt.mapper, &ReportMethodArgs{}); !out.IsOK() {
+				t.Fatalf("Execute(): should not have received error for %s (%v)", tt.name, out)
+			}
+			if l.EntryCount != len(tt.wantEntries) {
+				t.Fatalf("Execute(): got %d entries, wanted %d for %s", l.EntryCount, len(tt.wantEntries), tt.name)
+			}
+			if !reflect.DeepEqual(l.Logs, tt.wantEntries) {
+				t.Fatalf("Execute(): got %v, wanted %v for %s", l.Logs, tt.wantEntries, tt.name)
+			}
+		})
 	}
 }
 
-func TestLoggerManager_ExecuteFailures(t *testing.T) {
+func TestLogWrapper_ExecuteFailures(t *testing.T) {
+	tmpl, _ := template.New("test").Parse("{{.test}}")
 
-	desc := dpb.LogEntryDescriptor{
-		Name:       "test",
-		Attributes: []string{"key"},
+	textLogInfo := logInfo{
+		format:    TEXT,
+		severity:  "DEFAULT",
+		timestamp: "timestamp",
+		tmpl:      tmpl,
+		tmplExprs: map[string]string{"tmplExprs": "tmplExprs"},
+		labels:    map[string]string{"labels": "labels"},
 	}
-	jsonPayloadDesc := dpb.LogEntryDescriptor{
-		Name:             "test",
-		Attributes:       []string{"key"},
-		PayloadAttribute: "payload",
-		PayloadFormat:    dpb.JSON,
+	jsonLogInfo := textLogInfo
+	jsonLogInfo.format = JSON
+
+	textPayload := applicationLogsWrapper{
+		name:   "name",
+		aspect: &test.Logger{},
+		metadata: map[string]*logInfo{
+			"text": &textLogInfo,
+		},
+	}
+	jsonPayload := applicationLogsWrapper{
+		name:   "name",
+		aspect: &test.Logger{},
+		metadata: map[string]*logInfo{
+			"json": &jsonLogInfo,
+		},
+	}
+	logError := applicationLogsWrapper{
+		name:   "name",
+		aspect: &test.Logger{ErrOnLog: true},
+		metadata: map[string]*logInfo{
+			"don't care": &jsonLogInfo,
+		},
 	}
 
-	errorExec := &applicationLogsWrapper{"istio_log",
-		[]dpb.LogEntryDescriptor{desc}, map[string]string{}, "severity", "ts", "", &test.Logger{ErrOnLog: true}, time.Now}
-	jsonErrorExec := &applicationLogsWrapper{"istio_log",
-		[]dpb.LogEntryDescriptor{jsonPayloadDesc}, map[string]string{"attr": "val"}, "severity", "ts", "", nil, time.Now}
+	timeTmpl, _ := template.New("test").Parse(`{{ .foo "-" .bar }}`)
+	errorLogInfo := textLogInfo
+	errorLogInfo.tmpl = timeTmpl
+	errorPayload := applicationLogsWrapper{
+		name:   "name",
+		aspect: &test.Logger{},
+		metadata: map[string]*logInfo{
+			"error": &errorLogInfo,
+		},
+	}
 
-	jsonPayloadBag := &test.Bag{Strs: map[string]string{"key": "value", "payload": `{"obj":{"val":54},"question":`}}
-
-	executeShouldFail := []struct {
+	tests := []struct {
 		name   string
 		exec   *applicationLogsWrapper
 		bag    attribute.Bag
 		mapper expr.Evaluator
 	}{
-		{"log failure", errorExec, &test.Bag{Strs: map[string]string{"key": "value"}}, test.NewIDEval()},
-		{"json payload failure", jsonErrorExec, jsonPayloadBag, test.NewIDEval()},
+		{"invalid json template", &jsonPayload, test.NewBag(), test.NewIDEval()},
+		{"err on log", &logError, test.NewBag(), test.NewIDEval()},
+		{"err on label eval", &textPayload, test.NewBag(), evalErrOnStr("labels")},
+		{"err on template eval", &jsonPayload, test.NewBag(), evalErrOnStr("tmplExprs")},
+		{"err on severity", &jsonPayload, test.NewBag(), evalErrOnStr("DEFAULT")},
+		{"err on timestamp", &jsonPayload, test.NewBag(), evalErrOnStr("timestamp")},
+		{"err on execute", &errorPayload, test.NewBag(), test.NewIDEval()},
 	}
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			if out := tt.exec.Execute(tt.bag, tt.mapper, &ReportMethodArgs{}); out.IsOK() {
+				t.Fatalf("Execute(): should have received error for %s", tt.name)
+			}
+		})
+	}
+}
 
-	for _, v := range executeShouldFail {
-		if out := v.exec.Execute(v.bag, v.mapper, &ReportMethodArgs{}); out.IsOK() {
-			t.Errorf("Execute(): should have received error for %s", v.name)
-		}
+func TestLogWrapper_Close(t *testing.T) {
+	l := &test.Logger{}
+	wrapper := applicationLogsWrapper{
+		name:     "name",
+		aspect:   l,
+		metadata: make(map[string]*logInfo),
+	}
+	if err := wrapper.Close(); err != nil {
+		t.Fatalf("wrapper.Close() = %s, wanted no err.", err)
+	}
+	if !l.Closed {
+		t.Fatal("wrapper.Close() didn't call aspect.Close()")
 	}
 }
 
 func TestLoggerManager_DefaultConfig(t *testing.T) {
 	m := newApplicationLogsManager()
 	got := m.DefaultConfig()
-	want := &aconfig.ApplicationLogsParams{LogName: "istio_log", TimestampFormat: time.RFC3339}
+	want := &aconfig.ApplicationLogsParams{LogName: "istio_log"}
 	if !proto.Equal(got, want) {
 		t.Errorf("DefaultConfig(): got %v, wanted %v", got, want)
 	}
@@ -258,5 +358,24 @@ func TestLoggerManager_ValidateConfig(t *testing.T) {
 	m := newApplicationLogsManager()
 	if err := m.ValidateConfig(&ptypes.Empty{}); err != nil {
 		t.Errorf("ValidateConfig(): unexpected error: %v", err)
+	}
+}
+
+func TestPayloadFormatFromProto(t *testing.T) {
+	tests := []struct {
+		name string
+		in   dpb.LogEntryDescriptor_PayloadFormat
+		out  PayloadFormat
+	}{
+		{"json", dpb.JSON, JSON},
+		{"text", dpb.TEXT, TEXT},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			if r := payloadFormatFromProto(tt.in); r != tt.out {
+				t.Errorf("payloadFormatFromProto(%s) = %v, wanted %v", tt.in, r, tt.out)
+			}
+		})
 	}
 }

--- a/pkg/aspect/config/applicationLogs.proto
+++ b/pkg/aspect/config/applicationLogs.proto
@@ -19,42 +19,35 @@ package pkg.aspect.config;
 option go_package="config";
 
 // Configures an individual application-logs aspect.
-//
-// Example usage:
-// kind: application-logs
-// params:
-//    log_name: "endpoint_log"
-//    log_entry_descriptor_names: "application_log_entry", "action_log_entry"
-//    severity_attribute: "severity"
-//    timestamp_attribute: "timestamp"
-//    timestamp_format: "2006-Jan-02"
-//
 message ApplicationLogsParams {
-    // Provides a way to identify a collection of related log entries.
+    // Identifies a collection of related log entries.
     string log_name = 1;
 
-    // A list of names of istio.mixer.v1.config.descriptor.LogEntryDescriptors
-    // for log entries that will be generated for a Report() call. If no
-    // LogEntryDescriptor is named in the config, the logger will not generate
-    // any log entries.
-    repeated string log_entry_descriptor_names = 2;
+    message ApplicationLog {
+        // Must match the name of some LogEntryDescriptor.
+        string descriptor_name = 1;
 
-    // The name of the attribute that will be used to derive log severity.
-    // If this attribute is not found in the set of attributes passed to this
-    // implementation, a default severity of "DEFAULT" will be used.
-    string severity_attribute = 3;
+        // The expression to evaluate to determine this log's severity at runtime.
+        string severity = 2;
 
-    // The name of the attribute that will be used to derive the timestamp
-    // for the corresponding log enty. If this attribute is not specified, the
-    // value from time.Now() will be used as the timestamp for the log.
-    string timestamp_attribute = 4;
+        // The expression to evaluate to determine this log's timestamp.
+        string timestamp = 3;
+        // The golang time layout string to use to parse the timestamp
+        string time_format = 4;
 
-    // The format to use when serializing timestamps. It is expected that
-    // this format string will follow the conventions of golang's time.Time
-    // package and use the reference date as defined in:
-    // https://golang.org/pkg/time/#pkg-constants.
-    //
-    // Default Value: "2006-01-02T15:04:05Z07:00" (RFC3339)
-    string timestamp_format = 5;
+        // Map of template variable name to expression for the descriptor's log_template. At
+        // run time each expression will be evaluated, and together they will provide values
+        // for the log's template string. Labels and template expressions do not mix: if the
+        // result of some expression is needed for both constructing the payload and for
+        // dimensioning the log entry, it must be included both in these expressions and in
+        // the `labels` expressions.
+        map<string, string> template_expressions = 5;
 
+        // Map of LogEntryDescriptor label name to attribute expression. At run time each
+        // expression will be evaluated to determine the value that will be used to fill
+        // in the log template. The result of evaluating the expression must match the
+        // ValueType of the label in the LogEntryDescriptor.
+        map<string, string> labels = 6;
+    }
+    repeated ApplicationLog logs = 2;
 }

--- a/pkg/aspect/config/applicationLogs.proto
+++ b/pkg/aspect/config/applicationLogs.proto
@@ -32,7 +32,8 @@ message ApplicationLogsParams {
 
         // The expression to evaluate to determine this log's timestamp.
         string timestamp = 3;
-        // The golang time layout string to use to parse the timestamp
+
+        // The golang time layout format string used to print the timestamp
         string time_format = 4;
 
         // Map of template variable name to expression for the descriptor's log_template. At

--- a/pkg/aspect/test/logger.go
+++ b/pkg/aspect/test/logger.go
@@ -32,6 +32,7 @@ type Logger struct {
 	AccessLogs     []adapter.LogEntry
 	ErrOnNewAspect bool
 	ErrOnLog       bool
+	Closed         bool
 }
 
 // NewApplicationLogsAspect returns a new instance of the Logger aspect.
@@ -67,7 +68,7 @@ func (t *Logger) Log(l []adapter.LogEntry) error {
 	if t.ErrOnLog {
 		return errors.New("log error")
 	}
-	t.EntryCount++
+	t.EntryCount += len(l)
 	t.Logs = append(t.Logs, l...)
 	return nil
 }
@@ -77,13 +78,16 @@ func (t *Logger) LogAccess(l []adapter.LogEntry) error {
 	if t.ErrOnLog {
 		return errors.New("log access error")
 	}
-	t.EntryCount++
+	t.EntryCount += len(l)
 	t.AccessLogs = append(t.AccessLogs, l...)
 	return nil
 }
 
-// Close does nothing at the moment.
-func (t *Logger) Close() error { return nil }
+// Close marks the logger as being closed.
+func (t *Logger) Close() error {
+	t.Closed = true
+	return nil
+}
 
 // NewLogEntry creates an adapter.LogEntry instance.
 func NewLogEntry(n string, l map[string]interface{}, ts string, s adapter.Severity, tp string, sp map[string]interface{}) adapter.LogEntry {

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -56,4 +56,4 @@ rules:
   - kind: application-logs
     params:
       logName: "mixer_log"
-      logEntryDescriptorNames: ["default"]
+      logs:


### PR DESCRIPTION
Follow on to PR https://github.com/istio/mixer/pull/294 that updates application logs to look like metric/quota managers. A follow on PR will update the access log manager to use descriptors as this one does, and a final PR will plumb descriptors through the mixer's config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/343)
<!-- Reviewable:end -->
