### PR TITLE
Use bazel's go enviroment for running all tools

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-
 set -e
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+source $SCRIPTPATH/use_bazel_go.sh
+
+ROOTDIR=$SCRIPTPATH/..
+cd $ROOTDIR
+
 
 echo "Code coverage test"
 echo "" > coverage.txt

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -4,6 +4,8 @@
 
 set -e
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+source $SCRIPTPATH/use_bazel_go.sh
+
 ROOTDIR=$SCRIPTPATH/..
 cd $ROOTDIR
 

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -2,6 +2,12 @@
 
 # Runs all requisite linters over the whole mixer code base.
 set -e
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+source $SCRIPTPATH/use_bazel_go.sh
+
+ROOTDIR=$SCRIPTPATH/..
+cd $ROOTDIR
+
 
 PARENT_BRANCH=''
 

--- a/bin/perftest.sh
+++ b/bin/perftest.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
-
 set -e
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+source $SCRIPTPATH/use_bazel_go.sh
+
+ROOT=$SCRIPTPATH/..
+cd $ROOT
+
+
 echo "Perf test"
 DIRS="pkg/expr pkg/attribute"
 cd $ROOT

--- a/bin/racetest.sh
+++ b/bin/racetest.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
 set -e
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+source $SCRIPTPATH/use_bazel_go.sh
+
+ROOTDIR=$SCRIPTPATH/..
+cd $ROOTDIR
+
 
 echo "Race test"
 go test -race ./...

--- a/bin/use_bazel_go.sh
+++ b/bin/use_bazel_go.sh
@@ -1,0 +1,14 @@
+# This file should be sourced before using go commands
+# it ensures that bazel's version of go is used
+
+SP=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+BDIR=$(dirname $(dirname $(readlink $SP/../bazel-mixer )))
+
+export GOROOT=$(ls -1d $BDIR/external/golang_*)
+export PATH=$GOROOT/bin:$PATH
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "*** Calling ${BASH_SOURCE[0]} directly has no effect. It should be sourced."
+  echo "Using GOROOT: $GOROOT" 
+  go version
+fi


### PR DESCRIPTION
This PR ensures that all tools in the bin directory use bazel's version of go.

It creates uniformity between bazel build and tests like race, code coverage and perf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/496)
<!-- Reviewable:end -->
