### PR TITLE
Bunch of cleanup work in mixc & mixs.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,6 +131,24 @@ new_go_repository(
 )
 
 new_go_repository(
+    name = "com_github_cpuguy83_go_md2man",
+    commit = "648eed146d3f3beacb64063cd0daae908015eebd", # Mar 19, 2017 (no releases)
+    importpath = "github.com/cpuguy83/go-md2man",
+)
+
+new_go_repository(
+    name = "com_github_russross_blackfriday",
+    commit = "35eb537633d9950afc8ae7bdf0edb6134584e9fc", # Mar 19, 2017 (no releases)
+    importpath = "github.com/russross/blackfriday",
+)
+
+new_go_repository(
+    name = "com_github_shurcooL_sanitized_anchor_name",
+    commit = "10ef21a441db47d8b13ebcc5fd2310f636973c77", # Mar 19, 2017 (no releases)
+    importpath = "github.com/shurcooL/sanitized_anchor_name",
+)
+
+new_go_repository(
     name = "com_github_hashicorp_go_multierror",
     commit = "ed905158d87462226a13fe39ddf685ea65f1c11f", # Dec 16, 2016 (no releases)
     importpath = "github.com/hashicorp/go-multierror",

--- a/cmd/client/cmd/BUILD
+++ b/cmd/client/cmd/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "check.go",
+        "quota.go",
+        "report.go",
+        "root.go",
+        "util.go",
+    ],
+    visibility = ["//cmd:__subpackages__"],
+    deps = [
+        "//pkg/tracing:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_istio_api//:mixer/v1",
+        "@com_github_opentracing_basictracer//:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_opentracing_opentracing_go//ext:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "util_test",
+    size = "small",
+    srcs = ["util_test.go"],
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/attribute:go_default_library",
+    ],
+)

--- a/cmd/client/cmd/report.go
+++ b/cmd/client/cmd/report.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Istio Authors
+// Copyright 2017 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"
@@ -24,60 +24,54 @@ import (
 	mixerpb "istio.io/api/mixer/v1"
 )
 
