### PR TITLE
Implement the attribute.Tracker.ApplyBag method.

### DIFF
--- a/cmd/client/cmd/BUILD
+++ b/cmd/client/cmd/BUILD
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//cmd:__subpackages__"],
     deps = [
         "//cmd/shared:go_default_library",
+        "//pkg/attribute:go_default_library",
         "//pkg/tracing:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_glog//:go_default_library",

--- a/cmd/client/cmd/check.go
+++ b/cmd/client/cmd/check.go
@@ -72,7 +72,8 @@ func check(rootArgs *rootArgs, printf, fatalf shared.FormatFn) {
 			fatalf("Failed to receive a response from Check RPC: %v", err)
 		}
 
-		printf("Check RPC returned %s\n", decodeStatus(response.Result))
+		printf("Check RPC returned %s", decodeStatus(response.Result))
+		dumpAttributes(printf, fatalf, response.AttributeUpdate)
 	}
 
 	if err = stream.CloseSend(); err != nil {

--- a/cmd/client/cmd/quota.go
+++ b/cmd/client/cmd/quota.go
@@ -92,10 +92,11 @@ func quota(rootArgs *rootArgs, printf, fatalf shared.FormatFn, name string, dedu
 			fatalf("Failed to receive a response from Quota RPC: %v", err)
 		}
 
-		printf("Quota RPC returned %s, amount %v, expiration %v\n",
+		printf("Quota RPC returned %s, amount %v, expiration %v",
 			decodeStatus(response.Result),
 			response.Amount,
 			response.Expiration)
+		dumpAttributes(printf, fatalf, response.AttributeUpdate)
 	}
 
 	if err = stream.CloseSend(); err != nil {

--- a/cmd/client/cmd/report.go
+++ b/cmd/client/cmd/report.go
@@ -72,7 +72,8 @@ func report(rootArgs *rootArgs, printf, fatalf shared.FormatFn) {
 			fatalf("Failed to receive a response from Report RPC: %v", err)
 		}
 
-		printf("Report RPC returned %s\n", decodeStatus(response.Result))
+		printf("Report RPC returned %s", decodeStatus(response.Result))
+		dumpAttributes(printf, fatalf, response.AttributeUpdate)
 	}
 
 	if err = stream.CloseSend(); err != nil {

--- a/cmd/client/cmd/util.go
+++ b/cmd/client/cmd/util.go
@@ -209,7 +209,10 @@ func parseAttributes(rootArgs *rootArgs) (*mixerpb.Attributes, error) {
 	}
 
 	var attrs mixerpb.Attributes
-	attribute.NewManager().NewTracker().ApplyBag(b, 0, &attrs)
+	if err := attribute.NewManager().NewTracker().ApplyBag(b, 0, &attrs); err != nil {
+		return nil, err
+	}
+
 	return &attrs, nil
 }
 

--- a/cmd/client/cmd/util.go
+++ b/cmd/client/cmd/util.go
@@ -15,10 +15,13 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	rpc "github.com/googleapis/googleapis/google/rpc"
@@ -26,6 +29,8 @@ import (
 	"google.golang.org/grpc"
 
 	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/mixer/cmd/shared"
+	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/tracing"
 )
 
@@ -111,45 +116,41 @@ func parseStringMap(s string) (interface{}, error) {
 		v := pair[colon+1:]
 		m[k] = v
 	}
+
 	return m, nil
 }
 
