### PR TITLE
Add initial support for use of details field in rpc.Status messages.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,11 +61,13 @@ load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogoslick_proto_library")
 gogoslick_proto_library(
     name = "google/rpc",
     protos = [
-        "google/rpc/status.proto",
         "google/rpc/code.proto",
+        "google/rpc/error_details.proto",
+        "google/rpc/status.proto",
     ],
     importmap = {
         "google/protobuf/any.proto": "github.com/gogo/protobuf/types",
+        "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
     },
     imports = [
         "../../external/com_github_google_protobuf/src",

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -27,7 +27,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sync"
 
@@ -102,9 +101,10 @@ func (s *grpcServer) dispatcher(stream grpc.Stream, methodName string,
 
 		bag, err := tracker.ApplyAttributes(attrs)
 		if err != nil {
-			msg := fmt.Sprintf("Unable to process attribute update: %v", err)
-			glog.Error(msg)
-			*result = status.WithInvalidArgument(msg)
+			msg := "Request could not be processed due to invalid 'attribute_update'."
+			glog.Error(msg, "\n", err)
+			details := status.NewBadRequest("attribute_update", err)
+			*result = status.InvalidWithDetails(msg, details)
 
 			sendLock.Lock()
 			err = s.sendMsg(stream, response)

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -399,6 +399,9 @@ func TestBadAttr(t *testing.T) {
 		if response.Result.Code != int32(rpc.INVALID_ARGUMENT) {
 			t.Errorf("Got result %d, expecting %d", response.Result.Code, rpc.INVALID_ARGUMENT)
 		}
+		if response.Result.Details == nil {
+			t.Errorf("No details supplied in response: %v", response.Result)
+		}
 	}
 
 	wg := sync.WaitGroup{}

--- a/pkg/status/BUILD
+++ b/pkg/status/BUILD
@@ -8,8 +8,8 @@ go_library(
         "status.go",
     ],
     deps = [
-        "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],

--- a/pkg/status/BUILD
+++ b/pkg/status/BUILD
@@ -9,7 +9,9 @@ go_library(
     ],
     deps = [
         "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
     ],
 )
 

--- a/pkg/status/BUILD
+++ b/pkg/status/BUILD
@@ -22,4 +22,7 @@ go_test(
         "status_test.go",
     ],
     library = ":go_default_library",
+    deps = [
+        "@com_github_hashicorp_go_multierror//:go_default_library",
+    ],
 )

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -16,7 +16,10 @@
 package status
 
 import (
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
 	rpc "github.com/googleapis/googleapis/google/rpc"
+	me "github.com/hashicorp/go-multierror"
 )
 
 // OK represents a status with a code of rpc.OK
@@ -70,4 +73,34 @@ func WithDeadlineExceeded(message string) rpc.Status {
 // IsOK returns true is the given status has the code rpc.OK
 func IsOK(status rpc.Status) bool {
 	return status.Code == int32(rpc.OK)
+}
+
+// InvalidWithDetails builds a google.rpc.Status proto with the provided
+// message and the `details` field populated with the supplied proto message.
+// NOTE: if there is an issue marshaling the proto to a google.protobuf.Any,
+// the returned Status message will not have the `details` field populated.
+func InvalidWithDetails(msg string, pb proto.Message) rpc.Status {
+	invalid := WithInvalidArgument(msg)
+	if any, err := types.MarshalAny(pb); err == nil {
+		invalid.Details = []*types.Any{any}
+	}
+	return invalid
+}
+
+// NewBadRequest builds a google.rpc.NewBadRequest proto. NewBadRequest proto messages
+// can be used to populate the `details` field in a google.rpc.Status message.
+func NewBadRequest(field string, err error) *rpc.BadRequest {
+	fvs := make([]*rpc.BadRequest_FieldViolation, 0, 1) // alloc for at least one
+	switch err.(type) {
+	case *me.Error:
+		merr := err.(*me.Error)
+		for _, e := range merr.Errors {
+			fv := &rpc.BadRequest_FieldViolation{Field: field, Description: e.Error()}
+			fvs = append(fvs, fv)
+		}
+	default:
+		fv := &rpc.BadRequest_FieldViolation{Field: field, Description: err.Error()}
+		fvs = append(fvs, fv)
+	}
+	return &rpc.BadRequest{FieldViolations: fvs}
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -87,7 +87,7 @@ func InvalidWithDetails(msg string, pb proto.Message) rpc.Status {
 	return invalid
 }
 
-// NewBadRequest builds a google.rpc.NewBadRequest proto. NewBadRequest proto messages
+// NewBadRequest builds a google.rpc.BadRequest proto. BadRequest proto messages
 // can be used to populate the `details` field in a google.rpc.Status message.
 func NewBadRequest(field string, err error) *rpc.BadRequest {
 	fvs := make([]*rpc.BadRequest_FieldViolation, 0, 1) // alloc for at least one

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -18,7 +18,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	rpc "github.com/googleapis/googleapis/google/rpc"
+	"github.com/hashicorp/go-multierror"
 )
 
 func TestStatus(t *testing.T) {
@@ -73,6 +75,36 @@ func TestStatus(t *testing.T) {
 
 	s = InvalidWithDetails("Invalid", NewBadRequest("test", errors.New("error")))
 	if s.Code != int32(rpc.INVALID_ARGUMENT) && s.Message != "Invalid" && len(s.Details) != 1 {
-		t.Errorf("Got %v, expected status with code = rpc.INVALID_ARGUMENT and non-nil details", s)
+		t.Errorf("Got %v, expected status with code = rpc.INVALID_ARGUMENT and populated details", s)
 	}
+}
+
+func TestNewBadRequest(t *testing.T) {
+	me := multierror.Append(errors.New("error one"), errors.New("error two"))
+
+	cases := []struct {
+		name  string
+		field string
+		err   error
+		want  *rpc.BadRequest
+	}{
+		{"simple error", "field", errors.New("error"), newBadReq(newViolation("field", "error"))},
+		{"go-multierror", "field", me, newBadReq(newViolation("field", "error one"), newViolation("field", "error two"))},
+	}
+	for _, v := range cases {
+		t.Run(v.name, func(t *testing.T) {
+			got := NewBadRequest(v.field, v.err)
+			if !proto.Equal(got, v.want) {
+				t.Fatalf("Got %v, want %v", got, v.want)
+			}
+		})
+	}
+}
+
+func newViolation(field, desc string) *rpc.BadRequest_FieldViolation {
+	return &rpc.BadRequest_FieldViolation{Field: field, Description: desc}
+}
+
+func newBadReq(violations ...*rpc.BadRequest_FieldViolation) *rpc.BadRequest {
+	return &rpc.BadRequest{FieldViolations: violations}
 }

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -70,4 +70,9 @@ func TestStatus(t *testing.T) {
 	if s.Code != int32(rpc.DEADLINE_EXCEEDED) || s.Message != "Aborted!" {
 		t.Errorf("Got %v %v, expected rpc.DEADLINE_EXCEEDED Aborted!", s.Code, s.Message)
 	}
+
+	s = InvalidWithDetails("Invalid", NewBadRequest("test", errors.New("error")))
+	if s.Code != int32(rpc.INVALID_ARGUMENT) && s.Message != "Invalid" && len(s.Details) != 1 {
+		t.Errorf("Got %v, expected status with code = rpc.INVALID_ARGUMENT and non-nil details", s)
+	}
 }


### PR DESCRIPTION
This is the first step in addressing #393.

It addresses the `attribute_update`-related messages that are 
returned from Mixer. These were the messages that had been 
leaking through mixerclient out to application clients.

Mixerclient will still need to figure out how best to translate this
messaging to something more appropriate for applications to see
(they should not care about issues with attributes, etc.).

The PR adds support for creating BadRequest messages, which is 
one of the standard rpc error types. Special handling is added for
go-multierrors (to generate a list of field violation messages).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/404)
<!-- Reviewable:end -->