-func checkCmd(rootArgs *rootArgs, outf outFn, errorf errorFn) *cobra.Command {
+func reportCmd(rootArgs *rootArgs, outf outFn, errorf errorFn) *cobra.Command {
 	return &cobra.Command{
-		Use:   "check",
-		Short: "Invokes the mixer's Check API.",
+		Use:   "report",
+		Short: "Invokes the mixer's Report API.",
 		Run: func(cmd *cobra.Command, args []string) {
-			check(rootArgs, outf, errorf)
+			report(rootArgs, outf, errorf)
 		}}
 }
 
-func check(rootArgs *rootArgs, outf outFn, errorf errorFn) {
+func report(rootArgs *rootArgs, outf outFn, errorf errorFn) {
 	var attrs *mixerpb.Attributes
 	var err error
 
 	if attrs, err = parseAttributes(rootArgs); err != nil {
-		errorf(err.Error())
-		return
+		errorf("%v", err)
 	}
 
 	var cs *clientState
 	if cs, err = createAPIClient(rootArgs.mixerAddress, rootArgs.enableTracing); err != nil {
-		errorf("Unable to establish connection to %s", rootArgs.mixerAddress)
-		return
+		errorf("Unable to establish connection to %s: %v", rootArgs.mixerAddress, err)
 	}
 	defer deleteAPIClient(cs)
 
-	span, ctx := cs.tracer.StartRootSpan(context.Background(), "mixc Check", ext.SpanKindRPCClient)
+	span, ctx := cs.tracer.StartRootSpan(context.Background(), "mixc Report", ext.SpanKindRPCClient)
 	_, ctx = cs.tracer.PropagateSpan(ctx, span)
 
-	var stream mixerpb.Mixer_CheckClient
-	if stream, err = cs.client.Check(ctx); err != nil {
-		errorf("Check RPC failed: %v", err)
-		return
+	var stream mixerpb.Mixer_ReportClient
+	if stream, err = cs.client.Report(ctx); err != nil {
+		errorf("Report RPC failed: %v", err)
 	}
 
 	for i := 0; i < rootArgs.repeat; i++ {
 		// send the request
-		request := mixerpb.CheckRequest{RequestIndex: int64(i), AttributeUpdate: *attrs}
+		request := mixerpb.ReportRequest{RequestIndex: 0, AttributeUpdate: *attrs}
 
 		if err = stream.Send(&request); err != nil {
-			errorf("Failed to send Check RPC: %v", err)
-			break
+			errorf("Failed to send Report RPC: %v", err)
 		}
 
-		var response *mixerpb.CheckResponse
+		var response *mixerpb.ReportResponse
 		response, err = stream.Recv()
 		if err == io.EOF {
-			errorf("Got no response from Check RPC")
-			break
+			errorf("Got no response from Report RPC")
 		} else if err != nil {
-			errorf("Failed to receive a response .from Check RPC: %v", err)
-			break
+			errorf("Failed to receive a response from Report RPC: %v", err)
 		}
 
-		outf("Check RPC returned %s\n", decodeStatus(response.Result))
+		outf("Report RPC returned %s\n", decodeStatus(response.Result))
 	}
 
 	if err = stream.CloseSend(); err != nil {

--- a/cmd/client/cmd/root.go
+++ b/cmd/client/cmd/root.go
@@ -1,0 +1,124 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type rootArgs struct {
+	// attributes is the list of name/value pairs of auto-sensed attributes that will be sent with requests
+	attributes string
+
+	// stringAttributes is the list of name/value pairs of string attributes that will be sent with requests.
+	stringAttributes string
+
+	// int64Attributes is the list of name/value pairs of int64 attributes that will be sent with requests.
+	int64Attributes string
+
+	// float64Attributes is the list of name/value pairs of float64 attributes that will be sent with requests.
+	doubleAttributes string
+
+	// boolAttributes is the list of name/value pairs of bool attributes that will be sent with requests.
+	boolAttributes string
+
+	// timestampAttributes is the list of name/value pairs of timestamp attributes that will be sent with requests.
+	timestampAttributes string
+
+	// durationAttributes is the list of name/value pairs of duration attributes that will be sent with requests.
+	durationAttributes string
+
+	// bytesAttributes is the list of name/value pairs of bytes attributes that will be sent with requests.
+	bytesAttributes string
+
+	// stringMapAttributes is the list of string maps that will be sent with requests
+	stringMapAttributes string
+
+	// mixerAddress is the full address (including port) of a mixer instance to call.
+	mixerAddress string
+
+	// enableTracing controls whether client-side traces are generated for calls to the mixer.
+	enableTracing bool
+
+	// # times to repeat the operation
+	repeat int
+}
+
+// A function used for normal output.
+type outFn func(format string, a ...interface{})
+
+// A function used for error output.
+type errorFn func(format string, a ...interface{})
+
+// GetRootCmd returns the root of the cobra command-tree.
+func GetRootCmd(args []string, outf outFn, errorf errorFn) *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "mixc",
+		Short: "Invoke the API of a running instance of the Istio mixer",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("'%s' is an invalid argument", args[0])
+			}
+			return nil
+		},
+	}
+	rootCmd.SetArgs(args)
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	// hack to make flag.Parsed return true such that glog is happy
+	// about the flags having been parsed
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	/* #nosec */
+	_ = fs.Parse([]string{})
+	flag.CommandLine = fs
+
+	rootArgs := &rootArgs{}
+
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.mixerAddress, "mixer", "m", "localhost:9091",
+		"Address and port of running instance of the mixer")
+	rootCmd.PersistentFlags().IntVarP(&rootArgs.repeat, "repeat", "r", 1,
+		"Sends the specified number of requests in quick succession")
+
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.attributes, "attributes", "a", "",
+		"List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.stringAttributes, "string_attributes", "s", "",
+		"List of name/value string attributes specified as name1=value1,name2=value2,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.int64Attributes, "int64_attributes", "i", "",
+		"List of name/value int64 attributes specified as name1=value1,name2=value2,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.doubleAttributes, "double_attributes", "d", "",
+		"List of name/value float64 attributes specified as name1=value1,name2=value2,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.boolAttributes, "bool_attributes", "b", "",
+		"List of name/value bool attributes specified as name1=value1,name2=value2,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.timestampAttributes, "timestamp_attributes", "t", "",
+		"List of name/value timestamp attributes specified as name1=value1,name2=value2,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.durationAttributes, "duration_attributes", "", "",
+		"List of name/value duration attributes specified as name1=value1,name2=value2,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.bytesAttributes, "bytes_attributes", "", "",
+		"List of name/value bytes attributes specified as name1=b0:b1:b3,name2=b4:b5:b6,...")
+	rootCmd.PersistentFlags().StringVarP(&rootArgs.stringMapAttributes, "stringmap_attributes", "", "",
+		"List of name/value string map attributes specified as name1=k1:v1;k2:v2,name2=k3:v3...")
+	// TODO: implement an option to specify how traces are reported (hardcoded to report to stdout right now).
+	rootCmd.PersistentFlags().BoolVarP(&rootArgs.enableTracing, "trace", "", false,
+		"Whether to trace rpc executions")
+
+	rootCmd.AddCommand(checkCmd(rootArgs, outf, errorf))
+	rootCmd.AddCommand(reportCmd(rootArgs, outf, errorf))
+	rootCmd.AddCommand(quotaCmd(rootArgs, outf, errorf))
+
+	return rootCmd
+}

