### PR TITLE
Address minor linting issue with go-multierror imports.

### DIFF
--- a/adapter/prometheus/prometheus.go
+++ b/adapter/prometheus/prometheus.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"istio.io/mixer/adapter/prometheus/config"

--- a/adapter/statsd/statsd.go
+++ b/adapter/statsd/statsd.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/cactus/go-statsd-client/statsd"
 	"github.com/gogo/protobuf/types"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	"istio.io/mixer/adapter/statsd/config"
 	"istio.io/mixer/pkg/adapter"

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -19,7 +19,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	"istio.io/mixer/pkg/attribute"
 	pb "istio.io/mixer/pkg/config/proto"

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	rpc "github.com/googleapis/googleapis/google/rpc"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 func TestStatus(t *testing.T) {


### PR DESCRIPTION
This PR is a cleanup PR, meant to resolve some minor liniting issues
that vary across versions of go. It is only needed to reduce churn
for some development environments and should have no impact on the
functionality of the codebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/449)
<!-- Reviewable:end -->
