### PR TITLE
Fix another bug in the Quota method.

### DIFF
--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -181,7 +181,7 @@ func (w *quotasWrapper) Execute(attrs attribute.Bag, mapper expr.Evaluator, ma A
 
 	return Output{
 		Status: status.OK,
-		Response: QuotaMethodResp{
+		Response: &QuotaMethodResp{
 			Amount:     qr.Amount,
 			Expiration: qr.Expiration,
 		}}


### PR DESCRIPTION
Given the current config, the quota method can be invoked from the mixc command
with:

   bazel-bin/cmd/client/mixc quota --amount 1 -name RequestCount

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/433)
<!-- Reviewable:end -->