--- a/cmd/client/cmd/util.go
+++ b/cmd/client/cmd/util.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Istio Authors
+// Copyright 2017 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/cmd/client/cmd/util_test.go
+++ b/cmd/client/cmd/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Istio Authors
+// Copyright 2017 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"reflect"

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -15,122 +15,23 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
+	"istio.io/mixer/cmd/client/cmd"
 )
 
-type rootArgs struct {
-	// attributes is the list of name/value pairs of auto-sensed attributes that will be sent with requests
-	attributes string
-
-	// stringAttributes is the list of name/value pairs of string attributes that will be sent with requests.
-	stringAttributes string
-
-	// int64Attributes is the list of name/value pairs of int64 attributes that will be sent with requests.
-	int64Attributes string
-
-	// float64Attributes is the list of name/value pairs of float64 attributes that will be sent with requests.
-	doubleAttributes string
-
-	// boolAttributes is the list of name/value pairs of bool attributes that will be sent with requests.
-	boolAttributes string
-
-	// timestampAttributes is the list of name/value pairs of timestamp attributes that will be sent with requests.
-	timestampAttributes string
-
-	// durationAttributes is the list of name/value pairs of duration attributes that will be sent with requests.
-	durationAttributes string
-
-	// bytesAttributes is the list of name/value pairs of bytes attributes that will be sent with requests.
-	bytesAttributes string
-
-	// stringMapAttributes is the list of string maps that will be sent with requests
-	stringMapAttributes string
-
-	// mixerAddress is the full address (including port) of a mixer instance to call.
-	mixerAddress string
-
-	// enableTracing controls whether client-side traces are generated for calls to the mixer.
-	enableTracing bool
-
-	// # times to repeat the operation
-	repeat int
-}
-
-// A function used for normal output.
-type outFn func(format string, a ...interface{})
-
-// A function used for error output.
-type errorFn func(format string, a ...interface{})
-
-// withArgs is like main except that it is parameterized with the
-// command-line arguments to use, along with functions to call
-// in case of normal output or errors. This allows the function to
-// be invoked from test code.
-func withArgs(args []string, outf outFn, errorf errorFn) {
-	// RootCmd represents the base command when called without any subcommands
-	rootCmd := &cobra.Command{
-		Use:   "mixc",
-		Short: "Invoke the API of a running instance of the Istio mixer",
-	}
-	rootCmd.SetArgs(args)
-	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-
-	// hack to make flag.Parsed return true such that glog is happy
-	// about the flags having been parsed
-	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	/* #nosec */
-	_ = fs.Parse([]string{})
-	flag.CommandLine = fs
-
-	rootArgs := &rootArgs{}
-
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.mixerAddress, "mixer", "m", "localhost:9091",
-		"Address and port of running instance of the mixer")
-	rootCmd.PersistentFlags().IntVarP(&rootArgs.repeat, "repeat", "r", 1,
-		"Sends the specified number of requests in quick succession")
-
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.attributes, "attributes", "a", "",
-		"List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.stringAttributes, "string_attributes", "s", "",
-		"List of name/value string attributes specified as name1=value1,name2=value2,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.int64Attributes, "int64_attributes", "i", "",
-		"List of name/value int64 attributes specified as name1=value1,name2=value2,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.doubleAttributes, "double_attributes", "d", "",
-		"List of name/value float64 attributes specified as name1=value1,name2=value2,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.boolAttributes, "bool_attributes", "b", "",
-		"List of name/value bool attributes specified as name1=value1,name2=value2,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.timestampAttributes, "timestamp_attributes", "t", "",
-		"List of name/value timestamp attributes specified as name1=value1,name2=value2,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.durationAttributes, "duration_attributes", "", "",
-		"List of name/value duration attributes specified as name1=value1,name2=value2,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.bytesAttributes, "bytes_attributes", "", "",
-		"List of name/value bytes attributes specified as name1=b0:b1:b3,name2=b4:b5:b6,...")
-	rootCmd.PersistentFlags().StringVarP(&rootArgs.stringMapAttributes, "stringmap_attributes", "", "",
-		"List of name/value string map attributes specified as name1=k1:v1;k2:v2,name2=k3:v3...")
-	// TODO: implement an option to specify how traces are reported (hardcoded to report to stdout right now).
-	rootCmd.PersistentFlags().BoolVarP(&rootArgs.enableTracing, "trace", "", false,
-		"Whether to trace rpc executions")
-
-	rootCmd.AddCommand(checkCmd(rootArgs, outf, errorf))
-	rootCmd.AddCommand(reportCmd(rootArgs, outf, errorf))
-	rootCmd.AddCommand(quotaCmd(rootArgs, outf, errorf))
-
-	if err := rootCmd.Execute(); err != nil {
-		errorf(err.Error())
-	}
-}
-
 func main() {
-	withArgs(os.Args[1:],
+	rootCmd := cmd.GetRootCmd(os.Args[1:],
 		func(format string, a ...interface{}) {
 			fmt.Printf(format, a...)
 		},
 		func(format string, a ...interface{}) {
-			fmt.Fprintf(os.Stderr, format, a...)
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, format+"\n", a...)
+			os.Exit(-1)
 		})
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(-1)
+	}
 }

