### PR TITLE
Add descriptor.Finder to the aspect.Manager.NewAspect interface method

### DIFF
--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/config:go_default_library",
+        "//pkg/config/descriptor:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -277,7 +277,9 @@ func (m *Manager) cacheGet(cfg *configpb.Combined, mgr aspect.Manager, builder a
 
 	// create an aspect
 	env := newEnv(builder.Name(), m.adapterGP)
-	asp, err = mgr.NewAspect(cfg, builder, env)
+
+	// TODO: figure out how we want to plumb the descriptor finder through the API layer and into this manager.
+	asp, err = mgr.NewAspect(cfg, builder, env, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	configpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
@@ -122,7 +123,7 @@ func newManager(r builderFinder, m map[aspect.Kind]aspect.Manager, exp expr.Eval
 
 // Execute iterates over cfgs and performs the actions described by the combined config using the attribute bag on each config.
 func (m *Manager) Execute(ctx context.Context, cfgs []*configpb.Combined,
-	requestBag *attribute.MutableBag, responseBag *attribute.MutableBag, ma aspect.APIMethodArgs) aspect.Output {
+	requestBag *attribute.MutableBag, responseBag *attribute.MutableBag, ma aspect.APIMethodArgs, df descriptor.Finder) aspect.Output {
 	numCfgs := len(cfgs)
 
 	// TODO: consider implementing a fast path when there is only a single config.
@@ -140,7 +141,7 @@ func (m *Manager) Execute(ctx context.Context, cfgs []*configpb.Combined,
 			childRequestBag := requestBag.Child()
 			childResponseBag := responseBag.Child()
 
-			out := m.execute(ctx, c, childRequestBag, childResponseBag, ma)
+			out := m.execute(ctx, c, childRequestBag, childResponseBag, ma, df)
 			resultChan <- result{c, out, childResponseBag}
 
 			childRequestBag.Done()
@@ -224,7 +225,7 @@ type result struct {
 
 // execute performs action described in the combined config using the attribute bag
 func (m *Manager) execute(ctx context.Context, cfg *configpb.Combined, requestBag attribute.Bag, responseBag *attribute.MutableBag,
-	ma aspect.APIMethodArgs) (out aspect.Output) {
+	ma aspect.APIMethodArgs, df descriptor.Finder) (out aspect.Output) {
 	var mgr aspect.Manager
 	var found bool
 
@@ -250,7 +251,7 @@ func (m *Manager) execute(ctx context.Context, cfg *configpb.Combined, requestBa
 		}
 	}()
 
-	asp, err := m.cacheGet(cfg, mgr, adp)
+	asp, err := m.cacheGet(cfg, mgr, adp, df)
 	if err != nil {
 		return aspect.Output{Status: status.WithError(err)}
 	}
@@ -262,7 +263,7 @@ func (m *Manager) execute(ctx context.Context, cfg *configpb.Combined, requestBa
 }
 
 // cacheGet gets an aspect wrapper from the cache, use adapter.Manager to construct an object in case of a cache miss
-func (m *Manager) cacheGet(cfg *configpb.Combined, mgr aspect.Manager, builder adapter.Builder) (asp aspect.Wrapper, err error) {
+func (m *Manager) cacheGet(cfg *configpb.Combined, mgr aspect.Manager, builder adapter.Builder, df descriptor.Finder) (asp aspect.Wrapper, err error) {
 	var key *cacheKey
 	if key, err = newCacheKey(mgr.Kind(), cfg); err != nil {
 		return nil, err
@@ -279,7 +280,7 @@ func (m *Manager) cacheGet(cfg *configpb.Combined, mgr aspect.Manager, builder a
 	env := newEnv(builder.Name(), m.adapterGP)
 
 	// TODO: figure out how we want to plumb the descriptor finder through the API layer and into this manager.
-	asp, err = mgr.NewAspect(cfg, builder, env, nil)
+	asp, err = mgr.NewAspect(cfg, builder, env, df)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -279,7 +279,6 @@ func (m *Manager) cacheGet(cfg *configpb.Combined, mgr aspect.Manager, builder a
 	// create an aspect
 	env := newEnv(builder.Name(), m.adapterGP)
 
-	// TODO: figure out how we want to plumb the descriptor finder through the API layer and into this manager.
 	asp, err = mgr.NewAspect(cfg, builder, env, df)
 	if err != nil {
 		return nil, err

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -97,7 +97,7 @@ func (testManager) Kind() aspect.Kind   { return aspect.DenialsKind }
 func (m testManager) Name() string      { return m.name }
 func (testManager) Description() string { return "deny checker aspect manager for testing" }
 
-func (m testManager) NewAspect(cfg *configpb.Combined, adapter adapter.Builder, env adapter.Env) (aspect.Wrapper, error) {
+func (m testManager) NewAspect(cfg *configpb.Combined, adapter adapter.Builder, env adapter.Env, _ descriptor.Finder) (aspect.Wrapper, error) {
 	if m.throw {
 		panic("NewAspect panic")
 	}
@@ -117,7 +117,7 @@ func (testAspect) ValidateConfig(adapter.Config) *adapter.ConfigErrors { return 
 func (testAspect) Name() string                                        { return "" }
 func (testAspect) Description() string                                 { return "" }
 
-func (m *fakemgr) NewAspect(cfg *configpb.Combined, adp adapter.Builder, env adapter.Env) (aspect.Wrapper, error) {
+func (m *fakemgr) NewAspect(cfg *configpb.Combined, adp adapter.Builder, env adapter.Env, _ descriptor.Finder) (aspect.Wrapper, error) {
 	m.called++
 	if m.w == nil {
 		return nil, errors.New("unable to create aspect")

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -196,7 +196,7 @@ func TestManager(t *testing.T) {
 		agp := pool.NewGoroutinePool(1, true)
 		m := newManager(r, mgr, mapper, nil, gp, agp)
 
-		out := m.Execute(context.Background(), tt.cfg, requestBag, responseBag, nil)
+		out := m.Execute(context.Background(), tt.cfg, requestBag, responseBag, nil, nil)
 		errStr := out.Message()
 		if !strings.Contains(errStr, tt.errString) {
 			t.Errorf("[%d] expected: '%s' \ngot: '%s'", idx, tt.errString, errStr)
@@ -217,7 +217,7 @@ func TestManager(t *testing.T) {
 
 		// call again
 		// check for cache
-		_ = m.Execute(context.Background(), tt.cfg, requestBag, responseBag, nil)
+		_ = m.Execute(context.Background(), tt.cfg, requestBag, responseBag, nil, nil)
 		if tt.wrapper.called != 2 {
 			t.Errorf("[%d] Expected 2nd wrapper call", idx)
 		}
@@ -269,7 +269,7 @@ func TestManager_BulkExecute(t *testing.T) {
 		agp := pool.NewGoroutinePool(1, true)
 		m := newManager(r, mgr, mapper, nil, gp, agp)
 
-		out := m.Execute(context.Background(), c.cfgs, requestBag, responseBag, nil)
+		out := m.Execute(context.Background(), c.cfgs, requestBag, responseBag, nil, nil)
 		errStr := out.Message()
 		if !strings.Contains(errStr, c.errString) {
 			t.Errorf("[%d] got: '%s' want: '%s'", idx, c.errString, errStr)
@@ -318,7 +318,7 @@ func testRecovery(t *testing.T, name string, throwOnNewAspect bool, throwOnExecu
 		},
 	}
 
-	out := m.Execute(context.Background(), cfg, nil, nil, nil)
+	out := m.Execute(context.Background(), cfg, nil, nil, nil, nil)
 	if out.IsOK() {
 		t.Error("Aspect panicked, but got no error from manager.Execute")
 	}
@@ -363,7 +363,7 @@ func TestExecute(t *testing.T) {
 			{&configpb.Adapter{Name: c.name}, &configpb.Aspect{Kind: c.name}},
 		}
 
-		o := m.Execute(context.Background(), cfg, nil, nil, nil)
+		o := m.Execute(context.Background(), cfg, nil, nil, nil, nil)
 		if c.inErr != nil && o.IsOK() {
 			t.Errorf("m.Execute(...) want err: %v", c.inErr)
 		}
@@ -396,7 +396,7 @@ func TestExecute_Cancellation(t *testing.T) {
 	cfg := []*configpb.Combined{
 		{&configpb.Adapter{Name: ""}, &configpb.Aspect{Kind: ""}},
 	}
-	if out := handler.Execute(ctx, cfg, attribute.GetMutableBag(nil), attribute.GetMutableBag(nil), nil); out.IsOK() {
+	if out := handler.Execute(ctx, cfg, attribute.GetMutableBag(nil), attribute.GetMutableBag(nil), nil, nil); out.IsOK() {
 		t.Error("handler.Execute(canceledContext, ...) = _, nil; wanted any err")
 	}
 
@@ -438,7 +438,7 @@ func TestExecute_TimeoutWaitingForResults(t *testing.T) {
 		&configpb.Adapter{Name: name},
 		&configpb.Aspect{Kind: name},
 	}}
-	if out := m.Execute(ctx, cfg, attribute.GetMutableBag(nil), attribute.GetMutableBag(nil), nil); out.IsOK() {
+	if out := m.Execute(ctx, cfg, attribute.GetMutableBag(nil), attribute.GetMutableBag(nil), nil, nil); out.IsOK() {
 		t.Error("handler.Execute(canceledContext, ...) = _, nil; wanted any err")
 	}
 	close(blockChan)

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/config:go_default_library",
+        "//pkg/config/descriptor:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/status"
 )
@@ -58,7 +59,7 @@ type Handler interface {
 type Executor interface {
 	// Execute takes a set of configurations and Executes all of them.
 	Execute(ctx context.Context, cfgs []*cpb.Combined, requestBag *attribute.MutableBag, responseBag *attribute.MutableBag,
-		ma aspect.APIMethodArgs) aspect.Output
+		ma aspect.APIMethodArgs, df descriptor.Finder) aspect.Output
 }
 
 // handlerState holds state and configuration for the handler.
@@ -66,6 +67,8 @@ type handlerState struct {
 	aspectExecutor Executor
 	// Configs for the aspects that'll be used to serve each API method. <*config.Runtime>
 	cfg atomic.Value
+	// Descriptor finder (derived from configs) that'll be used for creating aspect managers to serve API methods. <descriptor.Finder>
+	df atomic.Value
 
 	// methodMap maps an API method to a set of aspects configured for the method
 	methodMap map[aspect.APIMethod]config.AspectSet
@@ -86,7 +89,8 @@ func (h *handlerState) execute(ctx context.Context, requestBag *attribute.Mutabl
 	ctx = attribute.NewContext(ctx, requestBag)
 
 	cfg, _ := h.cfg.Load().(config.Resolver)
-	if cfg == nil {
+	df, _ := h.df.Load().(descriptor.Finder)
+	if cfg == nil || df == nil {
 		// config has not been loaded yet
 		const msg = "Configuration is not yet available"
 		glog.Error(msg)
@@ -104,7 +108,7 @@ func (h *handlerState) execute(ctx context.Context, requestBag *attribute.Mutabl
 		glog.Infof("Resolved [%d] ==> %v ", len(cfgs), cfgs)
 	}
 
-	return h.aspectExecutor.Execute(ctx, cfgs, requestBag, responseBag, ma)
+	return h.aspectExecutor.Execute(ctx, cfgs, requestBag, responseBag, ma, df)
 }
 
 // Check performs 'check' function corresponding to the mixer api.
@@ -173,6 +177,7 @@ func (h *handlerState) Quota(ctx context.Context, requestBag *attribute.MutableB
 }
 
 // ConfigChange listens for config change notifications.
-func (h *handlerState) ConfigChange(cfg config.Resolver) {
+func (h *handlerState) ConfigChange(cfg config.Resolver, df descriptor.Finder) {
 	h.cfg.Store(cfg)
+	h.df.Store(df)
 }

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -55,7 +55,7 @@ func newAccessLogsManager() Manager {
 	return accessLogsManager{}
 }
 
-func (m accessLogsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (m accessLogsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env, df descriptor.Finder) (Wrapper, error) {
 	cfg := c.Aspect.Params.(*aconfig.AccessLogsParams)
 
 	var templateStr string

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -93,7 +93,7 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 				Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &configpb.Aspect{Params: v.params, Inputs: map[string]string{"template": "{{.test}}"}},
 			}
-			asp, err := m.NewAspect(c, tl, test.Env{})
+			asp, err := m.NewAspect(c, tl, test.Env{}, nil)
 			if err != nil {
 				t.Fatalf("NewAspect(): should not have received error for %s (%v)", v.name, err)
 			}
@@ -142,7 +142,7 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 	m := newAccessLogsManager()
 	for idx, v := range failureCases {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			if _, err := m.NewAspect(v.cfg, v.adptr, test.Env{}); err == nil {
+			if _, err := m.NewAspect(v.cfg, v.adptr, test.Env{}, nil); err == nil {
 				t.Fatalf("NewAspect()[%s]: expected error for bad adapter (%T)", v.name, v.adptr)
 			}
 		})

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -70,7 +70,7 @@ func newApplicationLogsManager() Manager {
 	return applicationLogsManager{}
 }
 
-func (applicationLogsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (applicationLogsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env, df descriptor.Finder) (Wrapper, error) {
 	// TODO: look up actual descriptors by name and build an array
 	cfg := c.Aspect.Params.(*aconfig.ApplicationLogsParams)
 

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -122,7 +122,7 @@ func TestLoggerManager_NewLogger(t *testing.T) {
 				Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &configpb.Aspect{Params: v.params, Inputs: map[string]string{}},
 			}
-			asp, err := m.NewAspect(&c, tl, atest.NewEnv(t))
+			asp, err := m.NewAspect(&c, tl, atest.NewEnv(t), nil)
 			if err != nil {
 				t.Fatalf("NewAspect(): should not have received error for %s (%v)", v.name, err)
 			}
@@ -172,7 +172,7 @@ func TestLoggerManager_NewLoggerFailures(t *testing.T) {
 				},
 			}
 
-			if _, err := m.NewAspect(cfg, v.adptr, atest.NewEnv(t)); err == nil {
+			if _, err := m.NewAspect(cfg, v.adptr, atest.NewEnv(t), nil); err == nil {
 				t.Fatalf("NewAspect(): expected error for bad adapter (%T)", v.adptr)
 			}
 		})

--- a/pkg/aspect/denialsManager.go
+++ b/pkg/aspect/denialsManager.go
@@ -38,7 +38,7 @@ func newDenialsManager() Manager {
 }
 
 // NewAspect creates a denyChecker aspect.
-func (denialsManager) NewAspect(cfg *cpb.Combined, ga adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (denialsManager) NewAspect(cfg *cpb.Combined, ga adapter.Builder, env adapter.Env, df descriptor.Finder) (Wrapper, error) {
 	aa := ga.(adapter.DenialsBuilder)
 	var asp adapter.DenialsAspect
 	var err error

--- a/pkg/aspect/listsManager.go
+++ b/pkg/aspect/listsManager.go
@@ -43,7 +43,7 @@ func newListsManager() Manager {
 }
 
 // NewAspect creates a listChecker aspect.
-func (listsManager) NewAspect(cfg *cpb.Combined, ga adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (listsManager) NewAspect(cfg *cpb.Combined, ga adapter.Builder, env adapter.Env, df descriptor.Finder) (Wrapper, error) {
 	aa := ga.(adapter.ListsBuilder)
 	var asp adapter.ListsAspect
 	var err error

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
@@ -50,7 +51,7 @@ type (
 		config.AspectValidator
 
 		// NewAspect creates a new aspect instance given configuration.
-		NewAspect(cfg *cpb.Combined, adapter adapter.Builder, env adapter.Env) (Wrapper, error)
+		NewAspect(cfg *cpb.Combined, adapter adapter.Builder, env adapter.Env, df descriptor.Finder) (Wrapper, error)
 
 		// Kind return the kind of aspect
 		Kind() Kind

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -55,7 +55,7 @@ func newMetricsManager() Manager {
 }
 
 // NewAspect creates a metric aspect.
-func (m *metricsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (m *metricsManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env, df descriptor.Finder) (Wrapper, error) {
 	params := c.Aspect.Params.(*aconfig.MetricsParams)
 
 	// TODO: get descriptors from config

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -93,7 +93,7 @@ func TestMetricsManager_NewAspect(t *testing.T) {
 	builder := &fakeBuilder{name: "test", body: func() (adapter.MetricsAspect, error) {
 		return &fakeaspect{body: func([]adapter.Value) error { return nil }}, nil
 	}}
-	if _, err := newMetricsManager().NewAspect(conf, builder, atest.NewEnv(t)); err != nil {
+	if _, err := newMetricsManager().NewAspect(conf, builder, atest.NewEnv(t), nil); err != nil {
 		t.Errorf("NewAspect(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -109,7 +109,7 @@ func TestMetricsManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.MetricsAspect, error) {
 			return nil, errors.New(errString)
 		}}
-	_, err := newMetricsManager().NewAspect(conf, builder, atest.NewEnv(t))
+	_, err := newMetricsManager().NewAspect(conf, builder, atest.NewEnv(t), nil)
 	if err == nil {
 		t.Error("newMetricsManager().NewAspect(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}

--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -53,7 +53,7 @@ func newQuotasManager() Manager {
 }
 
 // NewAspect creates a quota aspect.
-func (m *quotasManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env) (Wrapper, error) {
+func (m *quotasManager) NewAspect(c *cpb.Combined, a adapter.Builder, env adapter.Env, df descriptor.Finder) (Wrapper, error) {
 	params := c.Aspect.Params.(*aconfig.QuotasParams)
 
 	// TODO: get this from config

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -108,12 +108,12 @@ func TestQuotasManager_NewAspect(t *testing.T) {
 	}}
 
 	conf := newQuotaConfig("RequestCount", map[string]string{"source": "", "target": ""})
-	if _, err := newQuotasManager().NewAspect(conf, builder, atest.NewEnv(t)); err != nil {
+	if _, err := newQuotasManager().NewAspect(conf, builder, atest.NewEnv(t), nil); err != nil {
 		t.Errorf("NewAspect(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 
 	conf = newQuotaConfig("FOOBAR", map[string]string{})
-	if _, err := newQuotasManager().NewAspect(conf, builder, atest.NewEnv(t)); err != nil {
+	if _, err := newQuotasManager().NewAspect(conf, builder, atest.NewEnv(t), nil); err != nil {
 		t.Errorf("NewAspect(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -129,7 +129,7 @@ func TestQuotasManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.QuotasAspect, error) {
 			return nil, errors.New(errString)
 		}}
-	_, err := newQuotasManager().NewAspect(conf, builder, atest.NewEnv(t))
+	_, err := newQuotasManager().NewAspect(conf, builder, atest.NewEnv(t), nil)
 	if err == nil {
 		t.Error("newQuotasManager().NewAspect(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/config/descriptor"
 )
 
 type mtest struct {
@@ -39,12 +40,14 @@ type mtest struct {
 type fakelistener struct {
 	called int
 	rt     Resolver
+	df     descriptor.Finder
 	sync.Mutex
 }
 
-func (f *fakelistener) ConfigChange(cfg Resolver) {
+func (f *fakelistener) ConfigChange(cfg Resolver, df descriptor.Finder) {
 	f.Lock()
 	f.rt = cfg
+	f.df = df
 	f.called++
 	f.Unlock()
 }


### PR DESCRIPTION
Open question is how to get a descriptor finder into the adapterManager: it's the one place where the config and request paths intersect (otherwise all config loading and validation happens out of band).

I suspect long term the solution to plumbing the `descriptor.Finder` through is fully separating creation of adapters and managers when new config is provided from anything in the request path (issue https://github.com/istio/mixer/issues/272). I'm not sure how we want to handle it in the short term.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/440)
<!-- Reviewable:end -->
