### PR TITLE
Update ConfigErrors.Extend so that `nil.Extend(nil) == nil`

### DIFF
--- a/pkg/adapter/configError.go
+++ b/pkg/adapter/configError.go
@@ -87,12 +87,11 @@ func (e *ConfigErrors) Error() string {
 
 // Extend joins 2 configErrors together.
 func (e *ConfigErrors) Extend(ee *ConfigErrors) *ConfigErrors {
-	ce := e
-	if ce == nil {
-		ce = &ConfigErrors{}
+	if e == nil {
+		return ee
 	}
 	if ee != nil {
-		ce.Multi = me.Append(ce.Multi, ee.Multi.Errors...)
+		e.Multi = me.Append(e.Multi, ee.Multi.Errors...)
 	}
-	return ce
+	return e
 }

--- a/pkg/adapter/configError_test.go
+++ b/pkg/adapter/configError_test.go
@@ -90,4 +90,14 @@ func TestExtend(t *testing.T) {
 	if len(c1.Multi.Errors) != len(c2.Multi.Errors) {
 		t.Error("Expected lengths to match")
 	}
+
+	var ce *ConfigErrors
+	if ce.Extend(nil) != nil {
+		t.Error("nil.Extend(nil) != nil")
+	}
+
+	ce = ce.Append("Foo", fmt.Errorf("format %d", 0))
+	if ce.Extend(nil) != ce {
+		t.Error("ce.Extend(nil) != ce")
+	}
 }


### PR DESCRIPTION
Previously such a call would return a zero-value ConfigErrors, breaking the standard `if ce := foo(); ce != nil { ... }` pattern if ConfigErrors.Extend was used anywhere during the construction of the error returned by `foo` (or any of the methods it calls, transitively).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/453)
<!-- Reviewable:end -->