--- a/cmd/collateral/BUILD
+++ b/cmd/collateral/BUILD
@@ -3,12 +3,12 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_binary(
-    name = "mixc",
+    name = "mixcol",
     srcs = [
         "main.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//cmd/client/cmd:go_default_library",
+        "//cmd/collateral/cmd:go_default_library",
     ],
 )

--- a/cmd/collateral/cmd/BUILD
+++ b/cmd/collateral/cmd/BUILD
@@ -1,0 +1,26 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "root.go",
+    ],
+    visibility = ["//cmd:__subpackages__"],
+    deps = [
+        "//cmd/client/cmd:go_default_library",
+        "//cmd/server/cmd:go_default_library",
+        "//pkg/tracing:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_istio_api//:mixer/v1",
+        "@com_github_opentracing_basictracer//:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_opentracing_opentracing_go//ext:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@com_github_spf13_cobra//doc:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/cmd/collateral/cmd/root.go
+++ b/cmd/collateral/cmd/root.go
@@ -1,0 +1,90 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a simple command that is used to output the auto-generated collateral
+// files for the various mixer CLI commands. More specifically, this outputs
+// markdown files and man pages that describe the CLI commands, along with
+// bash completion files.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+
+	mixc "istio.io/mixer/cmd/client/cmd"
+	mixs "istio.io/mixer/cmd/server/cmd"
+)
+
+// A function used for normal output.
+type outFn func(format string, a ...interface{})
+
+// A function used for error output.
+type errorFn func(format string, a ...interface{})
+
+// GetRootCmd returns the root of the cobra command-tree.
+func GetRootCmd(args []string, outf outFn, errorf errorFn) *cobra.Command {
+	outputDir := ""
+
+	rootCmd := &cobra.Command{
+		Use:   "mixcol",
+		Short: "Generate collateral for mixer CLI commands",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("'%s' is an invalid argument", args[0])
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			work(outf, errorf, outputDir)
+		},
+	}
+	rootCmd.Flags().StringVarP(&outputDir, "outputDir", "o", ".", "Directory where to generate the CLI collateral files")
+
+	return rootCmd
+}
+
+func work(outf outFn, errorf errorFn, outputDir string) {
+	roots := []*cobra.Command{
+		mixc.GetRootCmd(nil, nil, nil),
+		mixs.GetRootCmd(nil, nil, nil),
+	}
+
+	outf("Outputting Mixer CLI collateral files to %s\n", outputDir)
+	for _, r := range roots {
+		hdr := doc.GenManHeader{
+			Title:   "Istio Mixer",
+			Section: "Mixer CLI",
+			Manual:  "Istio Mixer",
+		}
+
+		if err := doc.GenManTree(r, &hdr, outputDir); err != nil {
+			errorf("Unable to output manpage tree: %v", err)
+		}
+
+		if err := doc.GenMarkdownTree(r, outputDir); err != nil {
+			errorf("Unable to output markdown tree: %v", err)
+		}
+
+		if err := doc.GenYamlTree(r, outputDir); err != nil {
+			errorf("Unable to output YAML tree: %v", err)
+		}
+
+		if err := r.GenBashCompletionFile(outputDir + "/" + r.Name() + ".bash"); err != nil {
+			errorf("Unable to output bash completion file: %v", err)
+		}
+	}
+}