-// add to dictionary
-func add2Dict(dictionary map[int32]string, s string) int32 {
-	// linear search to see if this string is already in the dictionary
-	for k, v := range dictionary {
-		if v == s {
-			return k
-		}
+func parseAny(s string) (interface{}, error) {
+	// auto-sense the type of attributes based on being able to parse the value
+	if val, err := parseInt64(s); err == nil {
+		return val, nil
+	} else if val, err := parseFloat64(s); err == nil {
+		return val, nil
+	} else if val, err := parseBool(s); err == nil {
+		return val, nil
+	} else if val, err := parseTime(s); err == nil {
+		return val, nil
+	} else if val, err := parseDuration(s); err == nil {
+		return val, nil
+	} else if val, err := parseBytes(s); err == nil {
+		return val, nil
+	} else if val, err := parseStringMap(s); err == nil {
+		return val, nil
 	}
-
-	index := int32(len(dictionary))
-	dictionary[index] = s
-	return index
-}
-
-func makeStringMap(dictionary map[int32]string, m map[string]string) mixerpb.StringMap {
-	sm := mixerpb.StringMap{Map: make(map[int32]string)}
-
-	for k, v := range m {
-		sm.Map[add2Dict(dictionary, k)] = v
-	}
-
-	return sm
+	return s, nil
 }
 
 type convertFn func(string) (interface{}, error)
 
-func process(dictionary map[int32]string, s string, f convertFn) (map[int32]interface{}, error) {
-	m := make(map[int32]interface{})
+func process(b *attribute.MutableBag, s string, f convertFn) error {
 	if len(s) > 0 {
 		for _, seg := range strings.Split(s, ",") {
 			eq := strings.Index(seg, "=")
 			if eq < 0 {
-				return nil, fmt.Errorf("attribute value %v does not include an = sign", seg)
+				return fmt.Errorf("attribute value %v does not include an = sign", seg)
 			}
 			if eq == 0 {
-				return nil, fmt.Errorf("attribute value %v does not contain a valid name", seg)
+				return fmt.Errorf("attribute value %v does not contain a valid name", seg)
 			}
 			name := seg[0:eq]
 			value := seg[eq+1:]
@@ -157,116 +158,58 @@ func process(dictionary map[int32]string, s string, f convertFn) (map[int32]inte
 			// convert
 			nv, err := f(value)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
 			// add to results
-			m[add2Dict(dictionary, name)] = nv
+			b.Set(name, nv)
 		}
 	}
 
-	return m, nil
+	return nil
 }
 
 func parseAttributes(rootArgs *rootArgs) (*mixerpb.Attributes, error) {
-	attrs := mixerpb.Attributes{}
-	attrs.Dictionary = make(map[int32]string)
-	attrs.StringAttributes = make(map[int32]string)
-	attrs.Int64Attributes = make(map[int32]int64)
-	attrs.DoubleAttributes = make(map[int32]float64)
-	attrs.BoolAttributes = make(map[int32]bool)
-	attrs.TimestampAttributes = make(map[int32]time.Time)
-	attrs.DurationAttributes = make(map[int32]time.Duration)
-	attrs.BytesAttributes = make(map[int32][]uint8)
-	attrs.StringMapAttributes = make(map[int32]mixerpb.StringMap)
+	b := attribute.GetMutableBag(nil)
 
-	// the following boilerplate would be more succinct with generics...
-
-	var m map[int32]interface{}
-	var err error
-
-	if m, err = process(attrs.Dictionary, rootArgs.stringAttributes, parseString); err != nil {
+	if err := process(b, rootArgs.stringAttributes, parseString); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.StringAttributes[k] = v.(string)
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.int64Attributes, parseInt64); err != nil {
+	if err := process(b, rootArgs.int64Attributes, parseInt64); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.Int64Attributes[k] = v.(int64)
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.doubleAttributes, parseFloat64); err != nil {
+	if err := process(b, rootArgs.doubleAttributes, parseFloat64); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.DoubleAttributes[k] = v.(float64)
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.boolAttributes, parseBool); err != nil {
+	if err := process(b, rootArgs.boolAttributes, parseBool); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.BoolAttributes[k] = v.(bool)
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.timestampAttributes, parseTime); err != nil {
+	if err := process(b, rootArgs.timestampAttributes, parseTime); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.TimestampAttributes[k] = v.(time.Time)
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.durationAttributes, parseDuration); err != nil {
+	if err := process(b, rootArgs.durationAttributes, parseDuration); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.DurationAttributes[k] = v.(time.Duration)
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.bytesAttributes, parseBytes); err != nil {
+	if err := process(b, rootArgs.bytesAttributes, parseBytes); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.BytesAttributes[k] = v.([]uint8)
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.stringMapAttributes, parseStringMap); err != nil {
+	if err := process(b, rootArgs.stringMapAttributes, parseStringMap); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		attrs.StringMapAttributes[k] = makeStringMap(attrs.Dictionary, v.(map[string]string))
-	}
 
-	if m, err = process(attrs.Dictionary, rootArgs.attributes, parseString); err != nil {
+	if err := process(b, rootArgs.attributes, parseAny); err != nil {
 		return nil, err
 	}
-	for k, v := range m {
-		s := v.(string)
 
-		// auto-sense the type of attributes based on being able to parse the value
-		if val, err := parseInt64(s); err == nil {
-			attrs.Int64Attributes[k] = val.(int64)
-		} else if val, err := parseFloat64(s); err == nil {
-			attrs.DoubleAttributes[k] = val.(float64)
-		} else if val, err := parseBool(s); err == nil {
-			attrs.BoolAttributes[k] = val.(bool)
-		} else if val, err := parseTime(s); err == nil {
-			attrs.TimestampAttributes[k] = val.(time.Time)
-		} else if val, err := parseDuration(s); err == nil {
-			attrs.DurationAttributes[k] = val.(time.Duration)
-		} else if val, err := parseBytes(s); err == nil {
-			attrs.BytesAttributes[k] = val.([]uint8)
-		} else if val, err := parseStringMap(s); err == nil {
-			attrs.StringMapAttributes[k] = makeStringMap(attrs.Dictionary, val.(map[string]string))
-		} else {
-			attrs.StringAttributes[k] = s
-		}
-	}
-
+	var attrs mixerpb.Attributes
+	attribute.NewManager().NewTracker().ApplyBag(b, 0, &attrs)
 	return &attrs, nil
 }
 
@@ -281,4 +224,35 @@ func decodeStatus(status rpc.Status) string {
 	}
 
 	return result
+}
+
+func dumpAttributes(printf, fatalf shared.FormatFn, attrs *mixerpb.Attributes) {
+	if attrs == nil {
+		return
+	}
+
+	b, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
+	if err != nil {
+		fatalf(fmt.Sprintf("  Unable to decode returned attributes: %v", err))
+	}
+
+	names := b.Names()
+	if len(names) == 0 {
+		return
+	}
+
+	sort.Strings(names)
+
+	buf := bytes.Buffer{}
+	tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+
+	fmt.Fprint(tw, "  Attribute\tType\tValue\n")
+
+	for _, name := range names {
+		v, _ := b.Get(name)
+		fmt.Fprintf(tw, "  %s\t%T\t%v\n", name, v, v)
+	}
+
+	_ = tw.Flush()
+	printf("%s", buf.String())
 }

--- a/cmd/client/cmd/util_test.go
+++ b/cmd/client/cmd/util_test.go
@@ -46,7 +46,7 @@ func TestAttributeHandling(t *testing.T) {
 	tracker := attribute.NewManager().NewTracker()
 
 	var b attribute.Bag
-	if b, err = tracker.ApplyRequestAttributes(a); err != nil {
+	if b, err = tracker.ApplyProto(a); err != nil {
 		t.Errorf("Expected to start request, got failure %v", err)
 	}
 

--- a/cmd/collateral/cmd/root.go
+++ b/cmd/collateral/cmd/root.go
@@ -58,7 +58,7 @@ func work(printf, fatalf shared.FormatFn, outputDir string) {
 		mixs.GetRootCmd(nil, nil, nil),
 	}
 
-	printf("Outputting Mixer CLI collateral files to %s\n", outputDir)
+	printf("Outputting Mixer CLI collateral files to %s", outputDir)
 	for _, r := range roots {
 		hdr := doc.GenManHeader{
 			Title:   "Istio Mixer",

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -145,14 +145,12 @@ func TestCheck(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {
 		t.Fatalf("Unable to prep test state: %v", err)
-		return
 	}
 	defer ts.cleanupTestState()
 
 	stream, err := ts.client.Check(context.Background())
 	if err != nil {
 		t.Fatalf("Check failed %v", err)
-		return
 	}
 
 	waitc := make(chan int64)
@@ -204,14 +202,12 @@ func TestReport(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {
 		t.Fatalf("Unable to prep test state: %v", err)
-		return
 	}
 	defer ts.cleanupTestState()
 
 	stream, err := ts.client.Report(context.Background())
 	if err != nil {
 		t.Fatalf("Report failed %v", err)
-		return
 	}
 
 	waitc := make(chan int64)
@@ -263,14 +259,12 @@ func TestQuota(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {
 		t.Fatalf("Unable to prep test state: %v", err)
-		return
 	}
 	defer ts.cleanupTestState()
 
 	stream, err := ts.client.Quota(context.Background())
 	if err != nil {
 		t.Fatalf("Quota failed %v", err)
-		return
 	}
 
 	waitc := make(chan *mixerpb.QuotaResponse)
@@ -327,14 +321,12 @@ func TestOverload(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {
 		t.Fatalf("Unable to prep test state: %v", err)
-		return
 	}
 	defer ts.cleanupTestState()
 
 	stream, err := ts.client.Report(context.Background())
 	if err != nil {
 		t.Fatalf("Report failed %v", err)
-		return
 	}
 
 	const numMessages = 16384
@@ -384,14 +376,12 @@ func TestBadAttr(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {
 		t.Fatalf("Unable to prep test state: %v", err)
-		return
 	}
 	defer ts.cleanupTestState()
 
 	stream, err := ts.client.Report(context.Background())
 	if err != nil {
 		t.Fatalf("Report failed %v", err)
-		return
 	}
 
 	attrs := mixerpb.Attributes{
@@ -442,14 +432,12 @@ func TestRudeClose(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {
 		t.Fatalf("Unable to prep test state: %v", err)
-		return
 	}
 	defer ts.cleanupTestState()
 
 	stream, err := ts.client.Report(context.Background())
 	if err != nil {
 		t.Fatalf("Report failed %v", err)
-		return
 	}
 
 	request := mixerpb.ReportRequest{}
@@ -503,7 +491,6 @@ func TestBadBag(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {
 		t.Fatalf("Unable to prep test state: %v", err)
-		return
 	}
 	defer ts.cleanupTestState()
 
@@ -522,7 +509,6 @@ func TestBadBag(t *testing.T) {
 	stream, err := ts.client.Report(context.Background())
 	if err != nil {
 		t.Fatalf("Report failed %v", err)
-		return
 	}
 
 	request := mixerpb.ReportRequest{}

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -57,7 +57,7 @@ func TestBag(t *testing.T) {
 	at := am.NewTracker()
 	defer at.Done()
 
-	ab, err := at.ApplyRequestAttributes(&attrs)
+	ab, err := at.ApplyProto(&attrs)
 	if err != nil {
 		t.Errorf("Unable to start request: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestBadStringMapKey(t *testing.T) {
 	at := am.NewTracker()
 	defer at.Done()
 
-	_, err := at.ApplyRequestAttributes(&attr)
+	_, err := at.ApplyProto(&attr)
 	if err == nil {
 		t.Error("Successfully updated attributes, expected an error")
 	}

--- a/pkg/attribute/manager.go
+++ b/pkg/attribute/manager.go
@@ -16,46 +16,32 @@
 //
 // Attributes are name/value pairs providing metadata about an operation.
 // In the Istio system, the proxy supplies a potentially large number of
-// attributes to the mixer for every request.
+// attributes to the mixer for every request and the mixer sends a
+// modest number of attributes back to the proxy with its responses.
 //
 // There is an 'attribute protocol' between the proxy and the mixer which
 // this package implements.
 //
 // The general use of this package is that there is a single Manager instance
 // created for the mixer as a whole. Each incoming gRPC stream uses the manager
-// to create a Tracker which is responsible for implementing the aforementioned
-// attribute protocol.
-//
-// The caller invokes the tracker for every incoming request and pushes into it
-// an Attributes proto. Doing so produces an attribute Bag which holds the current
-// value of all known attributes.
+// to create a pair of Trackers which are each responsible for implementing
+// 1/2 of the aforementioned attribute protocol (one for the input side, one
+// for the output side)
 package attribute
 
-// Manager implements the attribute protocol for the mixer's API
-//
-// There is typically:
-//
-// * One Manager per mixer instance
-// * One Tracker per incoming gRPC streams to the mixer
-// * One Bag per attribute context created on individual gRPC streams
-type Manager interface {
-	// NewTracker returns a Tracker.
-	//
-	// This method is thread-safe
-	NewTracker() Tracker
-}
-
-type manager struct {
+// Manager provides support for attributes in the mixer.
+type Manager struct {
 	dictionaries dictionaries
 }
 
 // NewManager allocates a fresh Manager.
-//
-// There is typically a single Manager allocated per mixer.
-func NewManager() Manager {
-	return &manager{}
+func NewManager() *Manager {
+	return &Manager{}
 }
 
-func (am *manager) NewTracker() Tracker {
+// NewTracker returns a Tracker.
+//
+// This method is thread-safe
+func (am *Manager) NewTracker() Tracker {
 	return getTracker(&am.dictionaries)
 }

--- a/pkg/attribute/manager_test.go
+++ b/pkg/attribute/manager_test.go
@@ -333,7 +333,7 @@ func TestAttributeManager(t *testing.T) {
 	defer at.Done()
 
 	for i, c := range cases {
-		ab, err := at.ApplyRequestAttributes(&c.attrs)
+		ab, err := at.ApplyProto(&c.attrs)
 		if (err == nil) != c.result {
 			if c.result {
 				t.Errorf("Expected ApplyRequestAttributes to succeed but it returned %v for test case %d", err, i)

--- a/pkg/attribute/tracker.go
+++ b/pkg/attribute/tracker.go
@@ -15,29 +15,33 @@
 package attribute
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
 	mixerpb "istio.io/api/mixer/v1"
 )
 
-// Tracker is responsible for tracking a set of live attributes over time.
+// Tracker is responsible for implementing the mixer's so-called attribute protocol.
 //
-// An instance of this type is created for every gRPC stream incoming to the
-// mixer. The instance tracks a current dictionary along with a set of
-// attribute contexts.
+// This tracks a set of attributes over time. The tracker keeps a current set of
+// attributes which can be mutated in one of two ways. The first way is by
+// applying an attribute proto using the ApplyProto method. The second way
+// is by applying a bag of attributes.
 type Tracker interface {
-	// ApplyRequestAttributes refreshes the set of input attributes tracked based on an incoming proto.
+	// ApplyProto refreshes the set of attributes based on an update proto.
 	//
-	// This returns a Bag that can be used to query and update the current
-	// set of attributes.
+	// This returns a Bag that reflects the current state of attribute context
+	// that the proto indicated.
 	//
 	// If this returns a non-nil error, it indicates there was a problem in the
 	// supplied Attributes proto. When this happens, none of the tracked attribute
 	// state will have been affected.
-	ApplyRequestAttributes(attrs *mixerpb.Attributes) (*MutableBag, error)
+	ApplyProto(attrs *mixerpb.Attributes) (*MutableBag, error)
 
-	// GetResponseAttributes refreshes the set of output attributes tracked for outgoing communication.
-	GetResponseAttributes(bag *MutableBag, output *mixerpb.Attributes)
+	// ApplyBag refreshes the tracked attributes with the content of the supplied bag and produces an
+	// output proto representing the change in state.
+	ApplyBag(bag *MutableBag, context int32, output *mixerpb.Attributes)
 
 	// Done indicates the tracker can be reclaimed.
 	Done()
@@ -46,17 +50,19 @@ type Tracker interface {
 type tracker struct {
 	dictionaries *dictionaries
 
-	// all active request (incoming) attribute contexts
-	requestContexts map[int32]*MutableBag
+	// all active attribute contexts
+	contexts map[int32]*MutableBag
 
-	// the current live request (incoming) dictionary
-	currentRequestDictionary dictionary
+	// the current live dictionary
+	currentDictionary dictionary
+
+	currentRevDictionary map[string]int32
 }
 
 var trackers = sync.Pool{
 	New: func() interface{} {
 		return &tracker{
-			requestContexts: make(map[int32]*MutableBag),
+			contexts: make(map[int32]*MutableBag),
 		}
 	},
 }
@@ -68,27 +74,28 @@ func getTracker(dictionaries *dictionaries) *tracker {
 }
 
 func (at *tracker) Done() {
-	for k, rb := range at.requestContexts {
-		rb.Done()
-		delete(at.requestContexts, k)
+	for k, b := range at.contexts {
+		b.Done()
+		delete(at.contexts, k)
 	}
 
-	at.dictionaries.Release(at.currentRequestDictionary)
-	at.currentRequestDictionary = nil
+	at.dictionaries.Release(at.currentDictionary)
+
+	at.currentDictionary = nil
 	at.dictionaries = nil
 
 	trackers.Put(at)
 }
 
-func (at *tracker) ApplyRequestAttributes(attrs *mixerpb.Attributes) (*MutableBag, error) {
+func (at *tracker) ApplyProto(attrs *mixerpb.Attributes) (*MutableBag, error) {
 	// find the context or create it if needed
-	mb := at.requestContexts[attrs.AttributeContext]
+	mb := at.contexts[attrs.AttributeContext]
 	if mb == nil {
 		mb = GetMutableBag(nil)
-		at.requestContexts[attrs.AttributeContext] = mb
+		at.contexts[attrs.AttributeContext] = mb
 	}
 
-	dict := at.currentRequestDictionary
+	dict := at.currentDictionary
 	if len(attrs.Dictionary) > 0 {
 		dict = attrs.Dictionary
 	}
@@ -99,13 +106,184 @@ func (at *tracker) ApplyRequestAttributes(attrs *mixerpb.Attributes) (*MutableBa
 
 	// remember any new dictionary for later
 	if len(attrs.Dictionary) > 0 {
-		at.dictionaries.Release(at.currentRequestDictionary)
-		at.currentRequestDictionary = at.dictionaries.Intern(attrs.Dictionary)
+		at.dictionaries.Release(at.currentDictionary)
+		at.currentDictionary = at.dictionaries.Intern(attrs.Dictionary)
+		at.currentRevDictionary = nil
 	}
 
 	return CopyBag(mb), nil
 }
 
-func (at *tracker) GetResponseAttributes(bag *MutableBag, output *mixerpb.Attributes) {
-	// TODO: fill in!
+func (at *tracker) ApplyBag(bag *MutableBag, context int32, output *mixerpb.Attributes) {
+	// TODO: this code has not been optimized for speed. For the moment, we just need
+	//       something that works reasonably well so we can evaluate usability and
+	//       general perf profile of the mixer API. Depending on what we find during
+	//       this evaluation, we might either simplify the attribute protocol, at which
+	//       point this code will need to be rewritten, or we'll keep the protocol at
+	//       which point we'll come back and optimize this code to avoid allocs.
+
+	output.AttributeContext = context
+	output.StringAttributes = make(map[int32]string)
+	output.Int64Attributes = make(map[int32]int64)
+	output.DoubleAttributes = make(map[int32]float64)
+	output.BoolAttributes = make(map[int32]bool)
+	output.TimestampAttributes = make(map[int32]time.Time)
+	output.DurationAttributes = make(map[int32]time.Duration)
+	output.BytesAttributes = make(map[int32][]uint8)
+	output.StringMapAttributes = make(map[int32]mixerpb.StringMap)
+	output.DeletedAttributes = make([]int32, 0)
+	output.ResetContext = false
+
+	// get the protocol-level bag
+	mb := at.contexts[context]
+	if mb == nil {
+		mb = GetMutableBag(nil)
+		at.contexts[context] = mb
+	}
+
+	// determine the set of attributes to delete
+	for attrName := range mb.values {
+		if _, ok := bag.Get(attrName); !ok {
+			index := at.getWordIndex(attrName)
+			output.DeletedAttributes = append(output.DeletedAttributes, index)
+		}
+	}
+
+	if len(output.DeletedAttributes) == len(mb.values) {
+		// everything is being deleted, so just reset the context
+		output.ResetContext = true
+		output.DeletedAttributes = nil
+	}
+
+	// determine the set of attributes to update
+	for _, attrName := range bag.Names() {
+		newValue, _ := bag.Get(attrName)
+		oldValue, _ := mb.Get(attrName)
+
+		if !compareAttributeValue(newValue, oldValue) {
+			mb.values[attrName] = newValue
+			index := at.getWordIndex(attrName)
+
+			switch t := newValue.(type) {
+			case string:
+				output.StringAttributes[index] = t
+			case int64:
+				output.Int64Attributes[index] = t
+			case float64:
+				output.DoubleAttributes[index] = t
+			case bool:
+				output.BoolAttributes[index] = t
+			case time.Time:
+				output.TimestampAttributes[index] = t
+			case time.Duration:
+				output.DurationAttributes[index] = t
+			case []byte:
+				output.BytesAttributes[index] = t
+			case map[string]string:
+				sm := make(map[int32]string, len(t))
+				for smk, smv := range t {
+					sm[at.getWordIndex(smk)] = smv
+				}
+				output.StringMapAttributes[index] = mixerpb.StringMap{Map: sm}
+			}
+		}
+	}
+
+	// if the reverse dictionary was updated, we need to update the protocol dictionary
+	if len(at.currentRevDictionary) != len(at.currentDictionary) {
+		newDict := make(dictionary, len(at.currentRevDictionary))
+		for word, index := range at.currentRevDictionary {
+			newDict[index] = word
+		}
+
+		at.currentDictionary = at.dictionaries.Intern(newDict)
+		output.Dictionary = at.currentDictionary
+	}
+}
+
+func (at *tracker) getWordIndex(newWord string) int32 {
+	if at.currentRevDictionary == nil {
+		// TODO: this should be interned and shared
+		at.currentRevDictionary = make(map[string]int32, len(at.currentDictionary))
+		for index, word := range at.currentDictionary {
+			at.currentRevDictionary[word] = index
+		}
+	}
+
+	index, ok := at.currentRevDictionary[newWord]
+	if !ok {
+		index = int32(len(at.currentRevDictionary))
+		at.currentRevDictionary[newWord] = index
+	}
+
+	return index
+}
+
+func compareAttributeValue(v1, v2 interface{}) bool {
+	switch t1 := v1.(type) {
+	case string:
+		t2, ok := v2.(string)
+		if !ok || t1 != t2 {
+			return false
+		}
+	case int64:
+		t2, ok := v2.(int64)
+		if !ok || t1 != t2 {
+			return false
+		}
+	case float64:
+		t2, ok := v2.(float64)
+		if !ok || t1 != t2 {
+			return false
+		}
+	case bool:
+		t2, ok := v2.(bool)
+		if !ok || t1 != t2 {
+			return false
+		}
+	case time.Time:
+		t2, ok := v2.(time.Time)
+		if !ok || t1 != t2 {
+			return false
+		}
+	case time.Duration:
+		t2, ok := v2.(time.Duration)
+		if !ok || t1 != t2 {
+			return false
+		}
+	case []byte:
+		t2, ok := v2.([]byte)
+		if !ok {
+			return false
+		}
+
+		if len(t1) != len(t2) {
+			return false
+		}
+
+		for i := 0; i < len(t1); i++ {
+			if t1[i] != t2[i] {
+				return false
+			}
+		}
+	case map[string]string:
+		t2, ok := v2.(map[string]string)
+		if !ok {
+			return false
+		}
+
+		if len(t1) != len(t2) {
+			return false
+		}
+
+		for k, v := range t1 {
+			if v != t2[k] {
+				return false
+			}
+		}
+	default:
+		panic(fmt.Sprintf("Unsupported attribute value type: %T", v1))
+	}
+
+	return true
 }

--- a/pkg/attribute/tracker_test.go
+++ b/pkg/attribute/tracker_test.go
@@ -113,7 +113,9 @@ func TestTracker_ApplyRequestAttributes(t *testing.T) {
 
 	// make sure round-tripping works properly
 	var a mixerpb.Attributes
-	NewManager().NewTracker().ApplyBag(b1, 0, &a)
+	if err = NewManager().NewTracker().ApplyBag(b1, 0, &a); err != nil {
+		t.Errorf("Expecting success, got %v", err)
+	}
 	b2, err := NewManager().NewTracker().ApplyProto(&a)
 	if err != nil {
 		t.Errorf("Expecting success, got %v", err)
@@ -174,7 +176,9 @@ func TestTracker_GetResponseAttributes(t *testing.T) {
 
 func checkRoundtrip(t *testing.T, tracker Tracker, b *MutableBag) {
 	var attrs mixerpb.Attributes
-	tracker.ApplyBag(b, 0, &attrs)
+	if err := tracker.ApplyBag(b, 0, &attrs); err != nil {
+		t.Errorf("Expecting success, got %v", err)
+	}
 
 	o, err := tracker.ApplyProto(&attrs)
 	if err != nil {
@@ -198,7 +202,7 @@ func compareBags(b1 Bag, b2 Bag) bool {
 			return false
 		}
 
-		if !compareAttributeValue(v1, v2) {
+		if same, _ := compareAttributeValues(v1, v2); !same {
 			return false
 		}
 	}
@@ -207,11 +211,12 @@ func compareBags(b1 Bag, b2 Bag) bool {
 }
 
 func TestTracker_BadValue(t *testing.T) {
-	defer func() {
-		_ = recover()
-	}()
-
 	j := 0
-	compareAttributeValue(&j, &j)
-	t.Error("Expecting panic, got cool, calm, and collected")
+	same, err := compareAttributeValues(&j, &j)
+	if same {
+		t.Error("Expecting false, got true")
+	}
+	if err == nil {
+		t.Error("Expected error, got success")
+	}
 }

--- a/pkg/attribute/tracker_test.go
+++ b/pkg/attribute/tracker_test.go
@@ -66,7 +66,7 @@ func BenchmarkTracker(b *testing.B) {
 		t := am.NewTracker()
 
 		for _, a := range attrs {
-			b, _ := t.ApplyRequestAttributes(&a)
+			b, _ := t.ApplyProto(&a)
 
 			_, _ = b.Get("a")
 		}
@@ -106,31 +106,82 @@ func TestTracker_ApplyRequestAttributes(t *testing.T) {
 	}
 
 	tracker := NewManager().NewTracker().(*tracker)
-	_, err := tracker.ApplyRequestAttributes(&attr1)
+	b1, err := tracker.ApplyProto(&attr1)
 	if err != nil {
 		t.Errorf("Expecting success, got %v", err)
 	}
 
-	oldDict := tracker.currentRequestDictionary
-	oldBag := CopyBag(tracker.requestContexts[0])
+	// make sure round-tripping works properly
+	var a mixerpb.Attributes
+	NewManager().NewTracker().ApplyBag(b1, 0, &a)
+	b2, err := NewManager().NewTracker().ApplyProto(&a)
+	if err != nil {
+		t.Errorf("Expecting success, got %v", err)
+	}
+	if !compareBags(b1, b2) {
+		t.Error("Expecting attributes to roundtrip, they didn't")
+	}
 
-	_, err = tracker.ApplyRequestAttributes(&attr2)
+	oldDict := tracker.currentDictionary
+	oldBag := CopyBag(tracker.contexts[0])
+
+	_, err = tracker.ApplyProto(&attr2)
 	if err == nil {
 		t.Error("Expecting failure, got success")
 	}
 
 	// make sure nothing has changed due to the second failed attribute update
-	if !compareDictionaries(oldDict, tracker.currentRequestDictionary) {
+	if !compareDictionaries(oldDict, tracker.currentDictionary) {
 		t.Error("Expected dictionaries to be consistent, they're different")
 	}
 
-	if !compareBags(oldBag, tracker.requestContexts[0]) {
+	if !compareBags(oldBag, tracker.contexts[0]) {
 		t.Error("Expecting bags to be consistent, they're different")
 	}
 
 	cp := CopyBag(oldBag)
 	if !compareBags(oldBag, cp) {
 		t.Error("Expecting copied bag to match original")
+	}
+}
+
+func TestTracker_GetResponseAttributes(t *testing.T) {
+	tracker := NewManager().NewTracker()
+
+	b := GetMutableBag(nil)
+	b.Set("A", "B")
+	b.Set("E", []byte{0, 1})
+	b.Set("F", map[string]string{"X": "Y"})
+	checkRoundtrip(t, tracker, b)
+
+	b = GetMutableBag(nil)
+	b.Set("A", "B")
+	b.Set("C", "D")
+	b.Set("E", []byte{2, 3})
+	b.Set("F", map[string]string{"X": "Z"})
+	checkRoundtrip(t, tracker, b)
+
+	b = GetMutableBag(nil)
+	b.Set("E", []byte{2, 3, 4})
+	b.Set("F", map[string]string{"X": "Y", "Z": "ZZ"})
+	checkRoundtrip(t, tracker, b)
+
+	b = GetMutableBag(nil)
+	checkRoundtrip(t, tracker, b)
+
+	tracker.Done()
+}
+
+func checkRoundtrip(t *testing.T, tracker Tracker, b *MutableBag) {
+	var attrs mixerpb.Attributes
+	tracker.ApplyBag(b, 0, &attrs)
+
+	o, err := tracker.ApplyProto(&attrs)
+	if err != nil {
+		t.Errorf("Expecting success, got %v", err)
+	}
+	if !compareBags(b, o) {
+		t.Error("Expecting bags to match, they don't")
 	}
 }
 
@@ -147,69 +198,20 @@ func compareBags(b1 Bag, b2 Bag) bool {
 			return false
 		}
 
-		switch t1 := v1.(type) {
-		case string:
-			t2, ok := v2.(string)
-			if !ok || t1 != t2 {
-				return false
-			}
-		case int64:
-			t2, ok := v2.(int64)
-			if !ok || t1 != t2 {
-				return false
-			}
-		case float64:
-			t2, ok := v2.(float64)
-			if !ok || t1 != t2 {
-				return false
-			}
-		case bool:
-			t2, ok := v2.(bool)
-			if !ok || t1 != t2 {
-				return false
-			}
-		case time.Time:
-			t2, ok := v2.(time.Time)
-			if !ok || t1 != t2 {
-				return false
-			}
-		case time.Duration:
-			t2, ok := v2.(time.Duration)
-			if !ok || t1 != t2 {
-				return false
-			}
-		case []byte:
-			t2, ok := v2.([]byte)
-			if !ok {
-				return false
-			}
-
-			if len(t1) != len(t2) {
-				return false
-			}
-
-			for i := 0; i < len(t1); i++ {
-				if t1[i] != t2[i] {
-					return false
-				}
-			}
-		case map[string]string:
-			t2, ok := v2.(map[string]string)
-			if !ok {
-				return false
-			}
-
-			if len(t1) != len(t2) {
-				return false
-			}
-
-			for k, v := range t1 {
-				if v != t2[k] {
-					return false
-				}
-			}
+		if !compareAttributeValue(v1, v2) {
+			return false
 		}
 	}
 
 	return true
+}
+
+func TestTracker_BadValue(t *testing.T) {
+	defer func() {
+		_ = recover()
+	}()
+
+	j := 0
+	compareAttributeValue(&j, &j)
+	t.Error("Expecting panic, got cool, calm, and collected")
 }

--- a/pkg/tracing/attributes_test.go
+++ b/pkg/tracing/attributes_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func TestContext(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().ApplyRequestAttributes(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}
@@ -54,7 +54,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().ApplyRequestAttributes(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}
@@ -77,7 +77,7 @@ func TestSet(t *testing.T) {
 }
 
 func TestForeachKey(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().ApplyRequestAttributes(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}
@@ -106,7 +106,7 @@ func TestForeachKey(t *testing.T) {
 }
 
 func TestForeachKey_PropagatesErr(t *testing.T) {
-	bag, err := attribute.NewManager().NewTracker().ApplyRequestAttributes(attrs)
+	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
 		t.Errorf("Failed to construct bag with err: %s", err)
 	}


### PR DESCRIPTION
This implements the second half of the attribute protocol in the
mixer. The mixer can now both receive and send attributes using
the full dictionary/delta/context model.

This also removes the attribute.Manager interface type. This was
unnecessary, I added it when still getting a hang of Golang...

The mixc command is updated to take advantage of the new functionality
and to print any attributes that the mixer returns in a response.

Given this foundation, I'll setup a test environment to evaluate
API mixer perf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/485)
<!-- Reviewable:end -->
