### PR TITLE
Fix testdata serviceconfig's quota setup

### DIFF
--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -7,6 +7,8 @@ rules:
   aspects:
   - kind: quotas
     params:
+      quotas:
+      - descriptor_name: RequestCount
   - kind: metrics
     adapter: prometheus
     params:


### PR DESCRIPTION
I forgot to add quota aspect params when I updated the quota aspect to use descriptors, so while a quota was defined in the globalconfig at runtime the quota adapter thought it had no quotas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/518)
<!-- Reviewable:end -->
