### PR TITLE
Implement config validation for the application logger aspect.

### DIFF
--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -74,29 +74,11 @@ func newApplicationLogsManager() ReportManager {
 func (applicationLogsManager) NewReportExecutor(c *cpb.Combined, a adapter.Builder, env adapter.Env, df descriptor.Finder) (ReportExecutor, error) {
 	// TODO: look up actual descriptors by name and build an array
 	cfg := c.Aspect.Params.(*aconfig.ApplicationLogsParams)
-
-	desc := []*dpb.LogEntryDescriptor{
-		{
-			Name:        "default",
-			DisplayName: "Default Log Entry",
-			Description: "Placeholder log descriptor",
-		},
-	}
-
 	metadata := make(map[string]*logInfo)
-	for _, d := range desc {
-		l, found := findLog(cfg.Logs, d.Name)
-		if !found {
-			env.Logger().Warningf("No application log found for descriptor %s, skipping it", d.Name)
-			continue
-		}
-
-		// TODO: remove this error handling once validate config is given descriptors to validate
-		t, err := template.New(d.Name).Parse(d.LogTemplate)
-		if err != nil {
-			env.Logger().Warningf("log descriptors %s's template '%s' failed to parse with err: %s", d.Name, d.LogTemplate, err)
-		}
-
+	for _, l := range cfg.Logs {
+		// validation ensures both that the descriptor exists and that its template is parsable by the template library.
+		d := df.GetLog(l.DescriptorName)
+		t, _ := template.New(d.Name).Parse(d.LogTemplate)
 		metadata[d.Name] = &logInfo{
 			format:     payloadFormatFromProto(d.PayloadFormat),
 			severity:   l.Severity,
@@ -110,7 +92,7 @@ func (applicationLogsManager) NewReportExecutor(c *cpb.Combined, a adapter.Build
 
 	asp, err := a.(adapter.ApplicationLogsBuilder).NewApplicationLogsAspect(env, c.Builder.Params.(adapter.Config))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to construct application logs aspect with err: %v", err)
 	}
 
 	return &applicationLogsExecutor{
@@ -126,8 +108,35 @@ func (applicationLogsManager) DefaultConfig() config.AspectParams {
 }
 
 // TODO: validation of timestamp format
-func (applicationLogsManager) ValidateConfig(config.AspectParams, expr.Validator, descriptor.Finder) (ce *adapter.ConfigErrors) {
-	return nil
+func (applicationLogsManager) ValidateConfig(c config.AspectParams, v expr.Validator, df descriptor.Finder) (ce *adapter.ConfigErrors) {
+	cfg := c.(*aconfig.ApplicationLogsParams)
+	if cfg.LogName == "" {
+		ce = ce.Appendf("LogName", "no log name provided")
+	}
+
+	for _, log := range cfg.Logs {
+		desc := df.GetLog(log.DescriptorName)
+		if desc == nil {
+			ce = ce.Appendf("Logs", "could not find a descriptor for the log '%s'", log.DescriptorName)
+			continue // we can't do any other validation without the descriptor
+		}
+
+		if err := v.AssertType(log.Severity, df, dpb.STRING); err != nil {
+			ce = ce.Appendf(fmt.Sprintf("Logs[%s].Severity", log.DescriptorName), "failed type checking with err: %v", err)
+		}
+		if err := v.AssertType(log.Timestamp, df, dpb.TIMESTAMP); err != nil {
+			ce = ce.Appendf(fmt.Sprintf("Logs[%s].Timestamp", log.DescriptorName), "failed type checking with err: %v", err)
+		}
+		ce = ce.Extend(validateLabels(fmt.Sprintf("Logs[%s].Labels", log.DescriptorName), log.Labels, desc.Labels, v, df))
+
+		// TODO: how do we validate the log.TemplateExpressions against desc.LogTemplate? We can't just `Execute` the template
+		// against the expressions: while the keys to the template may be correct, the values will be wrong which could result
+		// in non-nil error returns even when things would be valid at runtime.
+		if _, err := template.New(desc.Name).Parse(desc.LogTemplate); err != nil {
+			ce = ce.Appendf(fmt.Sprintf("LogDescriptor[%s].LogTemplate", desc.Name), "failed to parse template with err: %v", err)
+		}
+	}
+	return
 }
 
 func (e *applicationLogsExecutor) Close() error { return e.aspect.Close() }
@@ -209,15 +218,6 @@ func (e *applicationLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evalu
 		return status.WithError(err)
 	}
 	return status.OK
-}
-
-func findLog(defs []*aconfig.ApplicationLogsParams_ApplicationLog, name string) (*aconfig.ApplicationLogsParams_ApplicationLog, bool) {
-	for _, def := range defs {
-		if def.DescriptorName == name {
-			return def, true
-		}
-	}
-	return nil, false
 }
 
 func payloadFormatFromProto(format dpb.LogEntryDescriptor_PayloadFormat) PayloadFormat {


### PR DESCRIPTION
I'm not sure how we want to validate template expressions against a descriptor's log template: we can't just take the `map[string]string` the user gave us and `Execute` the template with it in general. Templates can contain function calls, e.g. `time.Format`, that will fail if the value being `Execute`d for a template's label is of the wrong golang type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/499)
<!-- Reviewable:end -->
