### PR TITLE
Updating pipeline version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('testutils@stable-96c1bdb')
+@Library('testutils@stable-cd138c4')
 
 import org.istio.testutils.Utilities
 import org.istio.testutils.GitUtilities

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,8 +90,9 @@ def stablePostsubmit(gitUtils, bazel, utils) {
   goBuildNode(gitUtils, 'istio.io/mixer') {
     bazel.updateBazelRc()
     stage('Docker Push') {
+      def date = new Date().format("YYYY-MM-dd-HH.mm.ss")
       def images = 'mixer,mixer_debug'
-      def tags = "${env.GIT_SHORT_SHA},\$(date +%Y-%m-%d-%H.%M.%S),latest"
+      def tags = "${env.GIT_SHORT_SHA},${date},latest"
       utils.publishDockerImagesToDockerHub(images, tags)
       utils.publishDockerImagesToContainerRegistry(images, tags, '', 'gcr.io/istio-io')
     }


### PR DESCRIPTION
bazel.updateBazelRc() in Jenkinsfile used to make the workspace dirty, which means that
all binary created per jenkins were marked as modified per build_stamp.sh

Using same tag for both docker hubs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/541)
<!-- Reviewable:end -->