--- a/cmd/collateral/main.go
+++ b/cmd/collateral/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Istio Authors
+// Copyright 2017 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This is a simple command that is used to output the auto-generated collateral
+// files for the various mixer CLI commands. More specifically, this outputs
+// markdown files and man pages that describe the CLI commands, along with
+// bash completion files.
+
 package main
 
 import (
 	"fmt"
 	"os"
 
-	"istio.io/mixer/cmd/server/cmd"
+	"istio.io/mixer/cmd/collateral/cmd"
 )
 
 func main() {

--- a/cmd/server/BUILD
+++ b/cmd/server/BUILD
@@ -2,41 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_library(
-    name = "go_default_library",
-    srcs = [
-        "inventory.go",
-        "main.go",
-        "server.go",
-    ],
-    visibility = ["//visibility:private"],
-    deps = [
-        "//adapter:go_default_library",
-        "//pkg/adapter:go_default_library",
-        "//pkg/adapterManager:go_default_library",
-        "//pkg/api:go_default_library",
-        "//pkg/aspect:go_default_library",
-        "//pkg/attribute:go_default_library",
-        "//pkg/config:go_default_library",
-        "//pkg/config/proto:go_default_library",
-        "//pkg/expr:go_default_library",
-        "//pkg/pool:go_default_library",
-        "//pkg/tracing:go_default_library",
-        "@com_github_ghodss_yaml//:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
-        "@com_github_istio_api//:mixer/v1",
-        "@com_github_istio_api//:mixer/v1/config",
-        "@com_github_opentracing_basictracer//:go_default_library",
-        "@com_github_opentracing_opentracing_go//:go_default_library",
-        "@com_github_spf13_cobra//:go_default_library",
-        "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//credentials:go_default_library",
-        "@org_golang_google_grpc//grpclog/glogger:go_default_library",
-    ],
-)
-
 go_binary(
     name = "mixs",
-    library = ":go_default_library",
+    srcs = [
+        "main.go",
+    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/server/cmd:go_default_library",
+    ],
 )

--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -1,0 +1,36 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "inventory.go",
+        "root.go",
+        "server.go",
+    ],
+    visibility = ["//cmd:__subpackages__"],
+    deps = [
+        "//adapter:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/adapterManager:go_default_library",
+        "//pkg/api:go_default_library",
+        "//pkg/aspect:go_default_library",
+        "//pkg/attribute:go_default_library",
+        "//pkg/config:go_default_library",
+        "//pkg/config/proto:go_default_library",
+        "//pkg/expr:go_default_library",
+        "//pkg/pool:go_default_library",
+        "//pkg/tracing:go_default_library",
+        "@com_github_ghodss_yaml//:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_istio_api//:mixer/v1",
+        "@com_github_istio_api//:mixer/v1/config",
+        "@com_github_opentracing_basictracer//:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_google_grpc//grpclog/glogger:go_default_library",
+    ],
+)

