### PR TITLE
Implement validation using descriptors for the quotas aspect

### DIFF
--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "accessLogsManager.go",
         "applicationLogsManager.go",
+        "common.go",
         "denialsManager.go",
         "descriptors.go",
         "inventory.go",
@@ -43,6 +44,7 @@ go_test(
     srcs = [
         "accessLogsManager_test.go",
         "applicationLogsManager_test.go",
+        "common_test.go",
         "denialsManager_test.go",
         "descriptors_test.go",
         "inventory_test.go",

--- a/pkg/aspect/common.go
+++ b/pkg/aspect/common.go
@@ -1,0 +1,74 @@
+// Copyright 2017 the Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aspect
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+
+	dpb "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/expr"
+)
+
+func evalAll(expressions map[string]string, attrs attribute.Bag, eval expr.Evaluator) (map[string]interface{}, error) {
+	result := &multierror.Error{}
+	labels := make(map[string]interface{}, len(expressions))
+	for label, texpr := range expressions {
+		val, err := eval.Eval(texpr, attrs)
+		if err != nil {
+			result = multierror.Append(result, fmt.Errorf("failed to construct value for label '%s' with err: %s", label, err))
+			continue
+		}
+		labels[label] = val
+	}
+	return labels, result.ErrorOrNil()
+}
+
+func findLabel(name string, labels []*dpb.LabelDescriptor) *dpb.LabelDescriptor {
+	for _, l := range labels {
+		if l.Name == name {
+			return l
+		}
+	}
+	return nil
+}
+
+func validateLabels(ceField string, labels map[string]string, labelDescs []*dpb.LabelDescriptor, v expr.Validator, df expr.AttributeDescriptorFinder) (
+	ce *adapter.ConfigErrors) {
+
+	if len(labels) != len(labelDescs) {
+		ce = ce.Appendf(ceField, "wrong dimensions: descriptor expects %d labels, found %d labels", len(labelDescs), len(labels))
+	}
+	for name, exp := range labels {
+		label := findLabel(name, labelDescs)
+		if label == nil {
+			ce = ce.Appendf(ceField, "wrong dimensions: extra label named %s", name)
+			continue
+		}
+
+		ltype, err := v.TypeCheck(exp, df)
+		if err != nil {
+			ce = ce.Appendf(ceField, "failed to evaluate type label %s with err: %v", name, err)
+			continue
+		}
+		if ltype != label.ValueType {
+			ce = ce.Appendf(ceField, "label %s has evaluated type %v, expected type %v", name, ltype, label.ValueType)
+		}
+	}
+	return
+}

--- a/pkg/aspect/common_test.go
+++ b/pkg/aspect/common_test.go
@@ -1,0 +1,141 @@
+// Copyright 2017 the Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aspect
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	dpb "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/mixer/pkg/aspect/test"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/expr"
+)
+
+func TestEvalAll(t *testing.T) {
+	// empty map
+	// 1 valid expr
+	// 2 valid exprs
+	// 1 valid, 1 invalid
+	// 1 invalid, 1 valid
+	bag := &test.Bag{Strs: map[string]string{"1": "1", "2": "2"}}
+	eval := test.NewFakeEval(func(s string, _ attribute.Bag) (interface{}, error) {
+		s, f := bag.String(s)
+		if !f {
+			return nil, fmt.Errorf("no key %s", s)
+		}
+		return s, nil
+	})
+
+	tests := []struct {
+		name  string
+		exprs map[string]string
+		out   map[string]interface{}
+		err   string
+	}{
+		{"no expressions", map[string]string{}, map[string]interface{}{}, ""},
+		{"valid expr", map[string]string{"foo": "1"}, map[string]interface{}{"foo": "1"}, ""},
+		{"2 valid expr", map[string]string{"foo": "1", "bar": "2"}, map[string]interface{}{"foo": "1", "bar": "2"}, ""},
+		{"1 valid, 1 invalid", map[string]string{"foo": "1", "bar": "does not exist"}, map[string]interface{}{"foo": "1"}, "failed to construct value"},
+		{"1 valid, 1 invalid", map[string]string{"foo": "does not exist", "bar": "2"}, map[string]interface{}{"bar": "2"}, "failed to construct value"},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			out, err := evalAll(tt.exprs, bag, eval)
+			if err != nil {
+				if tt.err == "" {
+					t.Errorf("ValidateConfig(tt.cfg, tt.v, tt.df) = '%s', wanted no err", err.Error())
+				} else if !strings.Contains(err.Error(), tt.err) {
+					t.Errorf("Expected errors containing the string '%s', actual: '%s'", tt.err, err.Error())
+				}
+			}
+
+			if len(out) != len(tt.out) {
+				t.Errorf("Expected %d outputs, got %d", len(tt.out), len(out))
+			}
+			for key, val := range out {
+				if expected, found := tt.out[key]; !found {
+					t.Errorf("unexpected extra output (%s, %v)", key, val)
+				} else if !reflect.DeepEqual(expected, val) {
+					t.Errorf("label %s = %v, wanted %v", key, val, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestFindLabel(t *testing.T) {
+	tests := []struct {
+		in     string
+		out    *dpb.LabelDescriptor
+		labels []*dpb.LabelDescriptor
+	}{
+		{"empty", nil, []*dpb.LabelDescriptor{}},
+		{"missing", nil, []*dpb.LabelDescriptor{{Name: "label", ValueType: dpb.BOOL}}},
+		{"present", &dpb.LabelDescriptor{Name: "present", ValueType: dpb.INT64}, []*dpb.LabelDescriptor{{Name: "present", ValueType: dpb.INT64}}},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.in), func(t *testing.T) {
+			if result := findLabel(tt.in, tt.labels); !reflect.DeepEqual(result, tt.out) {
+				t.Fatalf("findLabel(%s, %v) = %v, wanted %v", tt.in, tt.labels, result, tt.out)
+			}
+		})
+	}
+}
+
+func TestValidateLabels(t *testing.T) {
+	descriptors := []*dpb.LabelDescriptor{
+		{Name: "stringlabel", ValueType: dpb.STRING},
+	}
+
+	tests := []struct {
+		name   string
+		labels map[string]string
+		descs  []*dpb.LabelDescriptor
+		err    string
+	}{
+		{"no labels", map[string]string{}, []*dpb.LabelDescriptor{}, ""},
+		{"one label", map[string]string{"stringlabel": "string"}, descriptors, ""},
+		{"two labels", map[string]string{"stringlabel": "string", "durationlabel": "duration"}, []*dpb.LabelDescriptor{
+			{Name: "stringlabel", ValueType: dpb.STRING},
+			{Name: "durationlabel", ValueType: dpb.DURATION},
+		}, ""},
+		{"missing label", map[string]string{"missing": "not a label"}, descriptors, "wrong dimensions"},
+		{"cardinality mismatch", map[string]string{"stringlabel": "string", "string2": "string"}, descriptors, "wrong dimensions"},
+		{"type eval error", map[string]string{"stringlabel": "string |"}, descriptors, "failed to evaluate type"},
+		{"type doesn't match desc", map[string]string{"stringlabel": "duration"}, descriptors, "expected type STRING"},
+	}
+	df := test.NewDescriptorFinder(map[string]interface{}{
+		"duration": &dpb.AttributeDescriptor{Name: "duration", ValueType: dpb.DURATION},
+		"string":   &dpb.AttributeDescriptor{Name: "string", ValueType: dpb.STRING},
+		"int64":    &dpb.AttributeDescriptor{Name: "int64", ValueType: dpb.INT64},
+	})
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			err := validateLabels(tt.name, tt.labels, tt.descs, expr.NewCEXLEvaluator(), df)
+			if err != nil {
+				if tt.err == "" {
+					t.Fatalf("ValidateConfig(tt.cfg, tt.v, tt.df) = '%s', wanted no err", err.Error())
+				} else if !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("Expected errors containing the string '%s', actual: '%s'", tt.err, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/pkg/aspect/common_test.go
+++ b/pkg/aspect/common_test.go
@@ -27,18 +27,13 @@ import (
 )
 
 func TestEvalAll(t *testing.T) {
-	// empty map
-	// 1 valid expr
-	// 2 valid exprs
-	// 1 valid, 1 invalid
-	// 1 invalid, 1 valid
 	bag := &test.Bag{Strs: map[string]string{"1": "1", "2": "2"}}
 	eval := test.NewFakeEval(func(s string, _ attribute.Bag) (interface{}, error) {
-		s, f := bag.String(s)
+		str, f := bag.String(s)
 		if !f {
 			return nil, fmt.Errorf("no key %s", s)
 		}
-		return s, nil
+		return str, nil
 	})
 
 	tests := []struct {

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -229,7 +229,7 @@ func TestMetricsManager_Validation(t *testing.T) {
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
 			errs := (&metricsManager{}).ValidateConfig(tt.cfg, tt.v, tt.df)
-			if errs != nil {
+			if errs != nil || tt.err != "" {
 				if tt.err == "" {
 					t.Fatalf("ValidateConfig(tt.cfg, tt.v, tt.df) = '%s', wanted no err", errs.Error())
 				} else if !strings.Contains(errs.Error(), tt.err) {

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -86,7 +86,7 @@ var (
 	}
 
 	quotaWithLabels = &dpb.QuotaDescriptor{
-		Name:       "no label desc",
+		Name:       "desc with labels",
 		Expiration: &ptypes.Duration{Seconds: 1},
 		Labels: []*dpb.LabelDescriptor{
 			{Name: "source", ValueType: dpb.STRING},

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/mixer/pkg/aspect/test"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
@@ -76,6 +77,27 @@ func (b *fakeQuotaBuilder) NewQuotasAspect(env adapter.Env, config adapter.Confi
 	return b.body()
 }
 
+var (
+	quotaRequestCount = &dpb.QuotaDescriptor{
+		Name:       "RequestCount",
+		MaxAmount:  5,
+		Expiration: &ptypes.Duration{Seconds: 1},
+		Labels:     []*dpb.LabelDescriptor{},
+	}
+
+	quotaWithLabels = &dpb.QuotaDescriptor{
+		Name:       "no label desc",
+		Expiration: &ptypes.Duration{Seconds: 1},
+		Labels: []*dpb.LabelDescriptor{
+			{Name: "source", ValueType: dpb.STRING},
+			{Name: "target", ValueType: dpb.STRING},
+			{Name: "service", ValueType: dpb.STRING},
+			{Name: "method", ValueType: dpb.STRING},
+			{Name: "response_code", ValueType: dpb.INT64},
+		},
+	}
+)
+
 func TestNewQuotasManager(t *testing.T) {
 	m := newQuotasManager()
 	if m.Kind() != config.QuotasKind {
@@ -108,15 +130,11 @@ func TestQuotasManager_NewAspect(t *testing.T) {
 	builder := &fakeQuotaBuilder{name: "test", body: func() (adapter.QuotasAspect, error) {
 		return &fakeQuotaAspect{}, nil
 	}}
-
+	df := test.NewDescriptorFinder(map[string]interface{}{quotaRequestCount.Name: quotaRequestCount})
 	conf := newQuotaConfig("RequestCount", map[string]string{"source": "", "target": ""})
-	if _, err := newQuotasManager().NewQuotaExecutor(conf, builder, atest.NewEnv(t), nil); err != nil {
-		t.Errorf("NewExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
-	}
 
-	conf = newQuotaConfig("FOOBAR", map[string]string{})
-	if _, err := newQuotasManager().NewQuotaExecutor(conf, builder, atest.NewEnv(t), nil); err != nil {
-		t.Errorf("NewQuotaExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
+	if _, err := newQuotasManager().NewQuotaExecutor(conf, builder, atest.NewEnv(t), df); err != nil {
+		t.Fatalf("NewExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
 
@@ -137,6 +155,103 @@ func TestQuotasManager_NewAspect_PropagatesError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), errString) {
 		t.Errorf("NewExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted err %s", err, errString)
+	}
+}
+
+func TestQuotasManager_ValidateConfig(t *testing.T) {
+	df := test.NewDescriptorFinder(map[string]interface{}{
+		quotaRequestCount.Name: quotaRequestCount,
+		quotaWithLabels.Name:   quotaWithLabels,
+		"invalid desc": &dpb.QuotaDescriptor{
+			Name:       "invalid desc",
+			Expiration: nil,
+			Labels:     []*dpb.LabelDescriptor{},
+		},
+		// our attributes
+		"duration": &dpb.AttributeDescriptor{Name: "duration", ValueType: dpb.DURATION},
+		"string":   &dpb.AttributeDescriptor{Name: "string", ValueType: dpb.STRING},
+		"int64":    &dpb.AttributeDescriptor{Name: "int64", ValueType: dpb.INT64},
+	})
+	v := expr.NewCEXLEvaluator()
+
+	validParam := aconfig.QuotasParams_Quota{
+		DescriptorName: quotaWithLabels.Name,
+		Labels: map[string]string{
+			"source":        "string",
+			"target":        "string",
+			"service":       "string",
+			"method":        "string",
+			"response_code": "int64",
+		},
+	}
+
+	validNoLabels := aconfig.QuotasParams_Quota{
+		DescriptorName: quotaRequestCount.Name,
+		Labels:         map[string]string{},
+	}
+
+	missingDesc := validParam
+	missingDesc.DescriptorName = "not in the descriptor finder"
+
+	// annoyingly, even though we copy force a copy of the struct the copy points at the same map instance, so we need a new one
+	invalidExpr := validParam
+	invalidExpr.Labels = map[string]string{
+		"source":        "string |", // invalid expr
+		"target":        "string",
+		"service":       "string",
+		"method":        "string",
+		"response_code": "int64",
+	}
+
+	wrongLabelType := validParam
+	wrongLabelType.Labels = map[string]string{
+		"source":        "string",
+		"target":        "string",
+		"service":       "int64", // should be string
+		"method":        "string",
+		"response_code": "int64",
+	}
+
+	extraLabel := validParam
+	extraLabel.Labels = map[string]string{
+		"source":        "string",
+		"target":        "string",
+		"service":       "string",
+		"method":        "string",
+		"response_code": "int64",
+		"extra":         "string", // wrong dimensions
+	}
+
+	badDesc := validNoLabels
+	badDesc.DescriptorName = "invalid desc"
+
+	tests := []struct {
+		name string
+		cfg  *aconfig.QuotasParams
+		v    expr.Validator
+		df   descriptor.Finder
+		err  string
+	}{
+		{"empty config", &aconfig.QuotasParams{}, v, df, ""},
+		{"valid", &aconfig.QuotasParams{Quotas: []*aconfig.QuotasParams_Quota{&validParam}}, v, df, ""},
+		{"no labels", &aconfig.QuotasParams{Quotas: []*aconfig.QuotasParams_Quota{&validNoLabels}}, v, df, ""},
+		{"missing descriptor", &aconfig.QuotasParams{Quotas: []*aconfig.QuotasParams_Quota{&missingDesc}}, v, df, "could not find a descriptor"},
+		{"failed type checking (bad expr)", &aconfig.QuotasParams{Quotas: []*aconfig.QuotasParams_Quota{&invalidExpr}}, v, df, "failed to parse expression"},
+		{"label eval'd type doesn't match desc", &aconfig.QuotasParams{Quotas: []*aconfig.QuotasParams_Quota{&wrongLabelType}}, v, df, "expected type STRING"},
+		{"wrong dimensions for metric", &aconfig.QuotasParams{Quotas: []*aconfig.QuotasParams_Quota{&extraLabel}}, v, df, "wrong dimensions"},
+		{"can't convert proto to adapter rep", &aconfig.QuotasParams{Quotas: []*aconfig.QuotasParams_Quota{&badDesc}}, v, df, "failed to marshal descriptor"},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			if errs := (&quotasManager{}).ValidateConfig(tt.cfg, tt.v, tt.df); errs != nil || tt.err != "" {
+				if tt.err == "" {
+					t.Fatalf("ValidateConfig(tt.cfg, tt.v, tt.df) = '%s', wanted no err", errs.Error())
+				} else if !strings.Contains(errs.Error(), tt.err) {
+					t.Fatalf("Expected errors containing the string '%s', actual: '%s'", tt.err, errs.Error())
+				}
+			}
+		})
 	}
 }
 
@@ -310,25 +425,6 @@ func TestQuotas_DescToDef(t *testing.T) {
 			}
 			if !reflect.DeepEqual(result, c.out) {
 				t.Errorf("quotaDefinitionFromProto(%v) = %v, %v; wanted %v", c.in, result, err, c.out)
-			}
-		})
-	}
-}
-
-func TestQuotas_Find(t *testing.T) {
-	cases := []struct {
-		in   []*aconfig.QuotasParams_Quota
-		find string
-		out  bool
-	}{
-		{[]*aconfig.QuotasParams_Quota{}, "", false},
-		{[]*aconfig.QuotasParams_Quota{{DescriptorName: "foo"}}, "foo", true},
-		{[]*aconfig.QuotasParams_Quota{{DescriptorName: "bar"}}, "foo", false},
-	}
-	for _, c := range cases {
-		t.Run(c.find, func(t *testing.T) {
-			if q := findQuota(c.in, c.find); (q != nil) != c.out {
-				t.Errorf("find(%v, %s) = _, %t; wanted %t", c.in, c.find, q != nil, c.out)
 			}
 		})
 	}

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -59,3 +59,8 @@ metrics:
       value_type: 1 # STRING
     - name: response_code
       value_type: 2 # INT64
+quotas:
+- name: RequestCount
+  max_amount: 5
+  expiration:
+    seconds: 1


### PR DESCRIPTION
Note that the `ValidateConfig` test is essentially identical to the metricManager's `ValidateConfig` test; I expect we can refactor out nearly 100% of the config validation logic into a common place and test it once there. I'll take a stab at that when I move to the next aspect on the list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/482)
<!-- Reviewable:end -->
