### PR TITLE
Improve expr performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
 - bin/linters.sh
 - bin/codecov.sh
 - bin/racetest.sh
+- bin/perftest.sh
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/bin/perftest.sh
+++ b/bin/perftest.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+WD=$(dirname $0)
+WD=$(cd $WD; pwd)
+ROOT=$(dirname $WD)
+
+set -e
+echo "Perf test"
+DIRS="pkg/expr pkg/attribute"
+cd $ROOT
+for pkgdir in ${DIRS}; do
+    cd ${ROOT}/${pkgdir} 
+    go test -run=^$  -bench=.  -benchmem
+done

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -389,7 +389,7 @@ func TestBadAttr(t *testing.T) {
 	}
 
 	request := mixerpb.ReportRequest{AttributeUpdate: attrs}
-	if err := stream.Send(&request); err != nil {
+	if err = stream.Send(&request); err != nil {
 		t.Errorf("Failed to send request: %v", err)
 	}
 
@@ -443,7 +443,7 @@ func TestRudeClose(t *testing.T) {
 	}
 
 	request := mixerpb.ReportRequest{}
-	if err := stream.Send(&request); err != nil {
+	if err = stream.Send(&request); err != nil {
 		t.Errorf("Failed to send request: %v", err)
 	}
 

--- a/pkg/expr/BUILD
+++ b/pkg/expr/BUILD
@@ -21,6 +21,7 @@ go_test(
     name = "small_tests",
     size = "small",
     srcs = [
+        "benchmark_test.go",
         "eval_test.go",
         "expr_test.go",
         "func_test.go",

--- a/pkg/expr/benchmark_test.go
+++ b/pkg/expr/benchmark_test.go
@@ -15,7 +15,6 @@
 package expr
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -45,21 +44,20 @@ type exprFunc func(a attribute.Bag) (bool, error)
 // a == 20 || request.header["host"] == 50
 
 func dff(a attribute.Bag) (bool, error) {
-	var aa int64
+	var v interface{}
 	var b bool
-	var s map[string]string
-	if aa, b = a.Int64("a"); !b {
+	if v, b = a.Get("a"); !b {
 		return false, fmt.Errorf("a not found")
 	}
+	aa := v.(int64)
 	if aa == 20 {
 		return true, nil
 	}
 
-	s, b = a.StringMap("request.header")
-	if !b {
+	if v, b = a.Get("request.header"); !b {
 		return false, fmt.Errorf("a not found")
 	}
-	ss := s["host"]
+	ss := v.(map[string]string)["host"]
 	if ss == "abc" {
 		return true, nil
 	}

--- a/pkg/expr/benchmark_test.go
+++ b/pkg/expr/benchmark_test.go
@@ -59,8 +59,7 @@ func dff(a attribute.Bag) (bool, error) {
 	if !b {
 		return false, fmt.Errorf("a not found")
 	}
-	var ss string
-	ss = s["host"]
+	ss := s["host"]
 	if ss == "abc" {
 		return true, nil
 	}

--- a/pkg/expr/benchmark_test.go
+++ b/pkg/expr/benchmark_test.go
@@ -15,7 +15,7 @@
 package expr
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
@@ -48,7 +48,7 @@ func dff(a attribute.Bag) (bool, error) {
 	var v interface{}
 	var b bool
 	if v, b = a.Get("a"); !b {
-		return false, fmt.Errorf("a not found")
+		return false, errors.New("a not found")
 	}
 	aa := v.(int64)
 	if aa == 20 {
@@ -56,7 +56,7 @@ func dff(a attribute.Bag) (bool, error) {
 	}
 
 	if v, b = a.Get("request.header"); !b {
-		return false, fmt.Errorf("a not found")
+		return false, errors.New("a not found")
 	}
 	ss := v.(map[string]string)["host"]
 	if ss == "abc" {

--- a/pkg/expr/benchmark_test.go
+++ b/pkg/expr/benchmark_test.go
@@ -15,11 +15,11 @@
 package expr
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"istio.io/mixer/pkg/attribute"
-	"fmt"
 )
 
 // run micro benchmark using expression evaluator.
@@ -41,8 +41,9 @@ ok  	istio.io/mixer/pkg/expr	10.049s
 
 type exprFunc func(a attribute.Bag) (bool, error)
 
-// a == 20 || request.header["host"] == 50
-
+// dff implements `a == 20 || request.header["host"] == "abc"`
+// this is done so we can compare Expr processed expression with
+// raw direct golang performance.
 func dff(a attribute.Bag) (bool, error) {
 	var v interface{}
 	var b bool
@@ -77,7 +78,7 @@ func benchmarkExpression(b *testing.B, stype string) {
 	exprStr := `a == 20 || request.header["host"] == "abc"`
 	exf, _ := Parse(exprStr)
 
-	fmt.Printf("%s\n", exf.String())
+	b.Logf("%s\n", exf.String())
 	fm := FuncMap()
 	tests := []struct {
 		name   string

--- a/pkg/expr/benchmark_test.go
+++ b/pkg/expr/benchmark_test.go
@@ -20,58 +20,67 @@ import (
 	"testing"
 
 	"istio.io/mixer/pkg/attribute"
+	"fmt"
 )
 
 // run micro benchmark using expression evaluator.
 // Results vs hand coded expression eval function
-// 2017-03-10
+// 2017-03-16
 /*
-$ go test -bench=.
-BenchmarkExpression/ok_constantAST-8         	500000000	         3.70 ns/op
-BenchmarkExpression/ok_constantDirect-8      	1000000000	         2.43 ns/op
-BenchmarkExpression/ok_1stAST-8              	 1000000	      1626 ns/op
-BenchmarkExpression/ok_1stDirect-8           	100000000	        19.9 ns/op
-BenchmarkExpression/ok_2ndAST-8              	 1000000	      1623 ns/op
-BenchmarkExpression/ok_2ndDirect-8           	30000000	        41.5 ns/op
-BenchmarkExpression/ok_notfoundAST-8         	 1000000	      1628 ns/op
-BenchmarkExpression/ok_notfoundDirect-8      	30000000	        38.7 ns/op
+$ go test -run=^$  -bench=.  -benchmem
+LOR(EQ($a, 20), EQ(INDEX($request.header, "host"), "abc"))
+BenchmarkExpressionAST/ok_1stAST-8         	10000000	       188 ns/op	      16 B/op	       3 allocs/op
+BenchmarkExpressionAST/ok_2ndAST-8         	 3000000	       446 ns/op	      32 B/op	       5 allocs/op
+BenchmarkExpressionAST/ok_notfoundAST-8    	 3000000	       435 ns/op	      32 B/op	       5 allocs/op
+LOR(EQ($a, 20), EQ(INDEX($request.header, "host"), "abc"))
+BenchmarkExpressionDirect/ok_1stDirect-8   	100000000	        12.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExpressionDirect/ok_2ndDirect-8   	50000000	        31.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExpressionDirect/ok_notfoundDirect-8         	50000000	        29.5 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	istio.io/mixer/pkg/expr	10.049s
 */
 
 type exprFunc func(a attribute.Bag) (bool, error)
 
 // a == 20 || request.header["host"] == 50
 
-func BenchmarkExpression(b *testing.B) {
+func dff(a attribute.Bag) (bool, error) {
+	var aa int64
+	var b bool
+	var s map[string]string
+	if aa, b = a.Int64("a"); !b {
+		return false, fmt.Errorf("a not found")
+	}
+	if aa == 20 {
+		return true, nil
+	}
+
+	s, b = a.StringMap("request.header")
+	if !b {
+		return false, fmt.Errorf("a not found")
+	}
+	var ss string
+	ss = s["host"]
+	if ss == "abc" {
+		return true, nil
+	}
+	return false, nil
+}
+
+func BenchmarkExpressionAST(b *testing.B) {
+	benchmarkExpression(b, "AST")
+}
+
+func BenchmarkExpressionDirect(b *testing.B) {
+	benchmarkExpression(b, "Direct")
+}
+
+func benchmarkExpression(b *testing.B, stype string) {
 	success := "_SUCCESS_"
 	exprStr := `a == 20 || request.header["host"] == "abc"`
-	dff := func(a attribute.Bag) (bool, error) {
-		var b bool
-		var v interface{}
-		v, b = a.Get("a")
-		if !b {
-			return false, errors.New("a not found")
-		}
-		if v.(int64) == 20 {
-			return true, nil
-		}
-
-		v, b = a.Get("request.header")
-		if !b {
-			return false, errors.New("a not found")
-		}
-		s := v.(map[string]string)
-		ss := s["host"]
-		if ss == "abc" {
-			return true, nil
-		}
-		return false, nil
-	}
 	exf, _ := Parse(exprStr)
 
-	exprConstant := "true"
-	ex2, _ := Parse(exprConstant)
-	df2 := func(a attribute.Bag) (bool, error) { return true, nil }
-
+	fmt.Printf("%s\n", exf.String())
 	fm := FuncMap()
 	tests := []struct {
 		name   string
@@ -81,13 +90,6 @@ func BenchmarkExpression(b *testing.B) {
 		df     exprFunc
 		ex     *Expression
 	}{
-		{"ok_constant", map[string]interface{}{
-			"a": int64(20),
-			"request.header": map[string]string{
-				"host": "abc",
-			},
-		}, true, success, df2, ex2,
-		},
 		{"ok_1st", map[string]interface{}{
 			"a": int64(20),
 			"request.header": map[string]string{
@@ -130,21 +132,26 @@ func BenchmarkExpression(b *testing.B) {
 	}
 
 	for _, tst := range tests {
-		attrs := &bag{attrs: tst.tmap}
-		ii, err := tst.ex.Eval(attrs, fm)
-		assertNoError(err, tst.err, ii, tst.result, b)
-		b.Run(tst.name+"AST", func(bb *testing.B) {
-			for n := 0; n < bb.N; n++ {
-				_, _ = tst.ex.Eval(attrs, fm)
-			}
-		})
 
-		ii, err = tst.df(attrs)
-		assertNoError(err, tst.err, ii, tst.result, b)
-		b.Run(tst.name+"Direct", func(bb *testing.B) {
-			for n := 0; n < bb.N; n++ {
-				_, _ = tst.df(attrs)
-			}
-		})
+		attrs := &bag{attrs: tst.tmap}
+
+		if stype == "AST" {
+			ii, err := tst.ex.Eval(attrs, fm)
+			assertNoError(err, tst.err, ii, tst.result, b)
+			b.Run(tst.name+"AST", func(bb *testing.B) {
+				for n := 0; n < bb.N; n++ {
+					_, _ = tst.ex.Eval(attrs, fm)
+				}
+			})
+		} else {
+			ii, err := tst.df(attrs)
+			assertNoError(err, tst.err, ii, tst.result, b)
+			b.Run(tst.name+"Direct", func(bb *testing.B) {
+				for n := 0; n < bb.N; n++ {
+					_, _ = tst.df(attrs)
+				}
+			})
+
+		}
 	}
 }

--- a/pkg/expr/eval_test.go
+++ b/pkg/expr/eval_test.go
@@ -211,10 +211,6 @@ func TestGoodEval(tt *testing.T) {
 	}
 
 	for idx, tst := range tests {
-		if tst.src == "(x == 20 && y == 10) || x == 3" {
-			fmt.Printf(tst.src + "\n")
-		}
-
 		tt.Run(fmt.Sprintf("[%d] %s", idx, tst.src), func(t *testing.T) {
 			attrs := &bag{attrs: tst.tmap}
 			exp, err := Parse(tst.src)

--- a/pkg/expr/eval_test.go
+++ b/pkg/expr/eval_test.go
@@ -51,11 +51,32 @@ func TestGoodEval(tt *testing.T) {
 			false, "unresolved attribute",
 		},
 		{
+			"2 != a",
+			map[string]interface{}{
+				"d": int64(2),
+			},
+			false, "unresolved attribute",
+		},
+		{
 			"a ",
 			map[string]interface{}{
 				"a": int64(2),
 			},
 			int64(2), "",
+		},
+		{
+			"true == a",
+			map[string]interface{}{
+				"a": int64(2),
+			},
+			false, "",
+		},
+		{
+			"3.14 == a",
+			map[string]interface{}{
+				"a": int64(2),
+			},
+			false, "",
 		},
 		{
 			"2 ",
@@ -97,7 +118,7 @@ func TestGoodEval(tt *testing.T) {
 			map[string]interface{}{
 				"request.size": int64(0),
 			},
-			int64(200), "",
+			int64(0), "",
 		},
 		{
 			`request.size| 200`,
@@ -113,6 +134,14 @@ func TestGoodEval(tt *testing.T) {
 				"y": int64(10),
 			},
 			true, "",
+		},
+		{
+			`x == 20 && y == 10`,
+			map[string]interface{}{
+				"a": int64(20),
+				"b": int64(10),
+			},
+			false, "unresolved attribute",
 		},
 		{
 			`service.name == "*.ns1.cluster" && service.user == "admin"`,
@@ -148,13 +177,44 @@ func TestGoodEval(tt *testing.T) {
 				"request.header": map[string]string{
 					"X-FORWARDED-HOST": "bbb",
 				},
-				"y": int64(10),
 			},
 			false, "",
+		},
+		{
+			`request.header["X-FORWARDED-HOST"] == "aaa"`,
+			map[string]interface{}{
+				"request.header1": map[string]string{
+					"X-FORWARDED-HOST": "bbb",
+				},
+			},
+			false, "unresolved attribute",
+		},
+		{
+			`request.header[headername] == "aaa"`,
+			map[string]interface{}{
+				"request.header": map[string]string{
+					"X-FORWARDED-HOST": "bbb",
+				},
+			},
+			false, "unresolved attribute",
+		},
+		{
+			`request.header[headername] == "aaa"`,
+			map[string]interface{}{
+				"request.header": map[string]string{
+					"X-FORWARDED-HOST": "aaa",
+				},
+				"headername": "X-FORWARDED-HOST",
+			},
+			true, "",
 		},
 	}
 
 	for idx, tst := range tests {
+		if tst.src == "(x == 20 && y == 10) || x == 3" {
+			fmt.Printf(tst.src + "\n")
+		}
+
 		tt.Run(fmt.Sprintf("[%d] %s", idx, tst.src), func(t *testing.T) {
 			attrs := &bag{attrs: tst.tmap}
 			exp, err := Parse(tst.src)
@@ -172,7 +232,7 @@ func TestGoodEval(tt *testing.T) {
 				return
 			}
 			if res != tst.result {
-				t.Errorf("[%d] got %s\nwant %s", idx, res, tst.result)
+				t.Errorf("[%d] %s got %s\nwant %s", idx, exp.String(), res, tst.result)
 			}
 		})
 	}

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -107,7 +107,7 @@ func (e *Expression) TypeCheck(attrs AttributeDescriptorFinder, fMap map[string]
 
 // Eval returns value of the contained variable or error
 func (v *Variable) Eval(attrs attribute.Bag) (interface{}, error) {
-	val, ok := attribute.Value(attrs, v.Name)
+	val, ok := attrs.Get(v.Name)
 	if !ok {
 		return nil, fmt.Errorf("unresolved attribute %s", v.Name)
 	}

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -107,11 +107,10 @@ func (e *Expression) TypeCheck(attrs AttributeDescriptorFinder, fMap map[string]
 
 // Eval returns value of the contained variable or error
 func (v *Variable) Eval(attrs attribute.Bag) (interface{}, error) {
-	val, ok := attrs.Get(v.Name)
-	if !ok {
-		return nil, fmt.Errorf("unresolved attribute %s", v.Name)
+	if val, ok := attrs.Get(v.Name); ok {
+		return val, nil
 	}
-	return val, nil
+	return nil, fmt.Errorf("unresolved attribute %s", v.Name)
 }
 
 // Eval evaluates the expression given an attribute bag and a function map.

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -91,7 +91,7 @@ type AttributeDescriptorFinder interface {
 }
 
 // TypeCheck an expression using fMap and attribute vocabulary. Returns the type that this expression evaluates to.
-func (e *Expression) TypeCheck(attrs AttributeDescriptorFinder, fMap map[string]Func) (valueType config.ValueType, err error) {
+func (e *Expression) TypeCheck(attrs AttributeDescriptorFinder, fMap map[string]FuncBase) (valueType config.ValueType, err error) {
 	if e.Const != nil {
 		return e.Const.Type, nil
 	}
@@ -105,20 +105,30 @@ func (e *Expression) TypeCheck(attrs AttributeDescriptorFinder, fMap map[string]
 	return e.Fn.TypeCheck(attrs, fMap)
 }
 
+// Eval returns value of the contained variable or error
+func (v *Variable) Eval(attrs attribute.Bag) (interface{}, error) {
+	val, ok := attribute.Value(attrs, v.Name)
+	if !ok {
+		return nil, fmt.Errorf("unresolved attribute %s", v.Name)
+	}
+	return val, nil
+}
+
 // Eval evaluates the expression given an attribute bag and a function map.
-func (e *Expression) Eval(attrs attribute.Bag, fMap map[string]Func) (interface{}, error) {
+func (e *Expression) Eval(attrs attribute.Bag, fMap map[string]FuncBase) (interface{}, error) {
 	if e.Const != nil {
 		return e.Const.Value, nil
 	}
 	if e.Var != nil {
-		v, ok := attrs.Get(e.Var.Name)
-		if !ok {
-			return nil, fmt.Errorf("unresolved attribute %s", e.Var.Name)
-		}
-		return v, nil
+		return e.Var.Eval(attrs)
+	}
+
+	fn := fMap[e.Fn.Name]
+	if fn == nil {
+		return nil, fmt.Errorf("unknown function: %s", e.Fn.Name)
 	}
 	// may panic
-	return e.Fn.Eval(attrs, fMap)
+	return fn.(Func).Call(attrs, e.Fn.Args, fMap)
 }
 
 // String produces postfix version with all operators converted to function names
@@ -199,27 +209,8 @@ func (f *Function) String() string {
 	return s
 }
 
-// Eval evaluate function.
-func (f *Function) Eval(attrs attribute.Bag, fMap map[string]Func) (interface{}, error) {
-	fn := fMap[f.Name]
-	if fn == nil {
-		return nil, fmt.Errorf("unknown function: %s", f.Name)
-	}
-	// may panic if config is not consistent with Func.ArgTypes().
-	args := []interface{}{}
-	for _, earg := range f.Args {
-		arg, err := earg.Eval(attrs, fMap)
-		if err != nil && !fn.AcceptsNulls() {
-			return nil, err
-		}
-		args = append(args, arg)
-	}
-	glog.V(2).Infof("calling %#v %#v", fn, args)
-	return fn.Call(args), nil
-}
-
 // TypeCheck Function using fMap and attribute vocabulary. Return static or computed return type if all args have correct type.
-func (f *Function) TypeCheck(attrs AttributeDescriptorFinder, fMap map[string]Func) (valueType config.ValueType, err error) {
+func (f *Function) TypeCheck(attrs AttributeDescriptorFinder, fMap map[string]FuncBase) (valueType config.ValueType, err error) {
 	fn := fMap[f.Name]
 	if fn == nil {
 		return valueType, fmt.Errorf("unknown function: %s", f.Name)
@@ -387,7 +378,7 @@ func Parse(src string) (ex *Expression, err error) {
 type cexl struct {
 	//TODO add ast cache
 	// function Map
-	fMap map[string]Func
+	fMap map[string]FuncBase
 }
 
 func (e *cexl) Eval(s string, attrs attribute.Bag) (ret interface{}, err error) {

--- a/pkg/expr/func.go
+++ b/pkg/expr/func.go
@@ -110,11 +110,7 @@ func (f *eqFunc) call(args0 interface{}, args1 interface{}) bool {
 	switch s0 := args0.(type) {
 	default:
 		return reflect.DeepEqual(args0, args1)
-	case bool:
-		return args0 == args1
-	case int64:
-		return args0 == args1
-	case float64:
+	case bool, int64, float64:
 		return args0 == args1
 	case string:
 		var s1 string

--- a/pkg/expr/func.go
+++ b/pkg/expr/func.go
@@ -24,7 +24,7 @@ import (
 
 // FuncBase defines the interface that every expression function must implement.
 type FuncBase interface {
-	// Name uniquely identified the function.
+	// Name uniquely identifies the function.
 	Name() string
 
 	// ReturnType specifies the return type of this function.
@@ -36,7 +36,6 @@ type FuncBase interface {
 
 // Func implements a function call.
 // It needs to know details about Expressions and attribute bag.
-// Func is performant.
 type Func interface {
 	FuncBase
 

--- a/pkg/expr/func.go
+++ b/pkg/expr/func.go
@@ -19,10 +19,11 @@ import (
 	"strings"
 
 	config "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/mixer/pkg/attribute"
 )
 
-// Func defines the interface that every expression function provider must implement.
-type Func interface {
+// FuncBase defines the interface that every expression function must implement.
+type FuncBase interface {
 	// Name uniquely identified the function.
 	Name() string
 
@@ -31,16 +32,21 @@ type Func interface {
 
 	// ArgTypes specifies the argument types in order expected by the function.
 	ArgTypes() []config.ValueType
-
-	// NullArgs specifies if the function accepts null args
-	AcceptsNulls() bool
-
-	// Call performs the function call. It is guaranteed
-	// that call will be made with correct types and arity.
-	// may panic.
-	Call([]interface{}) interface{}
 }
 
+// Func implements a function call.
+// It needs to know details about Expressions and attribute bag.
+// Func is performant.
+type Func interface {
+	FuncBase
+
+	// Call performs the function call. It is guaranteed
+	// that call will be made with correct arity.
+	// may panic.
+	Call(attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error)
+}
+
+// baseFunc is basetype for many funcs
 type baseFunc struct {
 	name         string
 	argTypes     []config.ValueType
@@ -51,7 +57,6 @@ type baseFunc struct {
 func (f *baseFunc) Name() string                 { return f.name }
 func (f *baseFunc) ReturnType() config.ValueType { return f.retType }
 func (f *baseFunc) ArgTypes() []config.ValueType { return f.argTypes }
-func (f *baseFunc) AcceptsNulls() bool           { return f.acceptsNulls }
 
 type eqFunc struct {
 	*baseFunc
@@ -82,27 +87,44 @@ func newNEQ() Func {
 	}
 }
 
-func (f *eqFunc) Call(args []interface{}) interface{} {
-	res := f.call(args)
-	if f.invert {
-		return !res
+func (f *eqFunc) Call(attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error) {
+	arg0, err := args[0].Eval(attrs, fMap)
+	if err != nil {
+		return nil, err
 	}
-	return res
+
+	arg1, err := args[1].Eval(attrs, fMap)
+	if err != nil {
+		return nil, err
+	}
+
+	res := f.call(arg0, arg1)
+
+	if f.invert {
+		return !res, nil
+	}
+	return res, nil
 }
 
-func (f *eqFunc) call(args []interface{}) bool {
-	var s0 string
-	var s1 string
-	var ok bool
-
-	if s0, ok = args[0].(string); !ok {
-		return reflect.DeepEqual(args[0], args[1])
+func (f *eqFunc) call(args0 interface{}, args1 interface{}) bool {
+	switch s0 := args0.(type) {
+	default:
+		return reflect.DeepEqual(args0, args1)
+	case bool:
+		return args0 == args1
+	case int64:
+		return args0 == args1
+	case float64:
+		return args0 == args1
+	case string:
+		var s1 string
+		var ok bool
+		if s1, ok = args1.(string); !ok {
+			// s0 is string and s1 is not
+			return false
+		}
+		return matchWithWildcards(s0, s1)
 	}
-	if s1, ok = args[1].(string); !ok {
-		// s0 is string and s1 is not
-		return false
-	}
-	return matchWithWildcards(s0, s1)
 }
 
 // matchWithWildcards     s0 == ns1.*   --> ns1 should be a prefix of s0
@@ -135,8 +157,22 @@ func newLAND() Func {
 
 // Call returns true if both elements true
 // may panic
-func (f *lAndFunc) Call(args []interface{}) interface{} {
-	return args[0].(bool) && args[1].(bool)
+func (f *lAndFunc) Call(attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error) {
+	return logicalAndOr(false, attrs, args, fMap)
+}
+
+func logicalAndOr(exitVal bool, attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error) {
+	for _, arg := range args {
+		ret, err := arg.Eval(attrs, fMap)
+		if err != nil {
+			return nil, err
+		}
+		if ret == exitVal {
+			return exitVal, nil
+		}
+	}
+
+	return !exitVal, nil
 }
 
 type lOrFunc struct {
@@ -155,8 +191,8 @@ func newLOR() Func {
 }
 
 // Call should return true if at least one element is true
-func (f *lOrFunc) Call(args []interface{}) interface{} {
-	return args[0].(bool) || args[1].(bool)
+func (f *lOrFunc) Call(attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error) {
+	return logicalAndOr(true, attrs, args, fMap)
 }
 
 // applies to non bools.
@@ -177,17 +213,17 @@ func newOR() Func {
 	}
 }
 
-// Call selects first non empty argument
+// Call selects first non empty argument / non erroneous
 // may return nil
-func (f *orFunc) Call(args []interface{}) interface{} {
-	if args[0] == nil {
-		return args[1]
+func (f *orFunc) Call(attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error) {
+	for _, arg := range args {
+		ret, _ := arg.Eval(attrs, fMap)
+		if ret != nil {
+			return ret, nil
+		}
 	}
-	v := reflect.ValueOf(args[0])
-	if v.Interface() != reflect.Zero(v.Type()).Interface() {
-		return args[0]
-	}
-	return args[1]
+
+	return nil, nil
 }
 
 // func (Value) MapIndex
@@ -206,20 +242,20 @@ func newIndex() Func {
 	}
 }
 
-// Call returns map[key]
-// panics if arg[0] is not a map
-func (f *indexFunc) Call(args []interface{}) interface{} {
-	m := reflect.ValueOf(args[0])
-	k := reflect.ValueOf(args[1])
-	if v := m.MapIndex(k); v.IsValid() {
-		return v.Interface()
+func (f *indexFunc) Call(attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error) {
+	mp, err := args[0].Var.Eval(attrs)
+	if err != nil {
+		return nil, err
 	}
-
-	return nil
+	key, err := args[1].Eval(attrs, fMap)
+	if err != nil {
+		return nil, err
+	}
+	return mp.(map[string]string)[key.(string)], nil
 }
 
-func inventory() []Func {
-	return []Func{
+func inventory() []FuncBase {
+	return []FuncBase{
 		newEQ(),
 		newNEQ(),
 		newOR(),
@@ -230,8 +266,8 @@ func inventory() []Func {
 }
 
 // FuncMap provides inventory of available functions.
-func FuncMap() map[string]Func {
-	m := make(map[string]Func)
+func FuncMap() map[string]FuncBase {
+	m := make(map[string]FuncBase)
 	for _, fn := range inventory() {
 		m[fn.Name()] = fn
 	}

--- a/pkg/expr/func_test.go
+++ b/pkg/expr/func_test.go
@@ -24,27 +24,6 @@ import (
 
 func TestIndexFunc(tt *testing.T) {
 	fn := newIndex()
-	mp := map[string]interface{}{
-		"X-FORWARDED-HOST": "aaa",
-		"X-request-size":   2000,
-	}
-	tbl := []struct {
-		key  interface{}
-		want interface{}
-	}{
-		{"Does not Exists", nil},
-		{"X-FORWARDED-HOST", "aaa"},
-		{"X-request-size", 2000},
-	}
-
-	for idx, tst := range tbl {
-		tt.Run(fmt.Sprintf("[%d] %s", idx, tst.key), func(t *testing.T) {
-			rv := fn.Call([]interface{}{mp, tst.key})
-			if rv != tst.want {
-				t.Errorf("[%d] got %#v\nwant %#v", idx, rv, tst.want)
-			}
-		})
-	}
 
 	check(tt, "ReturnType", fn.ReturnType(), config.VALUE_TYPE_UNSPECIFIED)
 	check(tt, "ArgTypes", fn.ArgTypes(), []config.ValueType{config.STRING_MAP, config.STRING})
@@ -57,7 +36,7 @@ func check(t *testing.T, msg string, got interface{}, want interface{}) {
 }
 
 func TestEQFunc(tt *testing.T) {
-	fn := newEQ()
+	fn := newEQ().(*eqFunc)
 	tbl := []struct {
 		val   interface{}
 		match interface{}
@@ -73,7 +52,7 @@ func TestEQFunc(tt *testing.T) {
 	}
 	for idx, tst := range tbl {
 		tt.Run(fmt.Sprintf("[%d] %s", idx, tst.val), func(t *testing.T) {
-			rv := fn.Call([]interface{}{tst.val, tst.match})
+			rv := fn.call(tst.val, tst.match)
 			if rv != tst.equal {
 				tt.Errorf("[%d] %v ?= %v -- got %#v\nwant %#v", idx, tst.val, tst.match, rv, tst.equal)
 			}


### PR DESCRIPTION
initial perf: 1600 ns/op
new: 450 ns/op

Use unmanaged functions.
  Previously framework was doing a lot of common work and giving
  elementary types to Funcs, but it was not performant.
  Now writing a func is more involved, but it is more performant.
  Now funcs receive []*Expression

convert all existing funcs to unmanaged.

Issues with managed funcs:
1. involved creating a lot of objects. Could be resolved by using a pool of slices,
   but now removed the need for it.
2. Short circuit functions are easier with unmanaged.  { A && B && C } should return false if A is false and not evaluate B and C.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/392)
<!-- Reviewable:end -->
