### PR TITLE
Remove logging aspects from the testdata configuration.

### DIFF
--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -28,32 +28,3 @@ rules:
           service: api.name | "unknown"
           method: api.method | "unknown"
           response_code: response.http.code | 200
-  - kind: access-logs
-    params:
-      logName: "access_log"
-      log:
-        logFormat: COMMON
-        templateExpressions:
-           originIp: origin.ip
-           source_user: origin.user
-           timestamp: request.time
-           # TODO: remove this OR when the proxy has implemented support for the request.method attribute
-           method: request.method | ""
-           url: request.path
-           protocol: request.scheme
-           responseCode: response.code
-           responseSize: response.size
-        labels:
-           originIp: origin.ip
-           source_user: origin.user
-           timestamp: request.time
-           # TODO: remove this OR when the proxy has implemented support for the request.method attribute
-           method: request.method | ""
-           url: request.path
-           protocol: request.scheme
-           responseCode: response.code
-           responseSize: response.size
-  - kind: application-logs
-    params:
-      logName: "mixer_log"
-      logs:


### PR DESCRIPTION
Right now, there are problems with the logs aspects, as configured
in the testdata/ directory. As these are being relied upon to drive
configuration in demo directories, etc., this PR removes them.

When the issues with the logs bits of the configuration are resolved,
these should be added back in. This _MUST_ be verified by running mixs
and mixc and checking /metrics and seeing the logs in the output,
however.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/406)
<!-- Reviewable:end -->
