### PR TITLE
Register redis adapter into inventory.

### DIFF
--- a/adapter/BUILD
+++ b/adapter/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//adapter/ipListChecker:go_default_library",
         "//adapter/memQuota:go_default_library",
         "//adapter/prometheus:go_default_library",
+        "//adapter/redisquota:go_default_library",
         "//adapter/statsd:go_default_library",
         "//adapter/stdioLogger:go_default_library",
         "//pkg/adapter:go_default_library",

--- a/adapter/inventory.go
+++ b/adapter/inventory.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/mixer/adapter/ipListChecker"
 	"istio.io/mixer/adapter/memQuota"
 	"istio.io/mixer/adapter/prometheus"
+	"istio.io/mixer/adapter/redisquota"
 	"istio.io/mixer/adapter/statsd"
 	"istio.io/mixer/adapter/stdioLogger"
 	"istio.io/mixer/pkg/adapter"
@@ -33,6 +34,7 @@ func Inventory() []adapter.RegisterFn {
 		ipListChecker.Register,
 		memQuota.Register,
 		prometheus.Register,
+		redisquota.Register,
 		statsd.Register,
 		stdioLogger.Register,
 	}

--- a/adapter/redisquota/driver.go
+++ b/adapter/redisquota/driver.go
@@ -15,8 +15,6 @@
 package redisquota
 
 import (
-	"sync"
-
 	"github.com/mediocregopher/radix.v2/pool"
 	"github.com/mediocregopher/radix.v2/redis"
 )
@@ -25,7 +23,6 @@ import (
 type connPool struct {
 	// TODO: add number of connections here
 	pool *pool.Pool
-	sync.Mutex
 }
 
 type connection struct {
@@ -39,9 +36,7 @@ type response struct {
 
 // Get is to get a connection from the connection pool.
 func (cp *connPool) get() (*connection, error) {
-	cp.Lock()
 	client, err := cp.pool.Get()
-	cp.Unlock()
 
 	return &connection{client, 0}, err
 }
@@ -57,7 +52,7 @@ func newConnPool(redisURL string, redisSocketType string, redisPoolSize int64) (
 	if err != nil {
 		return nil, err
 	}
-	return &connPool{pool, sync.Mutex{}}, err
+	return &connPool{pool}, err
 }
 
 func (cp *connPool) empty() {

--- a/adapter/redisquota/redisquota.go
+++ b/adapter/redisquota/redisquota.go
@@ -99,6 +99,14 @@ func newAspectWithDedup(env adapter.Env, ticker *time.Ticker, c *config.Params) 
 		redisPool:  connPool,
 		redisError: nil,
 	}
+
+	env.ScheduleDaemon(func() {
+		for range rq.common.Ticker.C {
+			rq.common.Lock()
+			rq.common.ReapDedup()
+			rq.common.Unlock()
+		}
+	})
 	return rq, nil
 }
 


### PR DESCRIPTION
This PR attempted to register redis quota adapter into adapter inventory, and I'm working on test thread safety now.  The steps for testing quota method:
1. change `memQuota` to `redisQuota` in globalconfig.yaml.
2. run mixs with config: _./mixs server \
  --globalConfigFile testdata/globalconfig.yml \
  --serviceConfigFile testdata/serviceconfig.yml  --logtostderr_
3. run mixc: _./mixc quota --amount 10 --name RequestCount_
@geeknoid Should the name for mixc be the same as listed in globalconfig quotas section? Is there anything I'm missing here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/511)
<!-- Reviewable:end -->
