### PR TITLE
Split the adapter.ConfigValidator interface in two

### DIFF
--- a/adapter/denyChecker/denyChecker.go
+++ b/adapter/denyChecker/denyChecker.go
@@ -41,7 +41,7 @@ func newBuilder() builder {
 	return builder{adapter.NewDefaultBuilder(name, desc, conf)}
 }
 
-func (builder) NewDenialsAspect(env adapter.Env, c adapter.AspectConfig) (adapter.DenialsAspect, error) {
+func (builder) NewDenialsAspect(env adapter.Env, c adapter.Config) (adapter.DenialsAspect, error) {
 	return newDenyChecker(c.(*config.Params))
 }
 

--- a/adapter/genericListChecker/genericListChecker.go
+++ b/adapter/genericListChecker/genericListChecker.go
@@ -39,7 +39,7 @@ func newBuilder() builder {
 	return builder{adapter.NewDefaultBuilder(name, desc, conf)}
 }
 
-func (builder) NewListsAspect(env adapter.Env, c adapter.AspectConfig) (adapter.ListsAspect, error) {
+func (builder) NewListsAspect(env adapter.Env, c adapter.Config) (adapter.ListsAspect, error) {
 	return newListChecker(c.(*config.Params))
 }
 

--- a/adapter/ipListChecker/ipListChecker.go
+++ b/adapter/ipListChecker/ipListChecker.go
@@ -73,11 +73,11 @@ func newBuilder() adapter.ListsBuilder {
 	return builder{adapter.NewDefaultBuilder(name, desc, conf)}
 }
 
-func (builder) NewListsAspect(env adapter.Env, c adapter.AspectConfig) (adapter.ListsAspect, error) {
+func (builder) NewListsAspect(env adapter.Env, c adapter.Config) (adapter.ListsAspect, error) {
 	return newListChecker(env, c.(*config.Params))
 }
 
-func (builder) ValidateConfig(cfg adapter.AspectConfig) (ce *adapter.ConfigErrors) {
+func (builder) ValidateConfig(cfg adapter.Config) (ce *adapter.ConfigErrors) {
 	c := cfg.(*config.Params)
 
 	u, err := url.Parse(c.ProviderUrl)

--- a/adapter/memQuota/memQuota.go
+++ b/adapter/memQuota/memQuota.go
@@ -102,7 +102,7 @@ func newBuilder() builder {
 	return builder{adapter.NewDefaultBuilder(name, desc, conf)}
 }
 
-func (builder) ValidateConfig(cfg adapter.AspectConfig) (ce *adapter.ConfigErrors) {
+func (builder) ValidateConfig(cfg adapter.Config) (ce *adapter.ConfigErrors) {
 	c := cfg.(*config.Params)
 
 	dedupWindow, err := ptypes.DurationFromProto(c.MinDeduplicationDuration)
@@ -116,7 +116,7 @@ func (builder) ValidateConfig(cfg adapter.AspectConfig) (ce *adapter.ConfigError
 	return
 }
 
-func (builder) NewQuotasAspect(env adapter.Env, c adapter.AspectConfig, d map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+func (builder) NewQuotasAspect(env adapter.Env, c adapter.Config, d map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
 	return newAspect(env, c.(*config.Params))
 }
 

--- a/adapter/prometheus/prometheus.go
+++ b/adapter/prometheus/prometheus.go
@@ -66,7 +66,7 @@ func (f *factory) Close() error {
 }
 
 // NewMetricsAspect provides an implementation for adapter.MetricsBuilder.
-func (f *factory) NewMetricsAspect(env adapter.Env, cfg adapter.AspectConfig, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+func (f *factory) NewMetricsAspect(env adapter.Env, cfg adapter.Config, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	var serverErr error
 	f.once.Do(func() { serverErr = f.srv.Start(env) })
 	if serverErr != nil {

--- a/adapter/statsd/statsd.go
+++ b/adapter/statsd/statsd.go
@@ -67,7 +67,7 @@ func newBuilder() *builder {
 	return &builder{adapter.NewDefaultBuilder(name, desc, defaultConf)}
 }
 
-func (b *builder) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) {
+func (b *builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	params := c.(*config.Params)
 	flushDuration, err := types.DurationFromProto(params.FlushDuration)
 	if err != nil {
@@ -90,7 +90,7 @@ func (b *builder) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErro
 	return
 }
 
-func (*builder) NewMetricsAspect(env adapter.Env, cfg adapter.AspectConfig, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+func (*builder) NewMetricsAspect(env adapter.Env, cfg adapter.Config, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	params := cfg.(*config.Params)
 
 	flushBytes := int(params.FlushBytes)

--- a/adapter/stdioLogger/stdioLogger.go
+++ b/adapter/stdioLogger/stdioLogger.go
@@ -44,15 +44,15 @@ func Register(r adapter.Registrar) {
 	r.RegisterAccessLogsBuilder(b)
 }
 
-func (builder) NewApplicationLogsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.ApplicationLogsAspect, error) {
+func (builder) NewApplicationLogsAspect(env adapter.Env, cfg adapter.Config) (adapter.ApplicationLogsAspect, error) {
 	return newLogger(cfg)
 }
 
-func (builder) NewAccessLogsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.AccessLogsAspect, error) {
+func (builder) NewAccessLogsAspect(env adapter.Env, cfg adapter.Config) (adapter.AccessLogsAspect, error) {
 	return newLogger(cfg)
 }
 
-func newLogger(cfg adapter.AspectConfig) (*logger, error) {
+func newLogger(cfg adapter.Config) (*logger, error) {
 	c := cfg.(*config.Params)
 
 	w := os.Stderr

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -63,7 +63,7 @@ go_metalinter() {
         --enable=goconst\
         --enable=gofmt\
         --enable=goimports\
-        --enable=golint --min-confidence=0 --exclude=.pb.go --exclude="should have a package comment"\
+        --enable=golint --min-confidence=0 --exclude=.pb.go --exclude=pkg/config/proto/combined.go --exclude="should have a package comment"\
         --enable=gosimple\
         --enable=ineffassign\
         --enable=interfacer\

--- a/cmd/server/inventory.go
+++ b/cmd/server/inventory.go
@@ -24,6 +24,7 @@ import (
 	pkgadapter "istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/adapterManager"
 	"istio.io/mixer/pkg/aspect"
+	"istio.io/mixer/pkg/config"
 )
 
 func adapterCmd(outf outFn, errorf errorFn) *cobra.Command {
@@ -70,7 +71,7 @@ func listAspects(outf outFn) error {
 	for _, kind := range keys {
 		outf("aspect %s\n", kind)
 		k, _ := aspect.ParseKind(kind)
-		printConfigValidator(outf, aspectMap[k])
+		printAspectConfigValidator(outf, aspectMap[k])
 	}
 	return nil
 }
@@ -87,14 +88,13 @@ func listBuilders(outf outFn) error {
 		b := builderMap[impl].Builder
 
 		outf("adapter %s: %s\n", impl, b.Description())
-		printConfigValidator(outf, b)
+		printAdapterConfigValidator(outf, b)
 
 	}
 	return nil
 }
 
-func printConfigValidator(outf outFn, v pkgadapter.ConfigValidator) {
-
+func printAdapterConfigValidator(outf outFn, v pkgadapter.ConfigValidator) {
 	outf("Params: \n")
 	c := v.DefaultConfig()
 	if c == nil {
@@ -104,5 +104,18 @@ func printConfigValidator(outf outFn, v pkgadapter.ConfigValidator) {
 	if err != nil {
 		outf("%s", err)
 	}
-	outf("%s", string(out[:])+"\n")
+	outf("%s\n", string(out[:]))
+}
+
+func printAspectConfigValidator(outf outFn, v config.AspectValidator) {
+	outf("Params: \n")
+	c := v.DefaultConfig()
+	if c == nil {
+		return
+	}
+	out, err := yaml.Marshal(c)
+	if err != nil {
+		outf("%s", err)
+	}
+	outf("%s\n", string(out[:]))
 }

--- a/pkg/adapter/accessLogs.go
+++ b/pkg/adapter/accessLogs.go
@@ -33,6 +33,6 @@ type (
 		Builder
 
 		// NewAccessLogsAspect returns a new instance of the AccessLogger aspect.
-		NewAccessLogsAspect(env Env, c AspectConfig) (AccessLogsAspect, error)
+		NewAccessLogsAspect(env Env, c Config) (AccessLogsAspect, error)
 	}
 )

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -42,18 +42,18 @@ type (
 		Description() string
 	}
 
-	// AspectConfig represents a chunk of configuration state
-	AspectConfig proto.Message
+	// Config represents a chunk of adapter configuration state
+	Config proto.Message
 
 	// ConfigValidator handles adapter configuration defaults and validation.
 	ConfigValidator interface {
 		// DefaultConfig returns a default configuration struct for this
 		// adapter. This will be used by the configuration system to establish
 		// the shape of the block of configuration state passed to the NewAspect method.
-		DefaultConfig() (c AspectConfig)
+		DefaultConfig() (c Config)
 
 		// ValidateConfig determines whether the given configuration meets all correctness requirements.
-		ValidateConfig(c AspectConfig) *ConfigErrors
+		ValidateConfig(c Config) *ConfigErrors
 	}
 
 	// WorkFunc represents a function to invoke.

--- a/pkg/adapter/applicationLogs.go
+++ b/pkg/adapter/applicationLogs.go
@@ -60,7 +60,7 @@ type (
 		Builder
 
 		// NewApplicationLogsAspect returns a new instance of the Logger aspect.
-		NewApplicationLogsAspect(env Env, c AspectConfig) (ApplicationLogsAspect, error)
+		NewApplicationLogsAspect(env Env, c Config) (ApplicationLogsAspect, error)
 	}
 )
 

--- a/pkg/adapter/builder.go
+++ b/pkg/adapter/builder.go
@@ -19,11 +19,11 @@ package adapter
 type DefaultBuilder struct {
 	name string
 	desc string
-	conf AspectConfig
+	conf Config
 }
 
 // NewDefaultBuilder creates a new builder struct with the supplied params.
-func NewDefaultBuilder(name, desc string, config AspectConfig) DefaultBuilder {
+func NewDefaultBuilder(name, desc string, config Config) DefaultBuilder {
 	return DefaultBuilder{name, desc, config}
 }
 
@@ -34,10 +34,10 @@ func (b DefaultBuilder) Name() string { return b.name }
 func (b DefaultBuilder) Description() string { return b.desc }
 
 // DefaultConfig returns a default configuration struct for the adapters built by this builder.
-func (b DefaultBuilder) DefaultConfig() AspectConfig { return b.conf }
+func (b DefaultBuilder) DefaultConfig() Config { return b.conf }
 
 // ValidateConfig determines whether the given configuration meets all correctness requirements.
-func (DefaultBuilder) ValidateConfig(c AspectConfig) (ce *ConfigErrors) { return nil }
+func (DefaultBuilder) ValidateConfig(c Config) (ce *ConfigErrors) { return nil }
 
 // Close provides a hook for behavior used to cleanup a builder when it is removed.
 func (DefaultBuilder) Close() error { return nil }

--- a/pkg/adapter/lists.go
+++ b/pkg/adapter/lists.go
@@ -28,6 +28,6 @@ type (
 		Builder
 
 		// NewListsAspect returns a new instance of the ListChecker aspect.
-		NewListsAspect(env Env, c AspectConfig) (ListsAspect, error)
+		NewListsAspect(env Env, c Config) (ListsAspect, error)
 	}
 )

--- a/pkg/adapter/metrics.go
+++ b/pkg/adapter/metrics.go
@@ -66,7 +66,7 @@ type (
 		Builder
 
 		// NewMetricsAspect returns a new instance of the Metrics aspect.
-		NewMetricsAspect(env Env, config AspectConfig, metrics map[string]*MetricDefinition) (MetricsAspect, error)
+		NewMetricsAspect(env Env, config Config, metrics map[string]*MetricDefinition) (MetricsAspect, error)
 	}
 
 	// MetricDefinition provides the basic description of a metric schema

--- a/pkg/adapter/quotas.go
+++ b/pkg/adapter/quotas.go
@@ -36,7 +36,7 @@ type (
 		Builder
 
 		// NewQuotasAspect returns a new instance of the Quota aspect.
-		NewQuotasAspect(env Env, c AspectConfig, quotas map[string]*QuotaDefinition) (QuotasAspect, error)
+		NewQuotasAspect(env Env, c Config, quotas map[string]*QuotaDefinition) (QuotasAspect, error)
 	}
 
 	// QuotaDefinition is used to describe an individual quota that the aspect will encounter at runtime.

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -316,7 +316,7 @@ func (m *Manager) AspectValidatorFinder() config.AspectValidatorFinder {
 	}
 }
 
-// AdapterToAspectMapper returns AdapterToAspectMapper.
+// AdapterToAspectMapperFunc returns AdapterToAspectMapper.
 func (m *Manager) AdapterToAspectMapperFunc() config.AdapterToAspectMapper {
 	return func(impl string) (kinds []string) {
 		return m.builders.SupportedKinds(impl)

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	configpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
 	"istio.io/mixer/pkg/status"
@@ -68,7 +69,7 @@ type cacheKey struct {
 	aspectParamsSHA  [sha1.Size]byte
 }
 
-func newCacheKey(kind aspect.Kind, cfg *config.Combined) (*cacheKey, error) {
+func newCacheKey(kind aspect.Kind, cfg *configpb.Combined) (*cacheKey, error) {
 	ret := cacheKey{
 		kind: kind,
 		impl: cfg.Builder.GetImpl(),
@@ -120,7 +121,7 @@ func newManager(r builderFinder, m map[aspect.Kind]aspect.Manager, exp expr.Eval
 }
 
 // Execute iterates over cfgs and performs the actions described by the combined config using the attribute bag on each config.
-func (m *Manager) Execute(ctx context.Context, cfgs []*config.Combined,
+func (m *Manager) Execute(ctx context.Context, cfgs []*configpb.Combined,
 	requestBag *attribute.MutableBag, responseBag *attribute.MutableBag, ma aspect.APIMethodArgs) aspect.Output {
 	numCfgs := len(cfgs)
 
@@ -216,13 +217,13 @@ func combineResults(results []result) aspect.Output {
 
 // result holds the values returned by the execution of an adapter
 type result struct {
-	cfg         *config.Combined
+	cfg         *configpb.Combined
 	out         aspect.Output
 	responseBag *attribute.MutableBag
 }
 
 // execute performs action described in the combined config using the attribute bag
-func (m *Manager) execute(ctx context.Context, cfg *config.Combined, requestBag attribute.Bag, responseBag *attribute.MutableBag,
+func (m *Manager) execute(ctx context.Context, cfg *configpb.Combined, requestBag attribute.Bag, responseBag *attribute.MutableBag,
 	ma aspect.APIMethodArgs) (out aspect.Output) {
 	var mgr aspect.Manager
 	var found bool
@@ -261,7 +262,7 @@ func (m *Manager) execute(ctx context.Context, cfg *config.Combined, requestBag 
 }
 
 // cacheGet gets an aspect wrapper from the cache, use adapter.Manager to construct an object in case of a cache miss
-func (m *Manager) cacheGet(cfg *config.Combined, mgr aspect.Manager, builder adapter.Builder) (asp aspect.Wrapper, err error) {
+func (m *Manager) cacheGet(cfg *configpb.Combined, mgr aspect.Manager, builder adapter.Builder) (asp aspect.Wrapper, err error) {
 	var key *cacheKey
 	if key, err = newCacheKey(mgr.Kind(), cfg); err != nil {
 		return nil, err
@@ -303,9 +304,9 @@ func closeWrapper(asp aspect.Wrapper) {
 	}
 }
 
-// AspectValidatorFinder returns a ValidatorFinderFunc for aspects.
-func (m *Manager) AspectValidatorFinder() config.ValidatorFinderFunc {
-	return func(kind string) (adapter.ConfigValidator, bool) {
+// AspectValidatorFinder returns a AdapterValidatorFinder for aspects.
+func (m *Manager) AspectValidatorFinder() config.AspectValidatorFinder {
+	return func(kind string) (config.AspectValidator, bool) {
 		k, found := aspect.ParseKind(kind)
 		if !found {
 			return nil, false
@@ -315,15 +316,15 @@ func (m *Manager) AspectValidatorFinder() config.ValidatorFinderFunc {
 	}
 }
 
-// AdapterToAspectMapperFunc returns AdapterToAspectMapperFunc.
-func (m *Manager) AdapterToAspectMapperFunc() config.AdapterToAspectMapperFunc {
+// AdapterToAspectMapper returns AdapterToAspectMapper.
+func (m *Manager) AdapterToAspectMapperFunc() config.AdapterToAspectMapper {
 	return func(impl string) (kinds []string) {
 		return m.builders.SupportedKinds(impl)
 	}
 }
 
-// BuilderValidatorFinder returns a ValidatorFinderFunc for builders.
-func (m *Manager) BuilderValidatorFinder() config.ValidatorFinderFunc {
+// BuilderValidatorFinder returns a AdapterValidatorFinder for builders.
+func (m *Manager) BuilderValidatorFinder() config.AdapterValidatorFinder {
 	return func(name string) (adapter.ConfigValidator, bool) {
 		return m.builders.FindBuilder(name)
 	}

--- a/pkg/adapterManager/registry_test.go
+++ b/pkg/adapterManager/registry_test.go
@@ -28,15 +28,15 @@ type testBuilder struct {
 	name string
 }
 
-func (t testBuilder) Name() string                                              { return t.name }
-func (testBuilder) Close() error                                                { return nil }
-func (testBuilder) Description() string                                         { return "mock builder for testing" }
-func (testBuilder) DefaultConfig() adapter.AspectConfig                         { return nil }
-func (testBuilder) ValidateConfig(c adapter.AspectConfig) *adapter.ConfigErrors { return nil }
+func (t testBuilder) Name() string                                        { return t.name }
+func (testBuilder) Close() error                                          { return nil }
+func (testBuilder) Description() string                                   { return "mock builder for testing" }
+func (testBuilder) DefaultConfig() adapter.Config                         { return nil }
+func (testBuilder) ValidateConfig(c adapter.Config) *adapter.ConfigErrors { return nil }
 
 type denyBuilder struct{ testBuilder }
 
-func (denyBuilder) NewDenialsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.DenialsAspect, error) {
+func (denyBuilder) NewDenialsAspect(env adapter.Env, cfg adapter.Config) (adapter.DenialsAspect, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -59,7 +59,7 @@ func TestRegisterDenyChecker(t *testing.T) {
 type listBuilder struct{ testBuilder }
 type listBuilder2 struct{ listBuilder }
 
-func (listBuilder) NewListsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.ListsAspect, error) {
+func (listBuilder) NewListsAspect(env adapter.Env, cfg adapter.Config) (adapter.ListsAspect, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -81,7 +81,7 @@ func TestRegisterListChecker(t *testing.T) {
 
 type loggerBuilder struct{ testBuilder }
 
-func (loggerBuilder) NewApplicationLogsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.ApplicationLogsAspect, error) {
+func (loggerBuilder) NewApplicationLogsAspect(env adapter.Env, cfg adapter.Config) (adapter.ApplicationLogsAspect, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -103,7 +103,7 @@ func TestRegisterLogger(t *testing.T) {
 
 type accessLoggerBuilder struct{ testBuilder }
 
-func (accessLoggerBuilder) NewAccessLogsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.AccessLogsAspect, error) {
+func (accessLoggerBuilder) NewAccessLogsAspect(env adapter.Env, cfg adapter.Config) (adapter.AccessLogsAspect, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -125,12 +125,12 @@ func TestRegistry_RegisterAccessLogger(t *testing.T) {
 
 type quotaBuilder struct{ testBuilder }
 
-func (quotaBuilder) NewQuotasAspect(env adapter.Env, cfg adapter.AspectConfig, d map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+func (quotaBuilder) NewQuotasAspect(env adapter.Env, cfg adapter.Config, d map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
 	return nil, errors.New("not implemented")
 }
 
 // enables multiple aspects for testing.
-func (quotaBuilder) NewAccessLogsAspect(env adapter.Env, cfg adapter.AspectConfig) (adapter.AccessLogsAspect, error) {
+func (quotaBuilder) NewAccessLogsAspect(env adapter.Env, cfg adapter.Config) (adapter.AccessLogsAspect, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -151,7 +151,7 @@ func TestRegisterQuota(t *testing.T) {
 
 type metricsBuilder struct{ testBuilder }
 
-func (metricsBuilder) NewMetricsAspect(adapter.Env, adapter.AspectConfig, map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+func (metricsBuilder) NewMetricsAspect(adapter.Env, adapter.Config, map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/status"
 )
 
@@ -56,7 +57,7 @@ type Handler interface {
 // Executor executes any aspect as described by config.Combined.
 type Executor interface {
 	// Execute takes a set of configurations and Executes all of them.
-	Execute(ctx context.Context, cfgs []*config.Combined, requestBag *attribute.MutableBag, responseBag *attribute.MutableBag,
+	Execute(ctx context.Context, cfgs []*cpb.Combined, requestBag *attribute.MutableBag, responseBag *attribute.MutableBag,
 		ma aspect.APIMethodArgs) aspect.Output
 }
 

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -28,15 +28,16 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/status"
 )
 
 type fakeresolver struct {
-	ret []*config.Combined
+	ret []*cpb.Combined
 	err error
 }
 
-func (f *fakeresolver) Resolve(bag attribute.Bag, aspectSet config.AspectSet) ([]*config.Combined, error) {
+func (f *fakeresolver) Resolve(bag attribute.Bag, aspectSet config.AspectSet) ([]*cpb.Combined, error) {
 	return f.ret, f.err
 }
 
@@ -45,7 +46,7 @@ type fakeExecutor struct {
 }
 
 // Execute takes a set of configurations and Executes all of them.
-func (f *fakeExecutor) Execute(ctx context.Context, cfgs []*config.Combined, requestBag *attribute.MutableBag, responseBag *attribute.MutableBag,
+func (f *fakeExecutor) Execute(ctx context.Context, cfgs []*cpb.Combined, requestBag *attribute.MutableBag, responseBag *attribute.MutableBag,
 	ma aspect.APIMethodArgs) aspect.Output {
 	return f.body()
 }
@@ -55,7 +56,7 @@ func TestAspectManagerErrorsPropagated(t *testing.T) {
 		return aspect.Output{Status: status.WithError(errors.New("expected"))}
 	}}
 	h := NewHandler(f, map[aspect.APIMethod]config.AspectSet{}).(*handlerState)
-	h.ConfigChange(&fakeresolver{[]*config.Combined{nil, nil}, nil})
+	h.ConfigChange(&fakeresolver{[]*cpb.Combined{nil, nil}, nil})
 
 	o := h.execute(context.Background(), attribute.GetMutableBag(nil), attribute.GetMutableBag(nil), aspect.CheckMethod, nil)
 	if o.Status.Code != int32(rpc.INTERNAL) {
@@ -82,8 +83,8 @@ func TestHandler(t *testing.T) {
 		code        rpc.Code
 	}{
 		{nil, "", "", "", rpc.INTERNAL},
-		{&fakeresolver{[]*config.Combined{nil, nil}, nil}, "RESOLVER", "", "RESOLVER", rpc.INTERNAL},
-		{&fakeresolver{[]*config.Combined{nil, nil}, nil}, "", "BADASPECT", "BADASPECT", rpc.INTERNAL},
+		{&fakeresolver{[]*cpb.Combined{nil, nil}, nil}, "RESOLVER", "", "RESOLVER", rpc.INTERNAL},
+		{&fakeresolver{[]*cpb.Combined{nil, nil}, nil}, "", "BADASPECT", "BADASPECT", rpc.INTERNAL},
 	}
 
 	for _, c := range cases {
@@ -125,7 +126,7 @@ func TestHandler(t *testing.T) {
 	f := &fakeExecutor{func() aspect.Output {
 		return aspect.Output{Status: status.OK, Response: &aspect.QuotaMethodResp{Amount: 42}}
 	}}
-	r := &fakeresolver{[]*config.Combined{nil, nil}, nil}
+	r := &fakeresolver{[]*cpb.Combined{nil, nil}, nil}
 	h := NewHandler(f, map[aspect.APIMethod]config.AspectSet{}).(*handlerState)
 	h.ConfigChange(r)
 

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -22,6 +22,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
 	"istio.io/mixer/pkg/status"
@@ -53,7 +54,7 @@ func newAccessLogsManager() Manager {
 	return accessLogsManager{}
 }
 
-func (m accessLogsManager) NewAspect(c *config.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (m accessLogsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
 	cfg := c.Aspect.Params.(*aconfig.AccessLogsParams)
 
 	var templateStr string
@@ -73,7 +74,7 @@ func (m accessLogsManager) NewAspect(c *config.Combined, a adapter.Builder, env 
 		return nil, fmt.Errorf("log %s failed to parse template '%s' with err: %s", cfg.LogName, templateStr, err)
 	}
 
-	asp, err := a.(adapter.AccessLogsBuilder).NewAccessLogsAspect(env, c.Builder.Params.(adapter.AspectConfig))
+	asp, err := a.(adapter.AccessLogsBuilder).NewAccessLogsAspect(env, c.Builder.Params.(adapter.Config))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create aspect for log %s with err: %s", cfg.LogName, err)
 	}
@@ -88,7 +89,7 @@ func (m accessLogsManager) NewAspect(c *config.Combined, a adapter.Builder, env 
 }
 
 func (accessLogsManager) Kind() Kind { return AccessLogsKind }
-func (accessLogsManager) DefaultConfig() adapter.AspectConfig {
+func (accessLogsManager) DefaultConfig() config.AspectParams {
 	return &aconfig.AccessLogsParams{
 		LogName: "access_log",
 		Log: &aconfig.AccessLogsParams_AccessLog{
@@ -97,7 +98,7 @@ func (accessLogsManager) DefaultConfig() adapter.AspectConfig {
 	}
 }
 
-func (accessLogsManager) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) {
+func (accessLogsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) {
 	cfg := c.(*aconfig.AccessLogsParams)
 	if cfg.Log == nil {
 		ce = ce.Appendf("Log", "an AccessLog entry must be provided")

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -89,7 +89,7 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 
 	for idx, v := range newAspectShouldSucceed {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			c := &config.Combined{
+			c := &configpb.Combined{
 				Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &configpb.Aspect{Params: v.params, Inputs: map[string]string{"template": "{{.test}}"}},
 			}
@@ -107,7 +107,7 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 }
 
 func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
-	defaultCfg := &config.Combined{
+	defaultCfg := &configpb.Combined{
 		Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 		Aspect: &configpb.Aspect{Params: &aconfig.AccessLogsParams{
 			Log: &aconfig.AccessLogsParams_AccessLog{
@@ -132,7 +132,7 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 
 	failureCases := []struct {
 		name  string
-		cfg   *config.Combined
+		cfg   *configpb.Combined
 		adptr adapter.Builder
 	}{
 		{"errorLogger", defaultCfg, errLogger},
@@ -150,7 +150,7 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 }
 
 func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
-	configs := []adapter.AspectConfig{
+	configs := []config.AspectParams{
 		&aconfig.AccessLogsParams{
 			LogName: "test",
 			Log: &aconfig.AccessLogsParams_AccessLog{
@@ -172,7 +172,7 @@ func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
 }
 
 func TestAccessLoggerManager_ValidateConfigFailures(t *testing.T) {
-	configs := []adapter.AspectConfig{
+	configs := []config.AspectParams{
 		&aconfig.AccessLogsParams{},
 		&aconfig.AccessLogsParams{Log: &aconfig.AccessLogsParams_AccessLog{LogFormat: aconfig.ACCESS_LOG_FORMAT_UNSPECIFIED}},
 	}

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -28,6 +28,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
 	"istio.io/mixer/pkg/status"
@@ -68,7 +69,7 @@ func newApplicationLogsManager() Manager {
 	return applicationLogsManager{}
 }
 
-func (applicationLogsManager) NewAspect(c *config.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (applicationLogsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
 	// TODO: look up actual descriptors by name and build an array
 	cfg := c.Aspect.Params.(*aconfig.ApplicationLogsParams)
 
@@ -105,7 +106,7 @@ func (applicationLogsManager) NewAspect(c *config.Combined, a adapter.Builder, e
 		}
 	}
 
-	asp, err := a.(adapter.ApplicationLogsBuilder).NewApplicationLogsAspect(env, c.Builder.Params.(adapter.AspectConfig))
+	asp, err := a.(adapter.ApplicationLogsBuilder).NewApplicationLogsAspect(env, c.Builder.Params.(adapter.Config))
 	if err != nil {
 		return nil, err
 	}
@@ -118,12 +119,12 @@ func (applicationLogsManager) NewAspect(c *config.Combined, a adapter.Builder, e
 }
 
 func (applicationLogsManager) Kind() Kind { return ApplicationLogsKind }
-func (applicationLogsManager) DefaultConfig() adapter.AspectConfig {
+func (applicationLogsManager) DefaultConfig() config.AspectParams {
 	return &aconfig.ApplicationLogsParams{LogName: "istio_log"}
 }
 
 // TODO: validation of timestamp format
-func (applicationLogsManager) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) {
+func (applicationLogsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) {
 	return nil
 }
 

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -38,7 +38,7 @@ import (
 type (
 	aspectTestCase struct {
 		name   string
-		params adapter.AspectConfig
+		params config.AspectParams
 		want   *applicationLogsWrapper
 	}
 )
@@ -118,7 +118,7 @@ func TestLoggerManager_NewLogger(t *testing.T) {
 
 	for idx, v := range newAspectShouldSucceed {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			c := config.Combined{
+			c := configpb.Combined{
 				Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &configpb.Aspect{Params: v.params, Inputs: map[string]string{}},
 			}
@@ -163,7 +163,7 @@ func TestLoggerManager_NewLoggerFailures(t *testing.T) {
 	m := newApplicationLogsManager()
 	for idx, v := range failureCases {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			cfg := &config.Combined{
+			cfg := &configpb.Combined{
 				Builder: &configpb.Adapter{
 					Params: &ptypes.Empty{},
 				},

--- a/pkg/aspect/denialsManager.go
+++ b/pkg/aspect/denialsManager.go
@@ -19,6 +19,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
 
@@ -36,12 +37,12 @@ func newDenialsManager() Manager {
 }
 
 // NewAspect creates a denyChecker aspect.
-func (denialsManager) NewAspect(cfg *config.Combined, ga adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (denialsManager) NewAspect(cfg *cpb.Combined, ga adapter.Builder, env adapter.Env) (Wrapper, error) {
 	aa := ga.(adapter.DenialsBuilder)
 	var asp adapter.DenialsAspect
 	var err error
 
-	if asp, err = aa.NewDenialsAspect(env, cfg.Builder.Params.(adapter.AspectConfig)); err != nil {
+	if asp, err = aa.NewDenialsAspect(env, cfg.Builder.Params.(config.AspectParams)); err != nil {
 		return nil, err
 	}
 
@@ -50,9 +51,9 @@ func (denialsManager) NewAspect(cfg *config.Combined, ga adapter.Builder, env ad
 	}, nil
 }
 
-func (denialsManager) Kind() Kind                                                       { return DenialsKind }
-func (denialsManager) DefaultConfig() adapter.AspectConfig                              { return &aconfig.DenialsParams{} }
-func (denialsManager) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) { return }
+func (denialsManager) Kind() Kind                                                      { return DenialsKind }
+func (denialsManager) DefaultConfig() config.AspectParams                              { return &aconfig.DenialsParams{} }
+func (denialsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) { return }
 
 func (a *denialsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) Output {
 	return Output{Status: a.aspect.Deny()}

--- a/pkg/aspect/listsManager.go
+++ b/pkg/aspect/listsManager.go
@@ -21,6 +21,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
 )
@@ -41,12 +42,12 @@ func newListsManager() Manager {
 }
 
 // NewAspect creates a listChecker aspect.
-func (listsManager) NewAspect(cfg *config.Combined, ga adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (listsManager) NewAspect(cfg *cpb.Combined, ga adapter.Builder, env adapter.Env) (Wrapper, error) {
 	aa := ga.(adapter.ListsBuilder)
 	var asp adapter.ListsAspect
 	var err error
 
-	if asp, err = aa.NewListsAspect(env, cfg.Builder.Params.(adapter.AspectConfig)); err != nil {
+	if asp, err = aa.NewListsAspect(env, cfg.Builder.Params.(config.AspectParams)); err != nil {
 		return nil, err
 	}
 	return &listsWrapper{
@@ -60,13 +61,13 @@ func (listsManager) Kind() Kind {
 	return ListsKind
 }
 
-func (listsManager) DefaultConfig() adapter.AspectConfig {
+func (listsManager) DefaultConfig() config.AspectParams {
 	return &aconfig.ListsParams{
 		CheckAttribute: "src.ip",
 	}
 }
 
-func (listsManager) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) {
+func (listsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) {
 	lc := c.(*aconfig.ListsParams)
 	if lc.CheckAttribute == "" {
 		ce = ce.Appendf("CheckAttribute", "Missing")

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
 )
@@ -46,10 +47,10 @@ type (
 	// Manager is responsible for a specific aspect and presents a uniform interface
 	// to the rest of the system.
 	Manager interface {
-		adapter.ConfigValidator
+		config.AspectValidator
 
 		// NewAspect creates a new aspect instance given configuration.
-		NewAspect(cfg *config.Combined, adapter adapter.Builder, env adapter.Env) (Wrapper, error)
+		NewAspect(cfg *cpb.Combined, adapter adapter.Builder, env adapter.Env) (Wrapper, error)
 
 		// Kind return the kind of aspect
 		Kind() Kind

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -26,6 +26,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
 )
@@ -53,7 +54,7 @@ func newMetricsManager() Manager {
 }
 
 // NewAspect creates a metric aspect.
-func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (m *metricsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
 	params := c.Aspect.Params.(*aconfig.MetricsParams)
 
 	// TODO: get descriptors from config
@@ -112,17 +113,17 @@ func (m *metricsManager) NewAspect(c *config.Combined, a adapter.Builder, env ad
 		}
 	}
 	b := a.(adapter.MetricsBuilder)
-	asp, err := b.NewMetricsAspect(env, c.Builder.Params.(adapter.AspectConfig), defs)
+	asp, err := b.NewMetricsAspect(env, c.Builder.Params.(adapter.Config), defs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct metrics aspect with config '%v' and err: %s", c, err)
 	}
 	return &metricsWrapper{b.Name(), asp, metadata}, nil
 }
 
-func (*metricsManager) Kind() Kind                          { return MetricsKind }
-func (*metricsManager) DefaultConfig() adapter.AspectConfig { return &aconfig.MetricsParams{} }
+func (*metricsManager) Kind() Kind                         { return MetricsKind }
+func (*metricsManager) DefaultConfig() config.AspectParams { return &aconfig.MetricsParams{} }
 
-func (*metricsManager) ValidateConfig(adapter.AspectConfig) (ce *adapter.ConfigErrors) {
+func (*metricsManager) ValidateConfig(config.AspectParams) (ce *adapter.ConfigErrors) {
 	// TODO: we need to be provided the metric descriptors in addition to the metrics themselves here, so we can do type assertions.
 	// We also need some way to assert the type of the result of evaluating an expression, but we don't have any attributes or an
 	// evaluator on hand.

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -29,8 +29,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/aspect/test"
 	"istio.io/mixer/pkg/attribute"
-	"istio.io/mixer/pkg/config"
-	pb "istio.io/mixer/pkg/config/proto"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
 
@@ -60,7 +59,7 @@ func (b *fakeBuilder) Name() string {
 	return b.name
 }
 
-func (b *fakeBuilder) NewMetricsAspect(env adapter.Env, config adapter.AspectConfig,
+func (b *fakeBuilder) NewMetricsAspect(env adapter.Env, config adapter.Config,
 	metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	return b.body()
 }
@@ -76,8 +75,8 @@ func TestNewMetricsManager(t *testing.T) {
 }
 
 func TestMetricsManager_NewAspect(t *testing.T) {
-	conf := &config.Combined{
-		Aspect: &pb.Aspect{
+	conf := &cpb.Combined{
+		Aspect: &cpb.Aspect{
 			Params: &aconfig.MetricsParams{
 				Metrics: []*aconfig.MetricsParams_Metric{
 					{
@@ -89,7 +88,7 @@ func TestMetricsManager_NewAspect(t *testing.T) {
 			},
 		},
 		// the params we use here don't matter because we're faking the aspect
-		Builder: &pb.Adapter{Params: &aconfig.MetricsParams{}},
+		Builder: &cpb.Adapter{Params: &aconfig.MetricsParams{}},
 	}
 	builder := &fakeBuilder{name: "test", body: func() (adapter.MetricsAspect, error) {
 		return &fakeaspect{body: func([]adapter.Value) error { return nil }}, nil
@@ -100,10 +99,10 @@ func TestMetricsManager_NewAspect(t *testing.T) {
 }
 
 func TestMetricsManager_NewAspect_PropagatesError(t *testing.T) {
-	conf := &config.Combined{
-		Aspect: &pb.Aspect{Params: &aconfig.MetricsParams{}},
+	conf := &cpb.Combined{
+		Aspect: &cpb.Aspect{Params: &aconfig.MetricsParams{}},
 		// the params we use here don't matter because we're faking the aspect
-		Builder: &pb.Adapter{Params: &aconfig.MetricsParams{}},
+		Builder: &cpb.Adapter{Params: &aconfig.MetricsParams{}},
 	}
 	errString := "expected"
 	builder := &fakeBuilder{

--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -27,6 +27,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
 )
@@ -55,7 +56,7 @@ func newQuotasManager() Manager {
 }
 
 // NewAspect creates a quota aspect.
-func (m *quotasManager) NewAspect(c *config.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (m *quotasManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
 	params := c.Aspect.Params.(*aconfig.QuotasParams)
 
 	// TODO: get this from config
@@ -100,7 +101,7 @@ func (m *quotasManager) NewAspect(c *config.Combined, a adapter.Builder, env ada
 		}
 	}
 
-	asp, err := a.(adapter.QuotasBuilder).NewQuotasAspect(env, c.Builder.Params.(adapter.AspectConfig), defs)
+	asp, err := a.(adapter.QuotasBuilder).NewQuotasAspect(env, c.Builder.Params.(adapter.Config), defs)
 	if err != nil {
 		return nil, err
 	}
@@ -113,9 +114,9 @@ func (m *quotasManager) NewAspect(c *config.Combined, a adapter.Builder, env ada
 	}, nil
 }
 
-func (*quotasManager) Kind() Kind                                                     { return QuotasKind }
-func (*quotasManager) DefaultConfig() adapter.AspectConfig                            { return &aconfig.QuotasParams{} }
-func (*quotasManager) ValidateConfig(adapter.AspectConfig) (ce *adapter.ConfigErrors) { return }
+func (*quotasManager) Kind() Kind                                                    { return QuotasKind }
+func (*quotasManager) DefaultConfig() config.AspectParams                            { return &aconfig.QuotasParams{} }
+func (*quotasManager) ValidateConfig(config.AspectParams) (ce *adapter.ConfigErrors) { return }
 
 func (w *quotasWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) Output {
 	qma, ok := ma.(*QuotaMethodArgs)

--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -20,8 +20,8 @@ import (
 	"sync/atomic"
 
 	ptypes "github.com/gogo/protobuf/types"
-
 	"github.com/golang/glog"
+
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
 	aconfig "istio.io/mixer/pkg/aspect/config"

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -31,8 +31,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/aspect/test"
 	"istio.io/mixer/pkg/attribute"
-	"istio.io/mixer/pkg/config"
-	pb "istio.io/mixer/pkg/config/proto"
+	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
 
@@ -70,7 +69,7 @@ func (b *fakeQuotaBuilder) Name() string {
 	return b.name
 }
 
-func (b *fakeQuotaBuilder) NewQuotasAspect(env adapter.Env, config adapter.AspectConfig,
+func (b *fakeQuotaBuilder) NewQuotasAspect(env adapter.Env, config adapter.Config,
 	quotas map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
 	return b.body()
 }
@@ -85,9 +84,9 @@ func TestNewQuotasManager(t *testing.T) {
 	}
 }
 
-func newQuotaConfig(desc string, labels map[string]string) *config.Combined {
-	return &config.Combined{
-		Aspect: &pb.Aspect{
+func newQuotaConfig(desc string, labels map[string]string) *cpb.Combined {
+	return &cpb.Combined{
+		Aspect: &cpb.Aspect{
 			Params: &aconfig.QuotasParams{
 				Quotas: []*aconfig.QuotasParams_Quota{
 					{
@@ -99,7 +98,7 @@ func newQuotaConfig(desc string, labels map[string]string) *config.Combined {
 		},
 
 		// the params we use here don't matter because we're faking the aspect
-		Builder: &pb.Adapter{Params: &aconfig.QuotasParams{}},
+		Builder: &cpb.Adapter{Params: &aconfig.QuotasParams{}},
 	}
 }
 
@@ -120,10 +119,10 @@ func TestQuotasManager_NewAspect(t *testing.T) {
 }
 
 func TestQuotasManager_NewAspect_PropagatesError(t *testing.T) {
-	conf := &config.Combined{
-		Aspect: &pb.Aspect{Params: &aconfig.QuotasParams{}},
+	conf := &cpb.Combined{
+		Aspect: &cpb.Aspect{Params: &aconfig.QuotasParams{}},
 		// the params we use here don't matter because we're faking the aspect
-		Builder: &pb.Adapter{Params: &aconfig.QuotasParams{}},
+		Builder: &cpb.Adapter{Params: &aconfig.QuotasParams{}},
 	}
 	errString := "expected"
 	builder := &fakeQuotaBuilder{

--- a/pkg/aspect/test/BUILD
+++ b/pkg/aspect/test/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/adapter:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/config:go_default_library",
         "//pkg/expr:go_default_library",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
     ],

--- a/pkg/aspect/test/logger.go
+++ b/pkg/aspect/test/logger.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/config"
 )
 
 // Logger is a test struct that implements the application-logs and access-logs aspects.
@@ -26,7 +27,7 @@ type Logger struct {
 	adapter.AccessLogsBuilder
 	adapter.ApplicationLogsBuilder
 
-	DefaultCfg     adapter.AspectConfig
+	DefaultCfg     config.AspectParams
 	EntryCount     int
 	Logs           []adapter.LogEntry
 	AccessLogs     []adapter.LogEntry
@@ -36,7 +37,7 @@ type Logger struct {
 }
 
 // NewApplicationLogsAspect returns a new instance of the Logger aspect.
-func (t *Logger) NewApplicationLogsAspect(e adapter.Env, m adapter.AspectConfig) (adapter.ApplicationLogsAspect, error) {
+func (t *Logger) NewApplicationLogsAspect(e adapter.Env, m adapter.Config) (adapter.ApplicationLogsAspect, error) {
 	if t.ErrOnNewAspect {
 		return nil, errors.New("new aspect error")
 	}
@@ -44,7 +45,7 @@ func (t *Logger) NewApplicationLogsAspect(e adapter.Env, m adapter.AspectConfig)
 }
 
 // NewAccessLogsAspect returns a new instance of the accessLogger aspect.
-func (t *Logger) NewAccessLogsAspect(e adapter.Env, m adapter.AspectConfig) (adapter.AccessLogsAspect, error) {
+func (t *Logger) NewAccessLogsAspect(e adapter.Env, m adapter.Config) (adapter.AccessLogsAspect, error) {
 	if t.ErrOnNewAspect {
 		return nil, errors.New("new aspect error")
 	}
@@ -58,10 +59,10 @@ func (t *Logger) Name() string { return "testLogger" }
 func (t *Logger) Description() string { return "A test logger" }
 
 // DefaultConfig returns a default configuration struct for this adapter.
-func (t *Logger) DefaultConfig() adapter.AspectConfig { return t.DefaultCfg }
+func (t *Logger) DefaultConfig() adapter.Config { return t.DefaultCfg }
 
 // ValidateConfig determines whether the given configuration meets all correctness requirements.
-func (t *Logger) ValidateConfig(c adapter.AspectConfig) (ce *adapter.ConfigErrors) { return nil }
+func (t *Logger) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) { return nil }
 
 // Log simulates processing a batch of log entries.
 func (t *Logger) Log(l []adapter.LogEntry) error {

--- a/pkg/config/BUILD
+++ b/pkg/config/BUILD
@@ -18,6 +18,7 @@ go_library(
         "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_gogo_protobuf//jsonpb:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],
 )

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -25,13 +25,14 @@ import (
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config/descriptors"
+	pb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
 
 // Resolver resolves configuration to a list of combined configs.
 type Resolver interface {
 	// Resolve resolves configuration to a list of combined configs.
-	Resolve(bag attribute.Bag, aspectSet AspectSet) ([]*Combined, error)
+	Resolve(bag attribute.Bag, aspectSet AspectSet) ([]*pb.Combined, error)
 }
 
 // ChangeListener listens for config change notifications.
@@ -45,10 +46,10 @@ type ChangeListener interface {
 // api.Handler listens for config changes.
 type Manager struct {
 	eval             expr.Evaluator
-	aspectFinder     ValidatorFinderFunc
-	builderFinder    ValidatorFinderFunc
+	aspectFinder     AspectValidatorFinder
+	builderFinder    AdapterValidatorFinder
 	descriptorFinder descriptors.Finder
-	findAspects      AdapterToAspectMapperFunc
+	findAspects      AdapterToAspectMapper
 	loopDelay        time.Duration
 	globalConfig     string
 	serviceConfig    string
@@ -73,8 +74,8 @@ type Manager struct {
 // as command line input parameters.
 // GlobalConfig specifies the location of Global Config.
 // ServiceConfig specifies the location of Service config.
-func NewManager(eval expr.Evaluator, aspectFinder ValidatorFinderFunc, builderFinder ValidatorFinderFunc,
-	findAspects AdapterToAspectMapperFunc, globalConfig string, serviceConfig string, loopDelay time.Duration) *Manager {
+func NewManager(eval expr.Evaluator, aspectFinder AspectValidatorFinder, builderFinder AdapterValidatorFinder,
+	findAspects AdapterToAspectMapper, globalConfig string, serviceConfig string, loopDelay time.Duration) *Manager {
 	m := &Manager{
 		eval:          eval,
 		aspectFinder:  aspectFinder,

--- a/pkg/config/proto/BUILD
+++ b/pkg/config/proto/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cfg.pb.go",
+        "combined.go",
     ],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/pkg/config/proto/combined.go
+++ b/pkg/config/proto/combined.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Istio Authors
+// Copyright 2017 the Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package adapter
+package istio_mixer_v1_config
 
-import rpc "github.com/googleapis/googleapis/google/rpc"
+// Combined config is given to aspect managers.
+type Combined struct {
+	Builder *Adapter
+	Aspect  *Aspect
+}
 
-type (
-	// DenialsAspect always fail with an error.
-	DenialsAspect interface {
-		Aspect
-
-		// Deny always returns an error
-		Deny() rpc.Status
+func (c *Combined) String() (ret string) {
+	if c.Builder != nil {
+		ret += "builder: " + c.Builder.String() + " "
 	}
-
-	// DenialsBuilder builds instances of the DenyChecker aspect.
-	DenialsBuilder interface {
-		Builder
-
-		// NewDenialsAspect returns a new instance of the DenyChecker aspect.
-		NewDenialsAspect(env Env, c Config) (DenialsAspect, error)
+	if c.Aspect != nil {
+		ret += "aspect: " + c.Aspect.String()
 	}
-)
+	return
+}

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -39,8 +39,10 @@ import (
 )
 
 type (
+	// AspectParams describes configuration parameters for an aspect.
 	AspectParams proto.Message
 
+	// AspectValidator describes a type that is able to validate Aspect configuration.
 	AspectValidator interface {
 		// DefaultConfig returns a default configuration struct for this
 		// adapter. This will be used by the configuration system to establish
@@ -56,7 +58,7 @@ type (
 	// so ConfigValidators can be uniformly accessed.
 	AdapterValidatorFinder func(name string) (adapter.ConfigValidator, bool)
 
-	// AdapterValidatorFinder is used to find specific underlying validators.
+	// AspectValidatorFinder is used to find specific underlying validators.
 	// Manager registry and adapter registry should implement this interface
 	// so ConfigValidators can be uniformly accessed.
 	AspectValidatorFinder func(name string) (AspectValidator, bool)
@@ -226,7 +228,7 @@ func UnknownValidator(name string) error {
 	return fmt.Errorf("unknown type [%s]", name)
 }
 
-// ConvertParams converts returns a typed proto message based on available Validator.
+// ConvertAdapterParams converts returns a typed proto message based on available Validator.
 func ConvertAdapterParams(find AdapterValidatorFinder, name string, params interface{}, strict bool) (adapter.Config, error) {
 	var avl adapter.ConfigValidator
 	var found bool
@@ -245,7 +247,7 @@ func ConvertAdapterParams(find AdapterValidatorFinder, name string, params inter
 	return acfg, nil
 }
 
-// ConvertParams converts returns a typed proto message based on available Validator.
+// ConvertAspectParams converts returns a typed proto message based on available Validator.
 func ConvertAspectParams(find AspectValidatorFinder, name string, params interface{}, strict bool) (AspectParams, error) {
 	var avl AspectValidator
 	var found bool

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -15,8 +15,8 @@
 package config
 
 import (
-	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -26,12 +26,18 @@ import (
 )
 
 type fakeVFinder struct {
-	v     map[string]adapter.ConfigValidator
+	ada   map[string]adapter.ConfigValidator
+	asp   map[string]AspectValidator
 	kinds []string
 }
 
-func (f *fakeVFinder) FindValidator(name string) (adapter.ConfigValidator, bool) {
-	v, found := f.v[name]
+func (f *fakeVFinder) FindAdapterValidator(name string) (adapter.ConfigValidator, bool) {
+	v, found := f.ada[name]
+	return v, found
+}
+
+func (f *fakeVFinder) FindAspectValidator(name string) (AspectValidator, bool) {
+	v, found := f.asp[name]
 	return v, found
 }
 
@@ -43,30 +49,44 @@ type lc struct {
 	ce *adapter.ConfigErrors
 }
 
-func (m *lc) DefaultConfig() (c adapter.AspectConfig) {
+func (m *lc) DefaultConfig() (c adapter.Config) {
 	return &listcheckerpb.ListsParams{}
 }
 
 // ValidateConfig determines whether the given configuration meets all correctness requirements.
-func (m *lc) ValidateConfig(c adapter.AspectConfig) *adapter.ConfigErrors {
+func (m *lc) ValidateConfig(c adapter.Config) *adapter.ConfigErrors {
 	return m.ce
+}
+
+type ac struct {
+	ce *adapter.ConfigErrors
+}
+
+func (*ac) DefaultConfig() AspectParams {
+	return &listcheckerpb.ListsParams{}
+}
+
+// ValidateConfig determines whether the given configuration meets all correctness requirements.
+func (a *ac) ValidateConfig(AspectParams) *adapter.ConfigErrors {
+	return a.ce
 }
 
 type configTable struct {
 	cerr     *adapter.ConfigErrors
-	v        map[string]adapter.ConfigValidator
+	ada      map[string]adapter.ConfigValidator
+	asp      map[string]AspectValidator
 	nerrors  int
 	selector string
 	strict   bool
 	cfg      string
 }
 
-func newVfinder(v map[string]adapter.ConfigValidator) *fakeVFinder {
+func newVfinder(ada map[string]adapter.ConfigValidator, asp map[string]AspectValidator) *fakeVFinder {
 	kinds := []string{}
-	for k := range v {
+	for k := range ada {
 		kinds = append(kinds, k)
 	}
-	return &fakeVFinder{v: v, kinds: kinds}
+	return &fakeVFinder{ada: ada, asp: asp, kinds: kinds}
 }
 
 func TestConfigValidatorError(t *testing.T) {
@@ -74,57 +94,65 @@ func TestConfigValidatorError(t *testing.T) {
 	evaluator := newFakeExpr()
 	cerr := ct.Appendf("Url", "Must have a valid URL")
 
-	ctable := []*configTable{
-		{nil,
-			map[string]adapter.ConfigValidator{
-				"metrics":  &lc{},
-				"metrics2": &lc{},
-			}, 0, "service.name == “*”", false, sSvcConfig},
+	tests := []*configTable{
 		{nil,
 			map[string]adapter.ConfigValidator{
 				"denyChecker": &lc{},
 				"metrics2":    &lc{},
-			}, 0, "service.name == “*”", false, sGlobalConfig},
+			},
+			nil, 0, "service.name == “*”", false, sGlobalConfig},
 		{nil,
 			map[string]adapter.ConfigValidator{
 				"metrics":  &lc{},
 				"metrics2": &lc{},
-			}, 1, "service.name == “*”", false, sGlobalConfig},
-		{nil,
-			map[string]adapter.ConfigValidator{
-				"metrics":  &lc{},
-				"metrics2": &lc{},
-			}, 1, "service.name == “*”", true, sSvcConfig},
-		{cerr,
-			map[string]adapter.ConfigValidator{
-				"metrics": &lc{ce: cerr},
-			}, 2, "service.name == “*”", false, sSvcConfig},
+			},
+			nil, 1, "service.name == “*”", false, sGlobalConfig},
+		{nil, nil,
+			map[string]AspectValidator{
+				"metrics":  &ac{},
+				"metrics2": &ac{},
+			},
+			0, "service.name == “*”", false, sSvcConfig},
+		{nil, nil,
+			map[string]AspectValidator{
+				"metrics":  &ac{},
+				"metrics2": &ac{},
+			},
+			1, "service.name == “*”", true, sSvcConfig},
+		{cerr, nil,
+			map[string]AspectValidator{
+				"metrics2": &ac{ce: cerr},
+			},
+			2, "service.name == “*”", false, sSvcConfig},
 		{ct.Append("/:metrics", UnknownValidator("metrics")),
-			nil, 2, "\"\"", false, sSvcConfig},
+			nil, nil, 2, "\"\"", false, sSvcConfig},
 	}
 
-	for idx, ctx := range ctable {
-		var ce *adapter.ConfigErrors
-		mgr := newVfinder(ctx.v)
-		p := NewValidator(mgr.FindValidator, mgr.FindValidator, mgr.AdapterToAspectMapperFunc, ctx.strict, evaluator)
-		if ctx.cfg == sSvcConfig {
-			ce = p.validateServiceConfig(fmt.Sprintf(ctx.cfg, ctx.selector), false)
-		} else {
-			ce = p.validateGlobalConfig(ctx.cfg)
-		}
-		cok := ce == nil
-		ok := ctx.nerrors == 0
+	for idx, tt := range tests {
+		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 
-		if ok != cok {
-			t.Errorf("%d Expected %t Got %t", idx, ok, cok)
-		}
-		if ce == nil {
-			continue
-		}
+			var ce *adapter.ConfigErrors
+			mgr := newVfinder(tt.ada, tt.asp)
+			p := NewValidator(mgr.FindAspectValidator, mgr.FindAdapterValidator, mgr.AdapterToAspectMapperFunc, tt.strict, evaluator)
+			if tt.cfg == sSvcConfig {
+				ce = p.validateServiceConfig(fmt.Sprintf(tt.cfg, tt.selector), false)
+			} else {
+				ce = p.validateGlobalConfig(tt.cfg)
+			}
+			cok := ce == nil
+			ok := tt.nerrors == 0
 
-		if len(ce.Multi.Errors) != ctx.nerrors {
-			t.Error(idx, "\nExpected:", ctx.cerr.Error(), "\nGot:", ce.Error(), len(ce.Multi.Errors), ctx.nerrors)
-		}
+			if ok != cok {
+				t.Fatalf("Expected %t Got %t", ok, cok)
+			}
+			if ce == nil {
+				return
+			}
+
+			if len(ce.Multi.Errors) != tt.nerrors {
+				t.Fatalf("Expected: '%v' Got: %v", tt.cerr.Error(), ce.Error())
+			}
+		})
 	}
 }
 
@@ -132,7 +160,8 @@ func TestFullConfigValidator(tt *testing.T) {
 	fe := newFakeExpr()
 	ctable := []struct {
 		cerr     *adapter.ConfigError
-		v        map[string]adapter.ConfigValidator
+		ada      map[string]adapter.ConfigValidator
+		asp      map[string]AspectValidator
 		selector string
 		strict   bool
 		cfg      string
@@ -143,48 +172,71 @@ func TestFullConfigValidator(tt *testing.T) {
 				"denyChecker": &lc{},
 				"metrics":     &lc{},
 				"listchecker": &lc{},
-			}, "service.name == “*”", false, sSvcConfig2, nil},
+			},
+			map[string]AspectValidator{
+				"denyChecker": &ac{},
+				"metrics":     &ac{},
+				"listchecker": &ac{},
+			},
+			"service.name == “*”", false, sSvcConfig2, nil},
 		{nil,
 			map[string]adapter.ConfigValidator{
 				"denyChecker": &lc{},
 				"metrics":     &lc{},
 				"listchecker": &lc{},
-			}, "", false, sSvcConfig2, nil},
-		{&adapter.ConfigError{Field: "NamedAdapter", Underlying: errors.New("listchecker//denychecker.2 not available")},
+			},
+			map[string]AspectValidator{
+				"denyChecker": &ac{},
+				"metrics":     &ac{},
+				"listchecker": &ac{},
+			},
+			"", false, sSvcConfig2, nil},
+		{&adapter.ConfigError{Field: "NamedAdapter", Underlying: fmt.Errorf("listchecker//denychecker.2 not available")},
 			map[string]adapter.ConfigValidator{
 				"denyChecker": &lc{},
 				"metrics":     &lc{},
 				"listchecker": &lc{},
-			}, "", false, sSvcConfig3, nil},
-		{&adapter.ConfigError{Field: ":Selector service.name == “*”", Underlying: errors.New("invalid expression")},
+			},
+			map[string]AspectValidator{
+				"denyChecker": &ac{},
+				"metrics":     &ac{},
+				"listchecker": &ac{},
+			},
+			"", false, sSvcConfig3, nil},
+		{&adapter.ConfigError{Field: ":Selector service.name == “*”", Underlying: fmt.Errorf("invalid expression")},
 			map[string]adapter.ConfigValidator{
 				"denyChecker": &lc{},
 				"metrics":     &lc{},
 				"listchecker": &lc{},
-			}, "service.name == “*”", false, sSvcConfig1, errors.New("invalid expression")},
+			},
+			map[string]AspectValidator{
+				"denyChecker": &ac{},
+				"metrics":     &ac{},
+				"listchecker": &ac{},
+			},
+			"service.name == “*”", false, sSvcConfig1, fmt.Errorf("invalid expression")},
 	}
 	for idx, ctx := range ctable {
-		tt.Run(fmt.Sprintf("%s", ctx.v), func(t *testing.T) {
-			mgr := newVfinder(ctx.v)
+		tt.Run(fmt.Sprintf("[%d]", idx), func(t *testing.T) {
+			mgr := newVfinder(ctx.ada, ctx.asp)
 			fe.err = ctx.exprErr
-			p := NewValidator(mgr.FindValidator, mgr.FindValidator, mgr.AdapterToAspectMapperFunc, ctx.strict, fe)
+			p := NewValidator(mgr.FindAspectValidator, mgr.FindAdapterValidator, mgr.AdapterToAspectMapperFunc, ctx.strict, fe)
 			// sGlobalConfig only defines 1 adapter: denyChecker
 			_, ce := p.Validate(ctx.cfg, sGlobalConfig)
 			cok := ce == nil
 			ok := ctx.cerr == nil
 			if ok != cok {
-				t.Errorf("%d Expected %t Got %t", idx, ok, cok)
+				t.Fatalf("%d Expected %t Got %t", idx, ok, cok)
 
 			}
 			if ce == nil {
 				return
 			}
 			if len(ce.Multi.Errors) < 2 {
-				t.Error("expected at least 2 errors reported")
-				return
+				t.Fatal("expected at least 2 errors reported")
 			}
 			if !strings.Contains(ce.Multi.Errors[1].Error(), ctx.cerr.Error()) {
-				t.Errorf("%d got: %#v\nwant: %#v\n", idx, ce.Multi.Errors[1].Error(), ctx.cerr.Error())
+				t.Fatalf("%d got: %#v\nwant: %#v\n", idx, ce.Multi.Errors[1].Error(), ctx.cerr.Error())
 			}
 		})
 	}
@@ -193,7 +245,7 @@ func TestFullConfigValidator(tt *testing.T) {
 func TestConfigParseError(t *testing.T) {
 	mgr := &fakeVFinder{}
 	evaluator := newFakeExpr()
-	p := NewValidator(mgr.FindValidator, mgr.FindValidator, mgr.AdapterToAspectMapperFunc, false, evaluator)
+	p := NewValidator(mgr.FindAspectValidator, mgr.FindAdapterValidator, mgr.AdapterToAspectMapperFunc, false, evaluator)
 	ce := p.validateServiceConfig("<config>  </config>", false)
 
 	if ce == nil || !strings.Contains(ce.Error(), "error unmarshaling") {
@@ -308,30 +360,11 @@ func UnboundVariable(vname string) error {
 }
 
 // Eval evaluates given expression using the attribute bag
-func (e *fakeExpr) Eval(mapExpression string, attrs attribute.Bag) (v interface{}, err error) {
-	var found bool
-
-	v, found = attrs.Get(mapExpression)
-	if found {
-		return
+func (e *fakeExpr) Eval(mapExpression string, attrs attribute.Bag) (interface{}, error) {
+	if v, found := attrs.Get(mapExpression); found {
+		return v, nil
 	}
-
-	v, found = attrs.Get(mapExpression)
-	if found {
-		return
-	}
-
-	v, found = attrs.Get(mapExpression)
-	if found {
-		return
-	}
-
-	v, found = attrs.Get(mapExpression)
-	if found {
-		return
-	}
-
-	return v, UnboundVariable(mapExpression)
+	return nil, UnboundVariable(mapExpression)
 }
 
 // EvalString evaluates given expression using the attribute bag to a string


### PR DESCRIPTION
Aspect Managers now need different configuration information at validation time than aspects. Previously both described their ability to validate config via the `adapter.ConfigValidator` interface. This PR creates a new interface, `config.AspectValidator`, which aspect managers use to validate config. We also shuffle some names around (`adapter.Config` rather than `adapter.AspectConfig`, etc).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/429)
<!-- Reviewable:end -->
