### PR TITLE
Fix some prometheus adapter issues.

### DIFF
--- a/adapter/prometheus/server_test.go
+++ b/adapter/prometheus/server_test.go
@@ -22,10 +22,13 @@ import (
 	"istio.io/mixer/pkg/adapter/test"
 )
 
+func doesNothing(w http.ResponseWriter, r *http.Request) {}
+
 func TestServer(t *testing.T) {
 	testAddr := "127.0.0.1:9992"
 	s := newServer(testAddr)
-	if err := s.Start(test.NewEnv(t)); err != nil {
+
+	if err := s.Start(test.NewEnv(t), http.HandlerFunc(doesNothing)); err != nil {
 		t.Fatalf("Start() failed unexpectedly: %v", err)
 	}
 
@@ -43,11 +46,15 @@ func TestServer(t *testing.T) {
 	_ = resp.Body.Close()
 
 	s2 := newServer(testAddr)
-	if err := s2.Start(test.NewEnv(t)); err == nil {
+	if err := s2.Start(test.NewEnv(t), http.HandlerFunc(doesNothing)); err == nil {
 		t.Fatal("Start() succeeded, expecting a failure")
 	}
 
 	if err := s.Close(); err != nil {
+		t.Errorf("Failed to close server properly: %v", err)
+	}
+
+	if err := s2.Close(); err != nil {
 		t.Errorf("Failed to close server properly: %v", err)
 	}
 }


### PR DESCRIPTION
This PR addresses a few minor issues with the existing prometheus
adapter by adding:
- a graceful shutdown for the http servers that start up as
scraping targets
- a registry per factory, and configures the `/metrics`
handler to work solely off of that registry.

The new registry and handler code ensures that multiple factories can,
in theory, co-exist in the mixer itself and limits the reported metrics
to the prometheus backend doing the scraping to just the metrics
reported through the mixer for the configured factory. This means that
the go stats, etc., that were getting exported via the handler must be
exported though a different mechanism if desired.

Example:
```shell
$ ./bazel-bin/cmd/server/mixs server --globalConfigFile=testdata/globalconfig.yml --serviceConfigFile=testdata/serviceconfig.yml
Istio Mixer: version: stable-b875f9f-21-g43e8bd4 (build: 2017-04-07-43e8bd4, status: Modified)
Starting gRPC server on port 9091
```
```shell
$ ./bazel-bin/cmd/client/mixc report
```
localhost:42422/metrics:
```
# HELP request_count request count by source, target, service, and code
# TYPE request_count counter
request_count{method="unknown",response_code="200",service="unknown",source="unknown",target="unknown"} 1
# HELP request_latency request latency by source, target, and service
# TYPE request_latency counter
request_latency{method="unknown",response_code="200",service="unknown",source="unknown",target="unknown"} 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/521)
<!-- Reviewable:end -->
