### PR TITLE
Update mixer to golang version 1.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ branches:
   - stable
 
 go:
-- 1.7.x
+- 1.8.x
 
 jdk:
 - oraclejdk8
 
 env:
   global:
-  - BAZEL_VERSION=0.4.3
+  - BAZEL_VERSION=0.4.4
 
 addons:
   apt:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "com_github_istio_mixer")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "76c63b5cd0d47c1f2b47ab4953db96c574af1c1d", # Jan 16, 2017 (v0.3.3/0.4.0)
+    commit = "9496d79880a7d55b8e4a96f04688d70a374eaaf4", # Mar 3, 2017 (v0.4.1)
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/doc/dev/development.md
+++ b/doc/dev/development.md
@@ -53,7 +53,7 @@ need to setup before being able to build and run the code.
 
 The Istio mixer is written in the [Go](http://golang.org) programming language.
 To build the mixer, you'll need a Go development environment. Builds for
-the mixer require Go version 1.7. If you haven't set up a Go development
+the mixer require Go version 1.8. If you haven't set up a Go development
 environment, please follow [these instructions](http://golang.org/doc/code.html)
 to install the Go tools.
 


### PR DESCRIPTION
This is the first step towards being fully on golang 1.8.  Jenkins golang version is controlled in a different repo.

tracking issue is #265.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/363)
<!-- Reviewable:end -->
