### PR TITLE
Extract common util for quota adapters.

### DIFF
--- a/adapter/memQuota/BUILD
+++ b/adapter/memQuota/BUILD
@@ -7,10 +7,10 @@ go_library(
     srcs = [
         "memQuota.go",
         "rollingWindow.go",
-        "util.go",
     ],
     deps = [
         "//adapter/memQuota/config:go_default_library",
+        "//adapter/memQuota/util:go_default_library",
         "//pkg/adapter:go_default_library",
         "//pkg/pool:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",

--- a/adapter/memQuota/BUILD
+++ b/adapter/memQuota/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "memQuota.go",
         "rollingWindow.go",
+        "util.go",
     ],
     deps = [
         "//adapter/memQuota/config:go_default_library",

--- a/adapter/memQuota/memQuota_test.go
+++ b/adapter/memQuota/memQuota_test.go
@@ -107,7 +107,7 @@ func TestAllocAndRelease(t *testing.T) {
 				Labels:          labels,
 			}
 
-			asp.getTime = func() time.Time {
+			asp.common.GetTime = func() time.Time {
 				return now.Add(time.Duration(c.seconds) * time.Second)
 			}
 
@@ -262,7 +262,7 @@ func TestReaper(t *testing.T) {
 	asp := a.(*memQuota)
 
 	now := time.Now()
-	asp.getTime = func() time.Time {
+	asp.common.GetTime = func() time.Time {
 		return now
 	}
 
@@ -289,7 +289,7 @@ func TestReaper(t *testing.T) {
 	}
 
 	// move current dedup state into old dedup state
-	asp.reapDedup()
+	asp.common.ReapDedup()
 
 	qa.DeduplicationID = "2"
 	qr, _ = asp.Alloc(qa)
@@ -298,7 +298,7 @@ func TestReaper(t *testing.T) {
 	}
 
 	// retire original dedup state
-	asp.reapDedup()
+	asp.common.ReapDedup()
 
 	qa.DeduplicationID = "0"
 	qr, _ = asp.Alloc(qa)

--- a/adapter/memQuota/util.go
+++ b/adapter/memQuota/util.go
@@ -1,0 +1,184 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memQuota
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/pool"
+)
+
+// QuotaUtil stores common information for in-memory and redis quota adapters
+type QuotaUtil struct {
+	sync.Mutex
+
+	// two ping-ponging maps of active dedup ids
+	RecentDedup map[string]DedupState
+	OldDedup    map[string]DedupState
+
+	// used for reaping dedup ids
+	Ticker *time.Ticker
+
+	// indirection to support fast deterministic tests
+	GetTime func() time.Time
+
+	Logger adapter.Logger
+}
+
+// DedupState maintains a dedup state
+type DedupState struct {
+	amount int64
+	exp    time.Time
+}
+
+// we maintain a pool of these for use by the makeKey function
+type keyWorkspace struct {
+	keys []string
+}
+
+// pool of reusable keyWorkspace structs
+var keyWorkspacePool = sync.Pool{New: func() interface{} { return &keyWorkspace{} }}
+
+type quotaFunc func(d *adapter.QuotaDefinition, key string, currentTime time.Time, currentTick int64) (int64, time.Time, time.Duration)
+
+// CommonWrapper is a wrapper function to generate useful quota info.
+func (qu *QuotaUtil) CommonWrapper(args adapter.QuotaArgs, qf quotaFunc) (int64, time.Duration, error) {
+	d := args.Definition
+	if args.QuotaAmount < 0 {
+		return 0, 0, fmt.Errorf("negative quota amount %d received", args.QuotaAmount)
+	}
+
+	if args.QuotaAmount == 0 {
+		return 0, 0, nil
+	}
+
+	key := MakeKey(args.Definition.Name, args.Labels)
+
+	qu.Lock()
+
+	currentTime := qu.GetTime()
+	currentTick := currentTime.UnixNano() / nanosPerTick
+
+	var amount int64
+	var t time.Time
+	var exp time.Duration
+
+	result, dup := qu.RecentDedup[args.DeduplicationID]
+	if !dup {
+		result, dup = qu.OldDedup[args.DeduplicationID]
+	}
+
+	if dup {
+		qu.Logger.Infof("Quota operation satisfied through deduplication: dedupID %v, amount %v", args.DeduplicationID, result.amount)
+		amount = result.amount
+		exp = result.exp.Sub(currentTime)
+		if exp < 0 {
+			exp = 0
+		}
+	} else {
+		amount, t, exp = qf(d, key, currentTime, currentTick)
+		qu.RecentDedup[args.DeduplicationID] = DedupState{amount: amount, exp: t}
+	}
+
+	qu.Unlock()
+
+	return amount, exp, nil
+}
+
+// ReapDedup cleans up dedup entries from the oldDedup map and moves all entries from
+// the recentDedup map into the oldDedup map, making those next in line for deletion.
+//
+// This is normally called on a regular basis via a go routine. It's also used directly
+// from tests to inject specific behaviors.
+func (qu *QuotaUtil) ReapDedup() {
+	t := qu.OldDedup
+	qu.OldDedup = qu.RecentDedup
+	qu.RecentDedup = t
+
+	qu.Logger.Infof("Running repear to reclaim %d old deduplication entries", len(t))
+
+	// TODO: why isn't there a O(1) way to clear a map to the empty state?!
+	for k := range t {
+		delete(t, k)
+	}
+}
+
+// MakeKey produces a unique key representing the given labels.
+func MakeKey(name string, labels map[string]interface{}) string {
+	ws := keyWorkspacePool.Get().(*keyWorkspace)
+	keys := ws.keys
+	buf := pool.GetBuffer()
+
+	// ensure stable order
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf.WriteString(name)
+	for _, k := range keys {
+		buf.WriteString(";")
+		buf.WriteString(k)
+		buf.WriteString("=")
+
+		switch v := labels[k].(type) {
+		case string:
+			buf.WriteString(v)
+		case int64:
+			var bytes [32]byte
+			buf.Write(strconv.AppendInt(bytes[:], v, 16))
+		case float64:
+			var bytes [32]byte
+			buf.Write(strconv.AppendFloat(bytes[:], v, 'b', -1, 64))
+		case bool:
+			var bytes [32]byte
+			buf.Write(strconv.AppendBool(bytes[:], v))
+		case []byte:
+			buf.Write(v)
+		case map[string]string:
+			ws := keyWorkspacePool.Get().(*keyWorkspace)
+			mk := ws.keys
+
+			// ensure stable order
+			for k2 := range v {
+				mk = append(mk, k2)
+			}
+			sort.Strings(mk)
+
+			for _, k2 := range mk {
+				buf.WriteString(k2)
+				buf.WriteString(v[k2])
+			}
+
+			ws.keys = keys[:0]
+			keyWorkspacePool.Put(ws)
+		default:
+			buf.WriteString(v.(fmt.Stringer).String())
+		}
+	}
+
+	result := buf.String()
+
+	pool.PutBuffer(buf)
+	ws.keys = keys[:0]
+	keyWorkspacePool.Put(ws)
+
+	return result
+}

--- a/adapter/memQuota/util/BUILD
+++ b/adapter/memQuota/util/BUILD
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "util.go",
+    ],
+    deps = [
+        "//pkg/adapter:go_default_library",
+        "//pkg/pool:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+    ],
+)

--- a/adapter/memQuota/util/util.go
+++ b/adapter/memQuota/util/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memQuota
+package util
 
 import (
 	"fmt"
@@ -53,6 +53,14 @@ type keyWorkspace struct {
 	keys []string
 }
 
+const (
+	// TicksPerSecond determines the number of quantized time intervals in 1 second.
+	TicksPerSecond = 10
+
+	// NanosPerTick is equal to ns/tick
+	NanosPerTick = int64(time.Second / TicksPerSecond)
+)
+
 // pool of reusable keyWorkspace structs
 var keyWorkspacePool = sync.Pool{New: func() interface{} { return &keyWorkspace{} }}
 
@@ -74,7 +82,7 @@ func (qu *QuotaUtil) CommonWrapper(args adapter.QuotaArgs, qf quotaFunc) (int64,
 	qu.Lock()
 
 	currentTime := qu.GetTime()
-	currentTick := currentTime.UnixNano() / nanosPerTick
+	currentTick := currentTime.UnixNano() / NanosPerTick
 
 	var amount int64
 	var t time.Time

--- a/adapter/redisquota/BUILD
+++ b/adapter/redisquota/BUILD
@@ -9,6 +9,7 @@ go_library(
         "redisquota.go",
     ],
     deps = [
+        "//adapter/memQuota:go_default_library",
         "//adapter/redisquota/config:go_default_library",
         "//pkg/adapter:go_default_library",
         "//pkg/pool:go_default_library",

--- a/adapter/redisquota/BUILD
+++ b/adapter/redisquota/BUILD
@@ -9,7 +9,7 @@ go_library(
         "redisquota.go",
     ],
     deps = [
-        "//adapter/memQuota:go_default_library",
+        "//adapter/memQuota/util:go_default_library",
         "//adapter/redisquota/config:go_default_library",
         "//pkg/adapter:go_default_library",
         "//pkg/pool:go_default_library",

--- a/adapter/redisquota/redisquota.go
+++ b/adapter/redisquota/redisquota.go
@@ -17,58 +17,24 @@
 package redisquota
 
 import (
-	"fmt"
-	"sort"
-	"strconv"
-	"sync"
 	"time"
 
 	ptypes "github.com/gogo/protobuf/types"
 
+	"istio.io/mixer/adapter/memQuota"
 	"istio.io/mixer/adapter/redisquota/config"
 	"istio.io/mixer/pkg/adapter"
-	"istio.io/mixer/pkg/pool"
 )
 
 type builder struct{ adapter.DefaultBuilder }
 
 type redisQuota struct {
-	sync.Mutex
-
-	// the definitions we know about, immutable
-	definitions map[string]*adapter.QuotaDefinition
-
-	// the counters we track for non-expiring quotas, protected by lock
-	cells map[string]int64
+	// common info among different quota adapters
+	common memQuota.QuotaUtil
 
 	// connection pool with redis
 	redisPool *connPool
-
-	// two ping-ponging maps of active dedup ids
-	recentDedup map[string]dedupState
-	oldDedup    map[string]dedupState
-
-	// used for reaping dedup ids
-	ticker *time.Ticker
-
-	// indirection to support fast deterministic tests
-	getTime func() time.Time
-
-	logger adapter.Logger
 }
-
-type dedupState struct {
-	amount int64
-	exp    time.Time
-}
-
-// we maintain a pool of these for use by the makeKey function
-type keyWorkspace struct {
-	keys []string
-}
-
-// pool of reusable keyWorkspace structs
-var keyWorkspacePool = sync.Pool{New: func() interface{} { return &keyWorkspace{} }}
 
 var (
 	name = "redisQuota"
@@ -79,15 +45,6 @@ var (
 		SocketType:               "tcp",
 		ConnectionPoolSize:       10,
 	}
-)
-
-const (
-	// Time is abstracted in terms of ticks, provided by the caller, decoupling the
-	// implementation from real-time, enabling much easier testing and more flexibility.
-	ticksPerSecond = 10
-
-	// ns/tick
-	nanosPerTick = int64(time.Second / ticksPerSecond)
 )
 
 // Register records the builders exposed by this adapter.
@@ -121,31 +78,32 @@ func (builder) ValidateConfig(cfg adapter.Config) (ce *adapter.ConfigErrors) {
 }
 
 func (builder) NewQuotasAspect(env adapter.Env, c adapter.Config, d map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
-	return newAspect(env, c.(*config.Params), d)
+	return newAspect(env, c.(*config.Params))
 }
 
 // newAspect returns a new aspect.
-func newAspect(env adapter.Env, c *config.Params, definitions map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+func newAspect(env adapter.Env, c *config.Params) (adapter.QuotasAspect, error) {
 	dedupWindow, _ := ptypes.DurationFromProto(c.MinDeduplicationDuration)
 
-	return newAspectWithDedup(env, time.NewTicker(dedupWindow), c, definitions)
+	return newAspectWithDedup(env, time.NewTicker(dedupWindow), c)
 }
 
 // newAspectWithDedup returns a new aspect.
-func newAspectWithDedup(env adapter.Env, ticker *time.Ticker, c *config.Params, definitions map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+func newAspectWithDedup(env adapter.Env, ticker *time.Ticker, c *config.Params) (adapter.QuotasAspect, error) {
 	connPool, err := newConnPool(c.RedisServerUrl, c.SocketType, c.ConnectionPoolSize)
 	if err != nil {
 		// TODO: propagate Connection Pool error here
 		return nil, err
 	}
 	rq := &redisQuota{
-		definitions: definitions,
-		cells:       make(map[string]int64),
-		redisPool:   connPool,
-		recentDedup: make(map[string]dedupState),
-		oldDedup:    make(map[string]dedupState),
-		ticker:      ticker,
-		logger:      env.Logger(),
+		common: memQuota.QuotaUtil{
+			RecentDedup: make(map[string]memQuota.DedupState),
+			OldDedup:    make(map[string]memQuota.DedupState),
+			Ticker:      ticker,
+			GetTime:     time.Now,
+			Logger:      env.Logger(),
+		},
+		redisPool: connPool,
 	}
 	return rq, nil
 }
@@ -159,7 +117,7 @@ func (rq *redisQuota) AllocBestEffort(args adapter.QuotaArgs) (adapter.QuotaResu
 }
 
 func (rq *redisQuota) alloc(args adapter.QuotaArgs, bestEffort bool) (adapter.QuotaResult, error) {
-	amount, exp, err := rq.commonWrapper(args, func(d *adapter.QuotaDefinition, key string, currentTime time.Time, currentTick int64) (int64, time.Time,
+	amount, exp, err := rq.common.CommonWrapper(args, func(d *adapter.QuotaDefinition, key string, currentTime time.Time, currentTick int64) (int64, time.Time,
 		time.Duration) {
 		result := args.QuotaAmount
 		conn, _ := rq.redisPool.get()
@@ -199,7 +157,7 @@ func (rq *redisQuota) alloc(args adapter.QuotaArgs, bestEffort bool) (adapter.Qu
 }
 
 func (rq *redisQuota) ReleaseBestEffort(args adapter.QuotaArgs) (int64, error) {
-	amount, _, err := rq.commonWrapper(args,
+	amount, _, err := rq.common.CommonWrapper(args,
 		func(d *adapter.QuotaDefinition, key string, currentTime time.Time, currentTick int64) (int64, time.Time, time.Duration) {
 			result := args.QuotaAmount
 			conn, _ := rq.redisPool.get()
@@ -212,7 +170,6 @@ func (rq *redisQuota) ReleaseBestEffort(args adapter.QuotaArgs) (int64, error) {
 			// decrease the value of this key by the amount of result
 			conn.pipeAppend("DECRBY", key, result)
 			resp, _ := conn.pipeResponse()
-			// TODO: propagate Connection Pool error here
 			// TODO: propagate Connection Pool error here
 			// if err != nil {
 			// 	return 0, time.Time{}, 0
@@ -235,113 +192,4 @@ func (rq *redisQuota) ReleaseBestEffort(args adapter.QuotaArgs) (int64, error) {
 func (rq *redisQuota) Close() error {
 	rq.redisPool.empty()
 	return nil
-}
-
-type quotaFunc func(d *adapter.QuotaDefinition, key string, currentTime time.Time, currentTick int64) (int64, time.Time, time.Duration)
-
-// TODO: extract the common code below between memQuota and redisQuota into a util-like package, need to figure out where to put the package?
-func (rq *redisQuota) commonWrapper(args adapter.QuotaArgs, qf quotaFunc) (int64, time.Duration, error) {
-	d := args.Definition
-	if args.QuotaAmount < 0 {
-		return 0, 0, fmt.Errorf("negative quota amount %d received", args.QuotaAmount)
-	}
-
-	if args.QuotaAmount == 0 {
-		return 0, 0, nil
-	}
-
-	key := makeKey(args.Definition.Name, args.Labels)
-
-	rq.Lock()
-
-	currentTime := rq.getTime()
-	currentTick := currentTime.UnixNano() / nanosPerTick
-
-	var amount int64
-	var t time.Time
-	var exp time.Duration
-
-	result, dup := rq.recentDedup[args.DeduplicationID]
-	if !dup {
-		result, dup = rq.oldDedup[args.DeduplicationID]
-	}
-
-	if dup {
-		rq.logger.Infof("Quota operation satisfied through deduplication: dedupID %v, amount %v", args.DeduplicationID, result.amount)
-		amount = result.amount
-		exp = result.exp.Sub(currentTime)
-		if exp < 0 {
-			exp = 0
-		}
-	} else {
-		amount, t, exp = qf(d, key, currentTime, currentTick)
-		rq.recentDedup[args.DeduplicationID] = dedupState{amount: amount, exp: t}
-	}
-
-	rq.Unlock()
-
-	return amount, exp, nil
-}
-
-// Produce a unique key representing the given labels.
-func makeKey(name string, labels map[string]interface{}) string {
-	ws := keyWorkspacePool.Get().(*keyWorkspace)
-	keys := ws.keys
-	buf := pool.GetBuffer()
-
-	// ensure stable order
-	for k := range labels {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	buf.WriteString(name)
-	for _, k := range keys {
-		buf.WriteString(";")
-		buf.WriteString(k)
-		buf.WriteString("=")
-
-		switch v := labels[k].(type) {
-		case string:
-			buf.WriteString(v)
-		case int64:
-			var bytes [32]byte
-			buf.Write(strconv.AppendInt(bytes[:], v, 16))
-		case float64:
-			var bytes [32]byte
-			buf.Write(strconv.AppendFloat(bytes[:], v, 'b', -1, 64))
-		case bool:
-			var bytes [32]byte
-			buf.Write(strconv.AppendBool(bytes[:], v))
-		case []byte:
-			buf.Write(v)
-		case map[string]string:
-			ws := keyWorkspacePool.Get().(*keyWorkspace)
-			mk := ws.keys
-
-			// ensure stable order
-			for k2 := range v {
-				mk = append(mk, k2)
-			}
-			sort.Strings(mk)
-
-			for _, k2 := range mk {
-				buf.WriteString(k2)
-				buf.WriteString(v[k2])
-			}
-
-			ws.keys = keys[:0]
-			keyWorkspacePool.Put(ws)
-		default:
-			buf.WriteString(v.(fmt.Stringer).String())
-		}
-	}
-
-	result := buf.String()
-
-	pool.PutBuffer(buf)
-	ws.keys = keys[:0]
-	keyWorkspacePool.Put(ws)
-
-	return result
 }

--- a/adapter/redisquota/redisquota_test.go
+++ b/adapter/redisquota/redisquota_test.go
@@ -95,7 +95,7 @@ func TestAllocAndRelease(t *testing.T) {
 				Labels:          labels,
 			}
 
-			asp.getTime = func() time.Time {
+			asp.common.GetTime = func() time.Time {
 				return now.Add(time.Duration(c.seconds) * time.Second)
 			}
 

--- a/adapter/redisquota/redisquota_test.go
+++ b/adapter/redisquota/redisquota_test.go
@@ -74,6 +74,7 @@ func TestAllocAndRelease(t *testing.T) {
 		{"Q1", "5", 0, 0, true, 0, 0, 0, 0},
 		{"Q1", "5b", 0, 0, false, 0, 0, 5, 5},
 		{"Q1", "5b", 0, 0, false, 0, 0, 5, 5},
+		{"Q1", "5c", 0, 0, false, 0, 0, 15, 5},
 	}
 
 	labels := make(map[string]interface{})


### PR DESCRIPTION
To remove duplication between memQuota and redisQuota, extracted a util file inside memQuota dir. And redisQuota can call the methods in util.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/484)
<!-- Reviewable:end -->
