### PR TITLE
Add descriptors to the `config.AspectValidator` interface, plumb them through config validation

### DIFF
--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
 	// need to pull this in
 	_ "google.golang.org/grpc/grpclog/glogger"
 )

--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -34,6 +34,7 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
+        "//pkg/config/descriptor:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_istio_api//:mixer/v1/config",
         "@com_github_istio_api//:mixer/v1/config/descriptor",

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	configpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
@@ -87,12 +88,14 @@ func (m *fakemgr) Kind() aspect.Kind {
 func newTestManager(name string, throwOnNewAspect bool, body func() aspect.Output) testManager {
 	return testManager{name, throwOnNewAspect, testAspect{body}}
 }
-func (testManager) Close() error                                             { return nil }
-func (testManager) DefaultConfig() config.AspectParams                       { return nil }
-func (testManager) ValidateConfig(config.AspectParams) *adapter.ConfigErrors { return nil }
-func (testManager) Kind() aspect.Kind                                        { return aspect.DenialsKind }
-func (m testManager) Name() string                                           { return m.name }
-func (testManager) Description() string                                      { return "deny checker aspect manager for testing" }
+func (testManager) Close() error                       { return nil }
+func (testManager) DefaultConfig() config.AspectParams { return nil }
+func (testManager) ValidateConfig(config.AspectParams, descriptor.Finder) *adapter.ConfigErrors {
+	return nil
+}
+func (testManager) Kind() aspect.Kind   { return aspect.DenialsKind }
+func (m testManager) Name() string      { return m.name }
+func (testManager) Description() string { return "deny checker aspect manager for testing" }
 
 func (m testManager) NewAspect(cfg *configpb.Combined, adapter adapter.Builder, env adapter.Env) (aspect.Wrapper, error) {
 	if m.throw {

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/aspect/config:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/config:go_default_library",
+        "//pkg/config/descriptor:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",
@@ -44,6 +45,7 @@ go_test(
     srcs = [
         "accessLogsManager_test.go",
         "apiMethod_test.go",
+        "applicationLogsManager_test.go",
         "denialsManager_test.go",
         "descriptors_test.go",
         "inventory_test.go",

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -22,6 +22,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
@@ -98,7 +99,7 @@ func (accessLogsManager) DefaultConfig() config.AspectParams {
 	}
 }
 
-func (accessLogsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) {
+func (accessLogsManager) ValidateConfig(c config.AspectParams, _ descriptor.Finder) (ce *adapter.ConfigErrors) {
 	cfg := c.(*aconfig.AccessLogsParams)
 	if cfg.Log == nil {
 		ce = ce.Appendf("Log", "an AccessLog entry must be provided")

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -164,7 +164,7 @@ func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
 	m := newAccessLogsManager()
 	for idx, v := range configs {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			if err := m.ValidateConfig(v); err != nil {
+			if err := m.ValidateConfig(v, nil); err != nil {
 				t.Fatalf("ValidateConfig(%v) => unexpected error: %v", v, err)
 			}
 		})
@@ -180,7 +180,7 @@ func TestAccessLoggerManager_ValidateConfigFailures(t *testing.T) {
 	m := newAccessLogsManager()
 	for idx, v := range configs {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			if err := m.ValidateConfig(v); err == nil {
+			if err := m.ValidateConfig(v, nil); err == nil {
 				t.Fatalf("ValidateConfig(%v) expected err", v)
 			}
 		})

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -28,6 +28,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
@@ -124,7 +125,7 @@ func (applicationLogsManager) DefaultConfig() config.AspectParams {
 }
 
 // TODO: validation of timestamp format
-func (applicationLogsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) {
+func (applicationLogsManager) ValidateConfig(config.AspectParams, descriptor.Finder) (ce *adapter.ConfigErrors) {
 	return nil
 }
 

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -369,7 +369,7 @@ func TestLoggerManager_DefaultConfig(t *testing.T) {
 
 func TestLoggerManager_ValidateConfig(t *testing.T) {
 	m := newApplicationLogsManager()
-	if err := m.ValidateConfig(&ptypes.Empty{}); err != nil {
+	if err := m.ValidateConfig(&ptypes.Empty{}, nil); err != nil {
 		t.Errorf("ValidateConfig(): unexpected error: %v", err)
 	}
 }

--- a/pkg/aspect/denialsManager.go
+++ b/pkg/aspect/denialsManager.go
@@ -19,6 +19,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
@@ -51,9 +52,11 @@ func (denialsManager) NewAspect(cfg *cpb.Combined, ga adapter.Builder, env adapt
 	}, nil
 }
 
-func (denialsManager) Kind() Kind                                                      { return DenialsKind }
-func (denialsManager) DefaultConfig() config.AspectParams                              { return &aconfig.DenialsParams{} }
-func (denialsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) { return }
+func (denialsManager) Kind() Kind                         { return DenialsKind }
+func (denialsManager) DefaultConfig() config.AspectParams { return &aconfig.DenialsParams{} }
+func (denialsManager) ValidateConfig(config.AspectParams, descriptor.Finder) (ce *adapter.ConfigErrors) {
+	return
+}
 
 func (a *denialsWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) Output {
 	return Output{Status: a.aspect.Deny()}

--- a/pkg/aspect/listsManager.go
+++ b/pkg/aspect/listsManager.go
@@ -21,6 +21,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
@@ -67,7 +68,7 @@ func (listsManager) DefaultConfig() config.AspectParams {
 	}
 }
 
-func (listsManager) ValidateConfig(c config.AspectParams) (ce *adapter.ConfigErrors) {
+func (listsManager) ValidateConfig(c config.AspectParams, _ descriptor.Finder) (ce *adapter.ConfigErrors) {
 	lc := c.(*aconfig.ListsParams)
 	if lc.CheckAttribute == "" {
 		ce = ce.Appendf("CheckAttribute", "Missing")

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -26,6 +26,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
@@ -123,7 +124,7 @@ func (m *metricsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapt
 func (*metricsManager) Kind() Kind                         { return MetricsKind }
 func (*metricsManager) DefaultConfig() config.AspectParams { return &aconfig.MetricsParams{} }
 
-func (*metricsManager) ValidateConfig(config.AspectParams) (ce *adapter.ConfigErrors) {
+func (*metricsManager) ValidateConfig(config.AspectParams, descriptor.Finder) (ce *adapter.ConfigErrors) {
 	// TODO: we need to be provided the metric descriptors in addition to the metrics themselves here, so we can do type assertions.
 	// We also need some way to assert the type of the result of evaluating an expression, but we don't have any attributes or an
 	// evaluator on hand.

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -69,7 +69,7 @@ func TestNewMetricsManager(t *testing.T) {
 	if m.Kind() != MetricsKind {
 		t.Errorf("m.Kind() = %s wanted %s", m.Kind(), MetricsKind)
 	}
-	if err := m.ValidateConfig(m.DefaultConfig()); err != nil {
+	if err := m.ValidateConfig(m.DefaultConfig(), nil); err != nil {
 		t.Errorf("m.ValidateConfig(m.DefaultConfig()) = %v; wanted no err", err)
 	}
 }

--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -27,6 +27,7 @@ import (
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
@@ -114,9 +115,11 @@ func (m *quotasManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapte
 	}, nil
 }
 
-func (*quotasManager) Kind() Kind                                                    { return QuotasKind }
-func (*quotasManager) DefaultConfig() config.AspectParams                            { return &aconfig.QuotasParams{} }
-func (*quotasManager) ValidateConfig(config.AspectParams) (ce *adapter.ConfigErrors) { return }
+func (*quotasManager) Kind() Kind                         { return QuotasKind }
+func (*quotasManager) DefaultConfig() config.AspectParams { return &aconfig.QuotasParams{} }
+func (*quotasManager) ValidateConfig(config.AspectParams, descriptor.Finder) (ce *adapter.ConfigErrors) {
+	return
+}
 
 func (w *quotasWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma APIMethodArgs) Output {
 	qma, ok := ma.(*QuotaMethodArgs)

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -79,7 +79,7 @@ func TestNewQuotasManager(t *testing.T) {
 	if m.Kind() != QuotasKind {
 		t.Errorf("m.Kind() = %s wanted %s", m.Kind(), QuotasKind)
 	}
-	if err := m.ValidateConfig(m.DefaultConfig()); err != nil {
+	if err := m.ValidateConfig(m.DefaultConfig(), nil); err != nil {
 		t.Errorf("m.ValidateConfig(m.DefaultConfig()) = %v; wanted no err", err)
 	}
 }

--- a/pkg/config/BUILD
+++ b/pkg/config/BUILD
@@ -12,7 +12,7 @@ go_library(
     deps = [
         "//pkg/adapter:go_default_library",
         "//pkg/attribute:go_default_library",
-        "//pkg/config/descriptors:go_default_library",
+        "//pkg/config/descriptor:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",

--- a/pkg/config/descriptor/BUILD
+++ b/pkg/config/descriptor/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["descriptors.go"],
+    srcs = ["descriptor.go"],
     deps = [
         "//pkg/config/proto:go_default_library",
         "@com_github_istio_api//:mixer/v1/config/descriptor",
@@ -15,7 +15,7 @@ go_test(
     name = "small_tests",
     size = "small",
     srcs = [
-        "descriptors_test.go",
+        "descriptor_test.go",
     ],
     library = ":go_default_library",
     deps = [

--- a/pkg/config/descriptor/descriptor.go
+++ b/pkg/config/descriptor/descriptor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package descriptors
+package descriptor
 
 import (
 	dpb "istio.io/api/mixer/v1/config/descriptor"

--- a/pkg/config/descriptor/descriptor_test.go
+++ b/pkg/config/descriptor/descriptor_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package descriptors
+package descriptor
 
 import (
 	"fmt"

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -24,7 +24,7 @@ import (
 
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
-	"istio.io/mixer/pkg/config/descriptors"
+	"istio.io/mixer/pkg/config/descriptor"
 	pb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
@@ -48,7 +48,7 @@ type Manager struct {
 	eval             expr.Evaluator
 	aspectFinder     AspectValidatorFinder
 	builderFinder    AdapterValidatorFinder
-	descriptorFinder descriptors.Finder
+	descriptorFinder descriptor.Finder
 	findAspects      AdapterToAspectMapper
 	loopDelay        time.Duration
 	globalConfig     string
@@ -127,7 +127,7 @@ func (c *Manager) fetch() (*Runtime, error) {
 		return nil, cerr
 	}
 
-	c.descriptorFinder = descriptors.NewFinder(v.validated.globalConfig)
+	c.descriptorFinder = descriptor.NewFinder(v.validated.globalConfig)
 
 	c.gcSHA = gcSHA
 	c.scSHA = scSHA

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/mixer/pkg/adapter"
 	listcheckerpb "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config/descriptor"
 )
 
 type fakeVFinder struct {
@@ -67,7 +68,7 @@ func (*ac) DefaultConfig() AspectParams {
 }
 
 // ValidateConfig determines whether the given configuration meets all correctness requirements.
-func (a *ac) ValidateConfig(AspectParams) *adapter.ConfigErrors {
+func (a *ac) ValidateConfig(AspectParams, descriptor.Finder) *adapter.ConfigErrors {
 	return a.ce
 }
 


### PR DESCRIPTION
We add a `descriptor.Finder` parameter to the `ValidateConfig` method of the `config.AspectValidator` interface, and wire a `descriptor.Finder` through config validation. Follow on PRs will use the finder to validate configuration in the aspect managers.

This PR also renames the `descriptors` package to `descriptor` to conform to our style guide (https://github.com/istio/mixer/issues/374).

Note this PR is blocked on https://github.com/istio/mixer/pull/429

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/431)
<!-- Reviewable:end -->
