### PR TITLE
Introduce out-of-order async evaluation of API requests.

### DIFF
--- a/adapter/ipListChecker/ipListChecker.go
+++ b/adapter/ipListChecker/ipListChecker.go
@@ -132,7 +132,7 @@ func newListCheckerWithTimers(env adapter.Env, c *config.Params,
 	l.fetchList()
 
 	// goroutine to periodically refresh the list
-	env.ScheduleWork(l.listRefresher)
+	env.ScheduleDaemon(l.listRefresher)
 
 	return l, nil
 }

--- a/adapter/memQuota/memQuota.go
+++ b/adapter/memQuota/memQuota.go
@@ -139,7 +139,7 @@ func newAspectWithDedup(env adapter.Env, ticker *time.Ticker, definitions map[st
 		logger:      env.Logger(),
 	}
 
-	env.ScheduleWork(func() {
+	env.ScheduleDaemon(func() {
 		for range mq.ticker.C {
 			mq.Lock()
 			mq.reapDedup()

--- a/adapter/prometheus/server.go
+++ b/adapter/prometheus/server.go
@@ -61,7 +61,7 @@ func (s *serverInst) Start(env adapter.Env) error {
 	}
 
 	http.Handle(metricsPath, promhttp.Handler())
-	env.ScheduleWork(func() {
+	env.ScheduleDaemon(func() {
 		env.Logger().Infof("serving prometheus metrics on %s", s.addr)
 		if err := srv.Serve(listener.(*net.TCPListener)); err != nil {
 			_ = env.Logger().Errorf("prometheus HTTP server error: %v", err)

--- a/cmd/client/util_test.go
+++ b/cmd/client/util_test.go
@@ -46,7 +46,7 @@ func TestAttributeHandling(t *testing.T) {
 	tracker := attribute.NewManager().NewTracker()
 
 	var b attribute.Bag
-	if b, err = tracker.StartRequest(a); err != nil {
+	if b, err = tracker.ApplyAttributes(a); err != nil {
 		t.Errorf("Expected to start request, got failure %v", err)
 	}
 

--- a/doc/dev/adapters.md
+++ b/doc/dev/adapters.md
@@ -9,7 +9,7 @@ execution. This logger understands about which adapter
 is running and routes the data to the place where the
 operator wants to see it.
 
-- Adapters must use env.ScheduleWork in order to 
-dispatch goroutines. This ensures all adapter goroutines
+- Adapters must use env.ScheduleWork or env.ScheduleDaemon
+in order to dispatch goroutines. This ensures all adapter goroutines
 are prevented from crashing the mixer as a whole by catching
 any panics they produce.

--- a/pkg/adapter/test/env.go
+++ b/pkg/adapter/test/env.go
@@ -45,6 +45,11 @@ func (e *Env) ScheduleWork(fn adapter.WorkFunc) {
 	go fn()
 }
 
+// ScheduleDaemon runs the given function asynchronously.
+func (e *Env) ScheduleDaemon(fn adapter.DaemonFunc) {
+	go fn()
+}
+
 // Infof logs the provided message.
 func (e *Env) Infof(format string, args ...interface{}) {
 	e.log(format, args...)

--- a/pkg/adapterManager/env.go
+++ b/pkg/adapterManager/env.go
@@ -51,3 +51,20 @@ func (e env) ScheduleWork(fn adapter.WorkFunc) {
 		fn()
 	})
 }
+
+func (e env) ScheduleDaemon(fn adapter.DaemonFunc) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				_ = e.Logger().Errorf("Adapter daemon failed: %v", r)
+
+				// TODO: Beyond logging, we want to do something proactive here.
+				//       For example, we want to probably terminate the originating
+				//       adapter and record the failure so we can count how often
+				//       it happens, etc.
+			}
+		}()
+
+		fn()
+	}()
+}

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//pkg/config:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
+        "//pkg/pool:go_default_library",
         "//pkg/status:go_default_library",
         "//pkg/tracing:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"testing"
 
 	rpc "github.com/googleapis/googleapis/google/rpc"
@@ -51,12 +52,90 @@ func TestAspectManagerErrorsPropagated(t *testing.T) {
 	f := &fakeExecutor{func() aspect.Output {
 		return aspect.Output{Status: status.WithError(fmt.Errorf("expected"))}
 	}}
-	h := &handlerState{aspectExecutor: f, methodMap: map[aspect.APIMethod]config.AspectSet{}}
+	h := NewHandler(f, map[aspect.APIMethod]config.AspectSet{}).(*handlerState)
 	h.ConfigChange(&fakeresolver{[]*config.Combined{nil, nil}, nil})
 
-	o := h.execute(context.Background(), attribute.NewManager().NewTracker(), &mixerpb.Attributes{}, aspect.CheckMethod, nil)
+	bag, _ := attribute.NewManager().NewTracker().ApplyAttributes(&mixerpb.Attributes{})
+	o := h.execute(context.Background(), bag, aspect.CheckMethod, nil)
 	if o.Status.Code != int32(rpc.INTERNAL) {
 		t.Errorf("execute(..., invalidConfig, ...) returned %v, wanted status with code %v", o.Status, rpc.INTERNAL)
+	}
+}
+
+func TestHandler(t *testing.T) {
+	bag, _ := attribute.NewManager().NewTracker().ApplyAttributes(&mixerpb.Attributes{})
+
+	checkReq := &mixerpb.CheckRequest{}
+	checkResp := &mixerpb.CheckResponse{}
+	reportReq := &mixerpb.ReportRequest{}
+	reportResp := &mixerpb.ReportResponse{}
+	quotaReq := &mixerpb.QuotaRequest{}
+	quotaResp := &mixerpb.QuotaResponse{}
+
+	cases := []struct {
+		resolver    *fakeresolver
+		resolverErr string
+		executorErr string
+		resultErr   string
+		code        rpc.Code
+	}{
+		{nil, "", "", "", rpc.INTERNAL},
+		{&fakeresolver{[]*config.Combined{nil, nil}, nil}, "RESOLVER", "", "RESOLVER", rpc.INTERNAL},
+		{&fakeresolver{[]*config.Combined{nil, nil}, nil}, "", "BADASPECT", "BADASPECT", rpc.INTERNAL},
+	}
+
+	for _, c := range cases {
+		e := &fakeExecutor{}
+		if c.executorErr != "" {
+			e = &fakeExecutor{func() aspect.Output {
+				return aspect.Output{Status: status.WithInternal(c.executorErr)}
+			}}
+		}
+
+		h := NewHandler(e, map[aspect.APIMethod]config.AspectSet{}).(*handlerState)
+
+		if c.resolver != nil {
+			r := c.resolver
+			if c.resolverErr != "" {
+				r.err = fmt.Errorf(c.resolverErr)
+			}
+			h.ConfigChange(r)
+		}
+
+		h.Check(context.Background(), bag, checkReq, checkResp)
+		h.Report(context.Background(), bag, reportReq, reportResp)
+		h.Quota(context.Background(), bag, quotaReq, quotaResp)
+
+		if checkResp.Result.Code != int32(c.code) || reportResp.Result.Code != int32(c.code) || quotaResp.Result.Code != int32(c.code) {
+			t.Errorf("Expected %v for all responses, got %v, %v, %v", c.code, checkResp.Result.Code, reportResp.Result.Code, quotaResp.Result.Code)
+		}
+
+		if c.resultErr != "" {
+			if !strings.Contains(checkResp.Result.Message, c.resultErr) ||
+				!strings.Contains(reportResp.Result.Message, c.resultErr) ||
+				!strings.Contains(quotaResp.Result.Message, c.resultErr) {
+				t.Errorf("Expecting %s in error messages, got %s, %s, %s", c.resultErr, checkResp.Result.Message, reportResp.Result.Message,
+					quotaResp.Result.Message)
+			}
+		}
+	}
+
+	f := &fakeExecutor{func() aspect.Output {
+		return aspect.Output{Status: status.OK, Response: &aspect.QuotaMethodResp{Amount: 42}}
+	}}
+	r := &fakeresolver{[]*config.Combined{nil, nil}, nil}
+	h := NewHandler(f, map[aspect.APIMethod]config.AspectSet{}).(*handlerState)
+	h.ConfigChange(r)
+
+	// Should succeed
+	h.Quota(context.Background(), bag, quotaReq, quotaResp)
+
+	if !status.IsOK(quotaResp.Result) {
+		t.Errorf("Expected successful quota allocation, got %v", quotaResp.Result)
+	}
+
+	if quotaResp.Amount != 42 {
+		t.Errorf("Expected 42, got %v", quotaResp.Amount)
 	}
 }
 

--- a/pkg/attribute/manager_test.go
+++ b/pkg/attribute/manager_test.go
@@ -333,7 +333,7 @@ func TestAttributeManager(t *testing.T) {
 	defer at.Done()
 
 	for i, c := range cases {
-		ab, err := at.StartRequest(&c.attrs)
+		ab, err := at.ApplyAttributes(&c.attrs)
 		if (err == nil) != c.result {
 			if c.result {
 				t.Errorf("Expected StartRequest to succeed but it returned %v for test case %d", err, i)
@@ -341,7 +341,6 @@ func TestAttributeManager(t *testing.T) {
 				t.Errorf("Expected StartRequest to fail but it succeeded for test case %d", i)
 			}
 		}
-		defer at.EndRequest()
 
 		for j, g := range c.getString {
 			result, present := ab.String(g.name)

--- a/pkg/attribute/rootBag.go
+++ b/pkg/attribute/rootBag.go
@@ -428,7 +428,3 @@ func (rb *rootBag) update(dictionary dictionary, attrs *mixerpb.Attributes) erro
 
 	return nil
 }
-
-func (rb *rootBag) child() *mutableBag {
-	return getMutableBag(rb)
-}

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -105,7 +105,7 @@ func TestRuntime(t *testing.T) {
 		numAspects: 1,
 	}
 
-	bag, err := attribute.NewManager().NewTracker().StartRequest(&mixerpb.Attributes{})
+	bag, err := attribute.NewManager().NewTracker().ApplyAttributes(&mixerpb.Attributes{})
 	if err != nil {
 		t.Error("Unable to get attribute bag")
 	}

--- a/pkg/pool/BUILD
+++ b/pkg/pool/BUILD
@@ -6,8 +6,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "buffer.go",
+        "goroutine.go",
         "intern.go",
-        "worker.go",
     ],
 )
 
@@ -16,8 +16,8 @@ go_test(
     size = "small",
     srcs = [
         "buffer_test.go",
+        "goroutine_test.go",
         "intern_test.go",
-        "worker_test.go",
     ],
     library = ":go_default_library",
 )

--- a/pkg/pool/goroutine.go
+++ b/pkg/pool/goroutine.go
@@ -23,14 +23,16 @@ type WorkFunc func()
 
 // GoroutinePool represents a set of reusable goroutines onto which work can be scheduled.
 type GoroutinePool struct {
-	queue chan WorkFunc  // Channel providing the work that needs to be executed
-	wg    sync.WaitGroup // Used to block shutdown until all workers complete
+	queue          chan WorkFunc  // Channel providing the work that needs to be executed
+	wg             sync.WaitGroup // Used to block shutdown until all workers complete
+	singleThreaded bool           // Whether to actually use goroutines or not
 }
 
 // NewGoroutinePool creates a new pool of goroutines to schedule async work.
-func NewGoroutinePool(queueDepth int) *GoroutinePool {
+func NewGoroutinePool(queueDepth int, singleThreaded bool) *GoroutinePool {
 	gp := &GoroutinePool{
-		queue: make(chan WorkFunc, queueDepth),
+		queue:          make(chan WorkFunc, queueDepth),
+		singleThreaded: singleThreaded,
 	}
 
 	gp.AddWorkers(1)
@@ -39,25 +41,33 @@ func NewGoroutinePool(queueDepth int) *GoroutinePool {
 
 // Close waits for all goroutines to terminate
 func (gp *GoroutinePool) Close() {
-	close(gp.queue)
-	gp.wg.Wait()
+	if !gp.singleThreaded {
+		close(gp.queue)
+		gp.wg.Wait()
+	}
 }
 
 // ScheduleWork registers the given function to be executed at some point
 func (gp *GoroutinePool) ScheduleWork(fn WorkFunc) {
-	gp.queue <- fn
+	if gp.singleThreaded {
+		fn()
+	} else {
+		gp.queue <- fn
+	}
 }
 
 // AddWorkers introduces more goroutines in the worker pool, increasing potential parallelism.
 func (gp *GoroutinePool) AddWorkers(numWorkers int) {
-	gp.wg.Add(numWorkers)
-	for i := 0; i < numWorkers; i++ {
-		go func() {
-			for fn := range gp.queue {
-				fn()
-			}
+	if !gp.singleThreaded {
+		gp.wg.Add(numWorkers)
+		for i := 0; i < numWorkers; i++ {
+			go func() {
+				for fn := range gp.queue {
+					fn()
+				}
 
-			gp.wg.Done()
-		}()
+				gp.wg.Done()
+			}()
+		}
 	}
 }

--- a/pkg/pool/goroutine_test.go
+++ b/pkg/pool/goroutine_test.go
@@ -23,21 +23,23 @@ func TestWorkerPool(t *testing.T) {
 	const numWorkers = 123
 	const numWorkItems = 456
 
-	gp := NewGoroutinePool(128)
-	gp.AddWorkers(numWorkers)
+	for i := 0; i < 2; i++ {
+		gp := NewGoroutinePool(128, i == 0)
+		gp.AddWorkers(numWorkers)
 
-	wg := &sync.WaitGroup{}
-	wg.Add(numWorkItems)
+		wg := &sync.WaitGroup{}
+		wg.Add(numWorkItems)
 
-	for i := 0; i < numWorkItems; i++ {
-		gp.ScheduleWork(func() {
-			wg.Done()
-		})
+		for i := 0; i < numWorkItems; i++ {
+			gp.ScheduleWork(func() {
+				wg.Done()
+			})
+		}
+
+		// wait for all the functions to have run
+		wg.Wait()
+
+		// make sure the pool can be shutdown cleanly
+		gp.Close()
 	}
-
-	// wait for all the functions to have run
-	wg.Wait()
-
-	// make sure the pool can be shutdown cleanly
-	gp.Close()
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -42,6 +42,11 @@ func WithInternal(message string) rpc.Status {
 	return rpc.Status{Code: int32(rpc.INTERNAL), Message: message}
 }
 
+// WithCancelled returns an initialized status with the rpc.CANCELLED error code and the error's message.
+func WithCancelled(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.CANCELLED), Message: message}
+}
+
 // WithInvalidArgument returns an initialized status with the rpc.INVALID_ARGUMENT code and the given message.
 func WithInvalidArgument(message string) rpc.Status {
 	return rpc.Status{Code: int32(rpc.INVALID_ARGUMENT), Message: message}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -15,6 +15,7 @@
 package status
 
 import (
+	"fmt"
 	"testing"
 
 	rpc "github.com/googleapis/googleapis/google/rpc"
@@ -35,9 +36,19 @@ func TestStatus(t *testing.T) {
 		t.Errorf("Got %v %v, expected rpc.ABORTED Aborted!", s.Code, s.Message)
 	}
 
+	s = WithError(fmt.Errorf("aborted"))
+	if s.Code != int32(rpc.INTERNAL) || s.Message != "aborted" {
+		t.Errorf("Got %v %v, expected rpc.INTERNAL aborted", s.Code, s.Message)
+	}
+
 	s = WithInternal("Aborted!")
 	if s.Code != int32(rpc.INTERNAL) || s.Message != "Aborted!" {
 		t.Errorf("Got %v %v, expected rpc.INTERNAL Aborted!", s.Code, s.Message)
+	}
+
+	s = WithCancelled("Aborted!")
+	if s.Code != int32(rpc.CANCELLED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.CANCELLED Aborted!", s.Code, s.Message)
 	}
 
 	s = WithPermissionDenied("Aborted!")

--- a/pkg/tracing/attributes_test.go
+++ b/pkg/tracing/attributes_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func TestContext(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyAttributes(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}
@@ -54,7 +54,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyAttributes(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}
@@ -77,7 +77,7 @@ func TestSet(t *testing.T) {
 }
 
 func TestForeachKey(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyAttributes(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}
@@ -106,7 +106,7 @@ func TestForeachKey(t *testing.T) {
 }
 
 func TestForeachKey_PropagatesErr(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().StartRequest(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyAttributes(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}


### PR DESCRIPTION
- API dispatch is now handled using the goroutine pool.
This means we can accept API calls at a much higher rate
on a given stream, and we now process each call in parallel.
This in turn means that mixer can now complete API calls out
of order for a given stream.

- Allow command-line control of how many goroutines are used
for the adapter worker pool.

- Add the --singleThreaded command-line option which makes the
mixer run all API processing and adapter logic on a single
goroutine. This can be handy for debugging.

- Extend the goroutine pool to support a single-threaded
option. The pool behaves as normal, but doesn't actually use
any goroutines in that case.

- Add Env.ScheduleDaemon for use in adapters. Whereas ScheduleWork
is intended for short duration functions, ScheduleDaemon is intended
for long-running background stuff. When the mixer is running in
single-threaded mode, ScheduleDaemon continues to dispatch real
goroutines in the background, whereas ScheduleWork doesn't.

- Bump code coverage to 100% for pkg/api, pkg/attribute and pkg/status.

The one unfortunate part about dispatching API processing in
parallel is that the protocol-level attribute bag must be fully
copied for every API call, rather than being referenced. For now,
this is good enough. Eventually, we'll want to fancy up the
attribute bag functionality to support a versioned data structure
so that we can avoid the repetitive copying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/360)
<!-- Reviewable:end -->
