### PR TITLE
Add version information to log for the mixer.

### DIFF
--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",
         "//pkg/tracing:go_default_library",
+        "//pkg/version:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_istio_api//:mixer/v1",

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
 	"istio.io/mixer/pkg/tracing"
+	"istio.io/mixer/pkg/version"
 )
 
 type serverArgs struct {
@@ -199,6 +200,7 @@ func runServer(sa *serverArgs, printf, fatalf shared.FormatFn) {
 	s := api.NewGRPCServer(handler, tracer, gp)
 	mixerpb.RegisterMixerServer(gs, s)
 
+	printf("Istio Mixer: %s", version.Info)
 	printf("Starting gRPC server on port %v", sa.port)
 
 	if err = gs.Serve(listener); err != nil {


### PR DESCRIPTION
This PR will add a print out of version information to the log for
istio mixer. This should ease debugging, etc., as the version info
will come along with the log.

Example:

```shell
$ ./bazel-bin/cmd/server/mixs server
Istio Mixer: version: unknown (build: 2017-03-29-84ea18c, status: Modified)
Starting gRPC server on port 9091
```

Related to #424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/473)
<!-- Reviewable:end -->