--- a/cmd/server/cmd/inventory.go
+++ b/cmd/server/cmd/inventory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"sort"
@@ -27,7 +27,7 @@ import (
 	"istio.io/mixer/pkg/config"
 )
 
-func adapterCmd(outf outFn, errorf errorFn) *cobra.Command {
+func adapterCmd(outf outFn) *cobra.Command {
 	adapterCmd := cobra.Command{
 		Use:   "inventory",
 		Short: "Inventory of available adapters and aspects in the mixer",
@@ -37,10 +37,7 @@ func adapterCmd(outf outFn, errorf errorFn) *cobra.Command {
 		Use:   "adapter",
 		Short: "List available adapter builders",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := listBuilders(outf)
-			if err != nil {
-				errorf("%v", err)
-			}
+			listBuilders(outf)
 		},
 	})
 
@@ -48,17 +45,14 @@ func adapterCmd(outf outFn, errorf errorFn) *cobra.Command {
 		Use:   "aspect",
 		Short: "List available aspects",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := listAspects(outf)
-			if err != nil {
-				errorf("%v", err)
-			}
+			listAspects(outf)
 		},
 	})
 
 	return &adapterCmd
 }
 
-func listAspects(outf outFn) error {
+func listAspects(outf outFn) {
 	aspectMap, _ := adapterManager.ProcessBindings(aspect.Inventory())
 
 	keys := []string{}
@@ -73,10 +67,9 @@ func listAspects(outf outFn) error {
 		k, _ := aspect.ParseKind(kind)
 		printAspectConfigValidator(outf, aspectMap[k])
 	}
-	return nil
 }
 
-func listBuilders(outf outFn) error {
+func listBuilders(outf outFn) {
 	builderMap := adapterManager.BuilderMap(adapter.Inventory())
 	keys := []string{}
 	for k := range builderMap {
@@ -89,9 +82,7 @@ func listBuilders(outf outFn) error {
 
 		outf("adapter %s: %s\n", impl, b.Description())
 		printAdapterConfigValidator(outf, b)
-
 	}
-	return nil
 }
 
 func printAdapterConfigValidator(outf outFn, v pkgadapter.ConfigValidator) {

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	// need to pull this in
+	_ "google.golang.org/grpc/grpclog/glogger"
+)
+
+// A function used for normal output.
+type outFn func(format string, a ...interface{})
+
+// A function used for error output.
+type errorFn func(format string, a ...interface{})
+
+// GetRootCmd returns the root of the cobra command-tree.
+func GetRootCmd(args []string, outf outFn, errorf errorFn) *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "mixs",
+		Short: "The Istio mixer provides control plane functionality to the Istio proxy and services",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("'%s' is an invalid argument", args[0])
+			}
+			return nil
+		},
+	}
+	rootCmd.SetArgs(args)
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	// hack to make flag.Parsed return true such that glog is happy
+	// about the flags having been parsed
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	/* #nosec */
+	_ = fs.Parse([]string{})
+	flag.CommandLine = fs
+
+	rootCmd.AddCommand(adapterCmd(outf))
+	rootCmd.AddCommand(serverCmd(outf, errorf))
+
+	return rootCmd
+}


### PR DESCRIPTION
- Produce errors when junk extraneous arguments are supplied.

- Use the right error code when exiting with an error.

- Eliminate useless "message" argument that was required for the 'mixc report' command.

- Correctly distinguish between command-line errors vs. operational errors. We don't want
to print the usage line when it's an operational error.

- Introduce the mixcol command which is used to output the collateral files for the mixer CLI commands: markdown doc files, man page files, and bash completion files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/415)
<!-- Reviewable:end -->
