### PR TITLE
Implement config validation for access logs, and implement use of descriptors

### DIFF
--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -78,7 +78,7 @@ func (accessLogsManager) Kind() config.Kind { return config.AccessLogsKind }
 func (accessLogsManager) DefaultConfig() config.AspectParams {
 	return &aconfig.AccessLogsParams{
 		LogName: "access_log",
-		Log: &aconfig.AccessLogsParams_AccessLog{
+		Log: aconfig.AccessLogsParams_AccessLog{
 			DescriptorName: "common",
 		},
 	}
@@ -88,10 +88,6 @@ func (accessLogsManager) ValidateConfig(c config.AspectParams, v expr.Validator,
 	cfg := c.(*aconfig.AccessLogsParams)
 	if cfg.LogName == "" {
 		ce = ce.Appendf("LogName", "no log name provided")
-	}
-	if cfg.Log == nil {
-		// We can't do any more validation without a Log
-		return ce.Appendf("AccessLogs.Log", "an AccessLog entry must be provided")
 	}
 
 	desc := df.GetLog(cfg.Log.DescriptorName)

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -32,6 +32,10 @@ import (
 	"istio.io/mixer/pkg/status"
 )
 
+// TODO: there are several hard-coded but end-user-configurable things in this file we need to work to eliminiate:
+// - default config assumes a log descriptor named "common" is available
+// - if we get a label or template param named exactly "timestamp" we populate the value with time.Now()
+
 type (
 	accessLogsManager struct{}
 
@@ -44,15 +48,6 @@ type (
 	}
 )
 
-const (
-	// TODO: revisit when well-known attributes are defined.
-	commonLogFormat = `{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} ` +
-		`[{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} ` +
-		`{{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}`
-	// TODO: revisit when well-known attributes are defined.
-	combinedLogFormat = commonLogFormat + ` "{{or (.referer) "-"}}" "{{or (.user_agent) "-"}}"`
-)
-
 // newAccessLogsManager returns a manager for the access logs aspect.
 func newAccessLogsManager() ReportManager {
 	return accessLogsManager{}
@@ -61,22 +56,9 @@ func newAccessLogsManager() ReportManager {
 func (m accessLogsManager) NewReportExecutor(c *cpb.Combined, a adapter.Builder, env adapter.Env, df descriptor.Finder) (ReportExecutor, error) {
 	cfg := c.Aspect.Params.(*aconfig.AccessLogsParams)
 
-	var templateStr string
-	switch cfg.Log.LogFormat {
-	case aconfig.COMMON:
-		templateStr = commonLogFormat
-	case aconfig.COMBINED:
-		templateStr = combinedLogFormat
-	default:
-		// TODO: we should never fall into this case because of validation; should we panic?
-		templateStr = ""
-	}
-
-	// TODO: when users can provide us with descriptors, this error can be removed due to validation
-	tmpl, err := template.New("accessLogsTemplate").Parse(templateStr)
-	if err != nil {
-		return nil, fmt.Errorf("log %s failed to parse template '%s' with err: %s", cfg.LogName, templateStr, err)
-	}
+	// validation ensures both that the descriptor exists and that its template is parsable by the template library.
+	desc := df.GetLog(cfg.Log.DescriptorName)
+	tmpl, _ := template.New("accessLogsTemplate").Parse(desc.LogTemplate)
 
 	asp, err := a.(adapter.AccessLogsBuilder).NewAccessLogsAspect(env, c.Builder.Params.(adapter.Config))
 	if err != nil {
@@ -96,19 +78,35 @@ func (accessLogsManager) Kind() config.Kind { return config.AccessLogsKind }
 func (accessLogsManager) DefaultConfig() config.AspectParams {
 	return &aconfig.AccessLogsParams{
 		LogName: "access_log",
-		Log: aconfig.AccessLogsParams_AccessLog{
-			LogFormat: aconfig.COMMON,
+		Log: &aconfig.AccessLogsParams_AccessLog{
+			DescriptorName: "common",
 		},
 	}
 }
 
-func (accessLogsManager) ValidateConfig(c config.AspectParams, _ expr.Validator, _ descriptor.Finder) (ce *adapter.ConfigErrors) {
+func (accessLogsManager) ValidateConfig(c config.AspectParams, v expr.Validator, df descriptor.Finder) (ce *adapter.ConfigErrors) {
 	cfg := c.(*aconfig.AccessLogsParams)
-	if cfg.Log.LogFormat == aconfig.ACCESS_LOG_FORMAT_UNSPECIFIED {
-		ce = ce.Appendf("Log.LogFormat", "a log format must be provided")
+	if cfg.LogName == "" {
+		ce = ce.Appendf("LogName", "no log name provided")
+	}
+	if cfg.Log == nil {
+		// We can't do any more validation without a Log
+		return ce.Appendf("AccessLogs.Log", "an AccessLog entry must be provided")
 	}
 
-	// TODO: validate custom templates when users can provide us with descriptors
+	desc := df.GetLog(cfg.Log.DescriptorName)
+	if desc == nil {
+		// nor can we do more validation without a descriptor
+		return ce.Appendf("AccessLogs", "could not find a descriptor for the access log '%s'", cfg.Log.DescriptorName)
+	}
+	ce = ce.Extend(validateLabels(fmt.Sprintf("AccessLogs[%s].Labels", cfg.Log.DescriptorName), cfg.Log.Labels, desc.Labels, v, df))
+
+	// TODO: how do we validate the log.TemplateExpressions against desc.LogTemplate? We can't just `Execute` the template
+	// against the expressions: while the keys to the template may be correct, the values will be wrong which could result
+	// in non-nil error returns even when things would be valid at runtime.
+	if _, err := template.New(desc.Name).Parse(desc.LogTemplate); err != nil {
+		ce = ce.Appendf(fmt.Sprintf("LogDescriptor[%s].LogTemplate", desc.Name), "failed to parse template with err: %v", err)
+	}
 	return
 }
 

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -100,6 +100,7 @@ func (accessLogsManager) ValidateConfig(c config.AspectParams, v expr.Validator,
 		return ce.Appendf("AccessLogs", "could not find a descriptor for the access log '%s'", cfg.Log.DescriptorName)
 	}
 	ce = ce.Extend(validateLabels(fmt.Sprintf("AccessLogs[%s].Labels", cfg.Log.DescriptorName), cfg.Log.Labels, desc.Labels, v, df))
+	ce = ce.Extend(validateTemplateExpressions(fmt.Sprintf("LogDescriptor[%s].TemplateExpressions", desc.Name), cfg.Log.TemplateExpressions, v, df))
 
 	// TODO: how do we validate the log.TemplateExpressions against desc.LogTemplate? We can't just `Execute` the template
 	// against the expressions: while the keys to the template may be correct, the values will be wrong which could result

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -18,19 +18,39 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"text/template"
 
 	ptypes "github.com/gogo/protobuf/types"
 
+	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
 	aconfig "istio.io/mixer/pkg/aspect/config"
 	"istio.io/mixer/pkg/aspect/test"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
 	configpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/status"
+)
+
+var (
+	validAccessLogDesc = dpb.LogEntryDescriptor{
+		Name:        "common",
+		LogTemplate: "{{.foo}}",
+		Labels: []*dpb.LabelDescriptor{
+			{Name: "label", ValueType: dpb.STRING},
+		},
+	}
+
+	accesslogsDF = test.NewDescriptorFinder(map[string]interface{}{
+		validAccessLogDesc.Name: &validAccessLogDesc,
+		// our attributes
+		"string": &dpb.AttributeDescriptor{Name: "string", ValueType: dpb.STRING},
+		"int64":  &dpb.AttributeDescriptor{Name: "int64", ValueType: dpb.INT64},
+	})
 )
 
 func TestNewAccessLoggerManager(t *testing.T) {
@@ -54,27 +74,12 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 		aspect: tl,
 	}
 
-	// TODO: add back tests for custom when we introduce descriptors
-	//customExec := &accessLogsExecutor{
-	//	name:   "custom_access_log",
-	//	aspect: tl,
-	//	labels: map[string]string{"test": "test"},
-	//}
-
 	combinedStruct := &aconfig.AccessLogsParams{
 		LogName: "combined_access_log",
-		Log: aconfig.AccessLogsParams_AccessLog{
-			LogFormat: aconfig.COMBINED,
+		Log: &aconfig.AccessLogsParams_AccessLog{
+			DescriptorName: "common",
 		},
 	}
-
-	//customStruct := &aconfig.AccessLogsParams{
-	//	LogName: "custom_access_log",
-	//	Log: &aconfig.AccessLogsParams_AccessLog{
-	//		LogFormat: aconfig.CUSTOM,
-	//		Labels:    map[string]string{"test": "test"},
-	//	},
-	//}
 
 	newAspectShouldSucceed := []struct {
 		name   string
@@ -83,7 +88,6 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 	}{
 		{"empty", dc, commonExec},
 		{"combined", combinedStruct, combinedExec},
-		//{"custom", customStruct, customExec},
 	}
 
 	m := newAccessLogsManager()
@@ -94,7 +98,7 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 				Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &configpb.Aspect{Params: v.params, Inputs: map[string]string{"template": "{{.test}}"}},
 			}
-			asp, err := m.NewReportExecutor(c, tl, test.Env{}, nil)
+			asp, err := m.NewReportExecutor(c, tl, test.Env{}, accesslogsDF)
 			if err != nil {
 				t.Fatalf("NewExecutor(): should not have received error for %s (%v)", v.name, err)
 			}
@@ -111,25 +115,13 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 	defaultCfg := &configpb.Combined{
 		Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 		Aspect: &configpb.Aspect{Params: &aconfig.AccessLogsParams{
-			Log: aconfig.AccessLogsParams_AccessLog{
-				LogFormat: aconfig.COMMON,
+			Log: &aconfig.AccessLogsParams_AccessLog{
+				DescriptorName: "common",
 			},
 		}},
 	}
 
-	// TODO: add back tests for bad templates when we introduce descriptors.
-	//badTemplateCfg := &config.Combined{
-	//	Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
-	//	Aspect: &configpb.Aspect{Params: &aconfig.AccessLogsParams{
-	//		LogName: "custom_access_log",
-	//		Log: &aconfig.AccessLogsParams_AccessLog{
-	//			LogFormat: aconfig.CUSTOM,
-	//		},
-	//	}, Inputs: map[string]string{"template": "{{{}}"}},
-	//}
-
 	errLogger := &test.Logger{DefaultCfg: &ptypes.Struct{}, ErrOnNewAspect: true}
-	//okLogger := &test.Logger{DefaultCfg: &ptypes.Struct{}}
 
 	failureCases := []struct {
 		name  string
@@ -137,13 +129,12 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 		adptr adapter.Builder
 	}{
 		{"errorLogger", defaultCfg, errLogger},
-		//{"badTemplateCfg", badTemplateCfg, okLogger},
 	}
 
 	m := newAccessLogsManager()
 	for idx, v := range failureCases {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			if _, err := m.NewReportExecutor(v.cfg, v.adptr, test.Env{}, nil); err == nil {
+			if _, err := m.NewReportExecutor(v.cfg, v.adptr, test.Env{}, accesslogsDF); err == nil {
 				t.Fatalf("NewExecutor()[%s]: expected error for bad adapter (%T)", v.name, v.adptr)
 			}
 		})
@@ -151,38 +142,73 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 }
 
 func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
-	configs := []config.AspectParams{
-		&aconfig.AccessLogsParams{
-			LogName: "test",
-			Log: aconfig.AccessLogsParams_AccessLog{
-				Labels:    map[string]string{"test": "good"},
-				LogFormat: aconfig.COMMON,
-			},
+	wrap := func(name string, log *aconfig.AccessLogsParams_AccessLog) *aconfig.AccessLogsParams {
+		return &aconfig.AccessLogsParams{
+			LogName: name,
+			Log:     log,
+		}
+	}
+
+	validDesc := dpb.LogEntryDescriptor{
+		Name:        "logentry",
+		LogTemplate: "{{.foo}}",
+		Labels: []*dpb.LabelDescriptor{
+			{Name: "label", ValueType: dpb.STRING},
 		},
-		&aconfig.AccessLogsParams{Log: aconfig.AccessLogsParams_AccessLog{LogFormat: aconfig.COMBINED}},
+	}
+	invalidDesc := validDesc
+	invalidDesc.Name = "invalid"
+	invalidDesc.LogTemplate = "{{.foo"
+
+	df := test.NewDescriptorFinder(map[string]interface{}{
+		validDesc.Name:   &validDesc,
+		invalidDesc.Name: &invalidDesc,
+		// our attributes
+		"string": &dpb.AttributeDescriptor{Name: "string", ValueType: dpb.STRING},
+		"int64":  &dpb.AttributeDescriptor{Name: "int64", ValueType: dpb.INT64},
+	})
+
+	validLog := aconfig.AccessLogsParams_AccessLog{
+		DescriptorName:      validDesc.Name,
+		Labels:              map[string]string{"label": "string"},
+		TemplateExpressions: map[string]string{"foo": "int64"},
 	}
 
-	m := newAccessLogsManager()
-	for idx, v := range configs {
-		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			if err := m.ValidateConfig(v, nil, nil); err != nil {
-				t.Fatalf("ValidateConfig(%v) => unexpected error: %v", v, err)
-			}
-		})
-	}
-}
+	noLogName := wrap("", &validLog)
 
-func TestAccessLoggerManager_ValidateConfigFailures(t *testing.T) {
-	configs := []config.AspectParams{
-		&aconfig.AccessLogsParams{},
-		&aconfig.AccessLogsParams{Log: aconfig.AccessLogsParams_AccessLog{LogFormat: aconfig.ACCESS_LOG_FORMAT_UNSPECIFIED}},
+	missingDesc := validLog
+	missingDesc.DescriptorName = "not in the df"
+
+	invalidLabels := validLog
+	invalidLabels.Labels = map[string]string{
+		"not a label": "string", // correct type, but doesn't match desc's label name
 	}
 
-	m := newAccessLogsManager()
-	for idx, v := range configs {
-		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			if err := m.ValidateConfig(v, nil, nil); err == nil {
-				t.Fatalf("ValidateConfig(%v) expected err", v)
+	invalidDescLog := validLog
+	invalidDescLog.DescriptorName = invalidDesc.Name
+
+	tests := []struct {
+		name string
+		cfg  *aconfig.AccessLogsParams
+		df   descriptor.Finder
+		err  string
+	}{
+		{"valid", wrap("valid", &validLog), df, ""},
+		{"empty config", &aconfig.AccessLogsParams{}, df, "LogName"},
+		{"no log name", noLogName, df, "LogName"},
+		{"missing desc", wrap("missing desc", &missingDesc), df, "could not find a descriptor"},
+		{"invalid labels", wrap("labels", &invalidLabels), df, "Labels"},
+		{"invalid logtemplate", wrap("tmpl", &invalidDescLog), df, "LogDescriptor"},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			if err := (&accessLogsManager{}).ValidateConfig(tt.cfg, expr.NewCEXLEvaluator(), tt.df); err != nil || tt.err != "" {
+				if tt.err == "" {
+					t.Fatalf("Foo = '%s', wanted no err", err.Error())
+				} else if !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("Expected errors containing the string '%s', actual: '%s'", tt.err, err.Error())
+				}
 			}
 		})
 	}

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -187,6 +187,9 @@ func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
 	invalidDescLog := validLog
 	invalidDescLog.DescriptorName = invalidDesc.Name
 
+	missingTmplExprs := validLog
+	missingTmplExprs.TemplateExpressions = map[string]string{"foo": "not an attribute"}
+
 	tests := []struct {
 		name string
 		cfg  *aconfig.AccessLogsParams
@@ -199,6 +202,7 @@ func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
 		{"missing desc", wrap("missing desc", &missingDesc), df, "could not find a descriptor"},
 		{"invalid labels", wrap("labels", &invalidLabels), df, "Labels"},
 		{"invalid logtemplate", wrap("tmpl", &invalidDescLog), df, "LogDescriptor"},
+		{"template expr attr missing", wrap("missing attr", &missingTmplExprs), df, "TemplateExpressions"},
 	}
 
 	for idx, tt := range tests {

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -76,7 +76,7 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 
 	combinedStruct := &aconfig.AccessLogsParams{
 		LogName: "combined_access_log",
-		Log: &aconfig.AccessLogsParams_AccessLog{
+		Log: aconfig.AccessLogsParams_AccessLog{
 			DescriptorName: "common",
 		},
 	}
@@ -115,7 +115,7 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 	defaultCfg := &configpb.Combined{
 		Builder: &configpb.Adapter{Params: &ptypes.Empty{}},
 		Aspect: &configpb.Aspect{Params: &aconfig.AccessLogsParams{
-			Log: &aconfig.AccessLogsParams_AccessLog{
+			Log: aconfig.AccessLogsParams_AccessLog{
 				DescriptorName: "common",
 			},
 		}},
@@ -142,7 +142,7 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 }
 
 func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
-	wrap := func(name string, log *aconfig.AccessLogsParams_AccessLog) *aconfig.AccessLogsParams {
+	wrap := func(name string, log aconfig.AccessLogsParams_AccessLog) *aconfig.AccessLogsParams {
 		return &aconfig.AccessLogsParams{
 			LogName: name,
 			Log:     log,
@@ -174,8 +174,6 @@ func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
 		TemplateExpressions: map[string]string{"foo": "int64"},
 	}
 
-	noLogName := wrap("", &validLog)
-
 	missingDesc := validLog
 	missingDesc.DescriptorName = "not in the df"
 
@@ -196,13 +194,13 @@ func TestAccessLoggerManager_ValidateConfig(t *testing.T) {
 		df   descriptor.Finder
 		err  string
 	}{
-		{"valid", wrap("valid", &validLog), df, ""},
+		{"valid", wrap("valid", validLog), df, ""},
 		{"empty config", &aconfig.AccessLogsParams{}, df, "LogName"},
-		{"no log name", noLogName, df, "LogName"},
-		{"missing desc", wrap("missing desc", &missingDesc), df, "could not find a descriptor"},
-		{"invalid labels", wrap("labels", &invalidLabels), df, "Labels"},
-		{"invalid logtemplate", wrap("tmpl", &invalidDescLog), df, "LogDescriptor"},
-		{"template expr attr missing", wrap("missing attr", &missingTmplExprs), df, "TemplateExpressions"},
+		{"no log name", wrap("", validLog), df, "LogName"}, // name is ""
+		{"missing desc", wrap("missing desc", missingDesc), df, "could not find a descriptor"},
+		{"invalid labels", wrap("labels", invalidLabels), df, "Labels"},
+		{"invalid logtemplate", wrap("tmpl", invalidDescLog), df, "LogDescriptor"},
+		{"template expr attr missing", wrap("missing attr", missingTmplExprs), df, "TemplateExpressions"},
 	}
 
 	for idx, tt := range tests {

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -128,6 +128,7 @@ func (applicationLogsManager) ValidateConfig(c config.AspectParams, v expr.Valid
 			ce = ce.Appendf(fmt.Sprintf("Logs[%s].Timestamp", log.DescriptorName), "failed type checking with err: %v", err)
 		}
 		ce = ce.Extend(validateLabels(fmt.Sprintf("Logs[%s].Labels", log.DescriptorName), log.Labels, desc.Labels, v, df))
+		ce = ce.Extend(validateTemplateExpressions(fmt.Sprintf("LogDescriptor[%s].TemplateExpressions", desc.Name), log.TemplateExpressions, v, df))
 
 		// TODO: how do we validate the log.TemplateExpressions against desc.LogTemplate? We can't just `Execute` the template
 		// against the expressions: while the keys to the template may be correct, the values will be wrong which could result

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -237,7 +237,7 @@ func TestLoggerManager_ValidateConfig(t *testing.T) {
 	noLogName := wrap("", &validLog)
 
 	missingDesc := validLog
-	missingDesc.DescriptorName = "not in the applogsDF"
+	missingDesc.DescriptorName = "not in the df"
 
 	invalidSeverity := validLog
 	invalidSeverity.Severity = "int64"
@@ -254,10 +254,10 @@ func TestLoggerManager_ValidateConfig(t *testing.T) {
 	invalidDescLog.DescriptorName = invalidDesc.Name
 
 	tests := []struct {
-		name      string
-		cfg       *aconfig.ApplicationLogsParams
-		applogsDF descriptor.Finder
-		err       string
+		name string
+		cfg  *aconfig.ApplicationLogsParams
+		df   descriptor.Finder
+		err  string
 	}{
 		{"valid", wrap("valid", &validLog), df, ""},
 		{"empty config", &aconfig.ApplicationLogsParams{}, df, "LogName"},
@@ -271,7 +271,7 @@ func TestLoggerManager_ValidateConfig(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			if err := (&applicationLogsManager{}).ValidateConfig(tt.cfg, expr.NewCEXLEvaluator(), tt.applogsDF); err != nil || tt.err != "" {
+			if err := (&applicationLogsManager{}).ValidateConfig(tt.cfg, expr.NewCEXLEvaluator(), tt.df); err != nil || tt.err != "" {
 				if tt.err == "" {
 					t.Fatalf("Foo = '%s', wanted no err", err.Error())
 				} else if !strings.Contains(err.Error(), tt.err) {

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -253,6 +253,9 @@ func TestLoggerManager_ValidateConfig(t *testing.T) {
 	invalidDescLog := validLog
 	invalidDescLog.DescriptorName = invalidDesc.Name
 
+	missingTmplExprs := validLog
+	missingTmplExprs.TemplateExpressions = map[string]string{"foo": "not an attribute"}
+
 	tests := []struct {
 		name string
 		cfg  *aconfig.ApplicationLogsParams
@@ -267,6 +270,7 @@ func TestLoggerManager_ValidateConfig(t *testing.T) {
 		{"invalid timestamp", wrap("ts", &invalidTimestamp), df, "Timestamp"},
 		{"invalid labels", wrap("labels", &invalidLabels), df, "Labels"},
 		{"invalid logtemplate", wrap("tmpl", &invalidDescLog), df, "LogDescriptor"},
+		{"template expr attr missing", wrap("missing attr", &missingTmplExprs), df, "TemplateExpressions"},
 	}
 
 	for idx, tt := range tests {

--- a/pkg/aspect/common.go
+++ b/pkg/aspect/common.go
@@ -58,7 +58,7 @@ func validateLabels(ceField string, labels map[string]string, labelDescs []*dpb.
 		if label := findLabel(name, labelDescs); label == nil {
 			ce = ce.Appendf(ceField, "wrong dimensions: extra label named %s", name)
 		} else if err := v.AssertType(exp, df, label.ValueType); err != nil {
-			ce = ce.Appendf(ceField, "error type checking label %s: %v", err)
+			ce = ce.Appendf(ceField, "error type checking label '%s': %v", name, err)
 		}
 	}
 	return

--- a/pkg/aspect/common.go
+++ b/pkg/aspect/common.go
@@ -63,3 +63,16 @@ func validateLabels(ceField string, labels map[string]string, labelDescs []*dpb.
 	}
 	return
 }
+
+func validateTemplateExpressions(ceField string, expressions map[string]string, v expr.Validator, df expr.AttributeDescriptorFinder) (
+	ce *adapter.ConfigErrors) {
+
+	// We can't do type assertions since we don't know what each template param needs to resolve to, but we can
+	// make sure they're syntactically correct and we have the attributes they need available in the system.
+	for name, exp := range expressions {
+		if _, err := v.TypeCheck(exp, df); err != nil {
+			ce = ce.Appendf(ceField, "failed to parse expression '%s' with err: %v", name, err)
+		}
+	}
+	return
+}

--- a/pkg/aspect/config/accessLogs.proto
+++ b/pkg/aspect/config/accessLogs.proto
@@ -54,28 +54,6 @@ message AccessLogsParams {
 
     // Describes how attributes must be evaluated to produce values for a log message.
     message AccessLog {
-        // AccessLogFormat specifies the format to use for generating textual log
-        // entries for the accessLogger aspect of the mixer.
-        enum AccessLogFormat {
-            // Invalid default value.
-            ACCESS_LOG_FORMAT_UNSPECIFIED = 0;
-
-            // Refers to the [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format).
-            // It is used to generate entries like:
-            // `127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326`
-            COMMON = 1;
-
-            // Refers to the Apache [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined).
-            // It is used to generate entries like:
-            // `127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"`
-            COMBINED = 2;
-
-            // TODO: add back CUSTOM logging formats after plumbing descriptors through config.
-            // // Used to enable operator-specified formats.
-            // CUSTOM = 99;
-        }
-        AccessLogFormat log_format = 1;
-
         // Only used if log_format is CUSTOM. Links this AccessLog to a LogEntryDescriptor
         // that describes the log's template.
         string descriptor_name = 2;

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -60,7 +60,14 @@ metrics:
     - name: response_code
       value_type: 2 # INT64
 quotas:
-- name: RequestCount
-  max_amount: 5
-  expiration:
-    seconds: 1
+  - name: RequestCount
+    max_amount: 5
+    expiration:
+      seconds: 1
+logs:
+  - name: common
+    display_name: Apache Common Log Format
+    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}'
+  - name: combined
+    display_name: Apache Combined Log Format
+    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}} {{or (.referer) "-"}} {{or (.user_agent) "-"}}'

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -84,6 +84,45 @@ logs:
   - name: accesslog.common
     display_name: Apache Common Log Format
     log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}'
+    labels:
+    - name: originIp
+      value_type: 6 # IP_ADDRESS
+    - name: sourceUser
+      value_type: 1 # STRING
+    - name: timestamp
+      value_type: 5 # TIMESTAMP
+    - name: method
+      value_type: 1 # STRING
+    - name: url
+      value_type: 1 # STRING
+    - name: protocol
+      value_type: 1 # STRING
+    - name: responseCode
+      value_type: 2 # INT64
+    - name: responseSize
+      value_type: 2 # INT64
   - name: accesslog.combined
     display_name: Apache Combined Log Format
-    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}} {{or (.referer) "-"}} {{or (.user_agent) "-"}}'
+    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}} {{or (.referer) "-"}} {{or (.userAgent) "-"}}'
+    labels:
+    - name: originIp
+      value_type: 6 # IP_ADDRESS
+    - name: sourceUser
+      value_type: 1 # STRING
+    - name: timestamp
+      value_type: 5 # TIMESTAMP
+    - name: method
+      value_type: 1 # STRING
+    - name: url
+      value_type: 1 # STRING
+    - name: protocol
+      value_type: 1 # STRING
+    - name: responseCode
+      value_type: 2 # INT64
+    - name: responseSize
+      value_type: 2 # INT64
+    - name: referer
+      value_type: 1 # STRING
+    - name: userAgent
+      value_type: 1 # STRING
+

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -81,9 +81,9 @@ quotas:
     expiration:
       seconds: 1
 logs:
-  - name: common
+  - name: accesslog.common
     display_name: Apache Common Log Format
     log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}'
-  - name: combined
+  - name: accesslog.combined
     display_name: Apache Combined Log Format
     log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}} {{or (.referer) "-"}} {{or (.user_agent) "-"}}'

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -20,10 +20,20 @@ attributes:
     value_type: 1 # STRING
   - name: target.name
     value_type: 1 # STRING
-  - name: api.name
+  - name: origin.ip
+    value_type: 6 # IP_ADDRESS
+  - name: origin.user
     value_type: 1 # STRING
-  - name: api.method
+  - name: request.time
+    value_type: 5 # TIMESTAMP
+  - name: request.method
     value_type: 1 # STRING
+  - name: request.path
+    value_type: 1 # STRING
+  - name: request.scheme
+    value_type: 1 # STRING
+  - name: response.size
+    value_type: 2 # INT64
   - name: response.code
     value_type: 2 # INT64
   - name: response.latency

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -16,6 +16,12 @@ adapters:
   - name: default
     impl: denyChecker
 attributes:
+  # TODO: we really need to remove these, they're not part of the attribute vocab.
+  - name: api.name
+    value_type: 1 # STRING
+  - name: api.method
+    value_type: 1 # STRING
+
   - name: source.name
     value_type: 1 # STRING
   - name: target.name

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -42,3 +42,12 @@ rules:
            protocol: request.scheme
            responseCode: response.code
            responseSize: response.size
+        labels:
+           originIp: origin.ip
+           sourceUser: origin.user
+           timestamp: request.time
+           method: request.method
+           url: request.path
+           protocol: request.scheme
+           responseCode: response.code
+           responseSize: response.size

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -30,10 +30,10 @@ rules:
           response_code: response.code | 200
   - kind: access-logs
     params:
-      logName: "access_log"
+      logName: access_log
       log:
-        descriptorName: "common"
-        templateExpressions:
+        descriptor_name: accesslog.common
+        template_expressions:
            originIp: origin.ip
            sourceUser: origin.user
            timestamp: request.time

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -32,17 +32,8 @@ rules:
     params:
       logName: "access_log"
       log:
-        logFormat: 1 # COMMON
+        descriptorName: "common"
         templateExpressions:
-           originIp: origin.ip
-           sourceUser: origin.user
-           timestamp: request.time
-           method: request.method
-           url: request.path
-           protocol: request.scheme
-           responseCode: response.code
-           responseSize: response.size
-        labels:
            originIp: origin.ip
            sourceUser: origin.user
            timestamp: request.time


### PR DESCRIPTION
We implement config validation. At the same time we update the access log manager to use descriptors. This update makes it natural to remove the log_format enum from the access log config: it adds substantial special logic if we 'know' about certain descriptors automagically, so I've removed the special casing around apache common/combined access logs. As a result, once again, access logs and application logs are essentially the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/500)
<!-- Reviewable:end -->
