### PR TITLE
proto jsonp parsing for descriptors 

### DIFF
--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -156,7 +156,7 @@ func metricDefinitionFromProto(desc *dpb.MetricDescriptor) (*adapter.MetricDefin
 	for name, labelType := range desc.Labels {
 		l, err := valueTypeToLabelType(labelType)
 		if err != nil {
-			return nil, fmt.Errorf("descriptor '%s' label '%s' failed to convert label type value '%v' from proto with err: %s",
+			return nil, fmt.Errorf("descriptor '%s' label '%v' failed to convert label type value '%v' from proto with err: %s",
 				desc.Name, name, labelType, err)
 		}
 		labels[name] = l

--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -164,7 +164,7 @@ func quotaDefinitionFromProto(desc *dpb.QuotaDescriptor) (*adapter.QuotaDefiniti
 	for name, labelType := range desc.Labels {
 		l, err := valueTypeToLabelType(labelType)
 		if err != nil {
-			return nil, fmt.Errorf("descriptor '%s' label '%s' failed to convert label type value '%v' from proto with err: %s",
+			return nil, fmt.Errorf("descriptor '%s' label '%v' failed to convert label type value '%v' from proto with err: %s",
 				desc.Name, name, labelType, err)
 		}
 		labels[name] = l

--- a/pkg/config/kind.go
+++ b/pkg/config/kind.go
@@ -85,14 +85,17 @@ func (ks KindSet) Set(k Kind) KindSet {
 	return ks | (1 << k)
 }
 
+// make gas happy
+func ignoreErrors(args ...interface{}) {}
+
 func (ks KindSet) String() string {
 	buf := pool.GetBuffer()
 	defer pool.PutBuffer(buf) // fine to pay the defer overhead; this is out of request path
 
-	fmt.Fprint(buf, "[")
+	ignoreErrors(fmt.Fprint(buf, "["))
 	for k, v := range kindToString {
 		if ks.IsSet(k) {
-			fmt.Fprintf(buf, "%s, ", v)
+			ignoreErrors(fmt.Fprintf(buf, "%s, ", v))
 		}
 	}
 
@@ -102,7 +105,7 @@ func (ks KindSet) String() string {
 	}
 	// Otherwise trim off the trailing ", " and close the bracket we opened.
 	buf.Truncate(buf.Len() - 2)
-	fmt.Fprint(buf, "]")
+	ignoreErrors(fmt.Fprint(buf, "]"))
 	return buf.String()
 }
 

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -200,13 +200,16 @@ func (a adapterKey) String() string {
 }
 
 // FIXME post alpha
+// create new messages of type
+// message MetricList {
+//   repeated metrics = 1;
+// }
+// One for each type of descriptor
+// Those messages can be parsed directly using proto.jsonp.
+// At present globalConfig.Adapters contains `struct` that prevents us from using proto.jsonp
+
 // compatfilterConfig
-// create new containing messages one for each type of descriptor
-// Those messages can be parsed straight thru jsonp.
-// At present m.Adapters contains `struct` that prevents us from
-// using jsonp
-// compatfilter
-// given a yaml file filter specific keys from it
+// given a yaml file, filter specific keys from it
 // globalConfig contains descriptors and adapters which will be split shortly.
 func compatfilterConfig(cfg string, shouldSelect func(string) bool) (data []byte, err error) {
 	var m = map[string]interface{}{}

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -199,13 +199,50 @@ func (a adapterKey) String() string {
 	return fmt.Sprintf("%s//%s", a.kind, a.name)
 }
 
+// FIXME post alpha
+// compatfilterConfig
+// create new containing messages one for each type of descriptor
+// Those messages can be parsed straight thru jsonp.
+// At present m.Adapters contains `struct` that prevents us from
+// using jsonp
+// compatfilter
+// given a yaml file filter specific keys from it
+// globalConfig contains descriptors and adapters which will be split shortly.
+func compatfilterConfig(cfg string, shouldSelect func(string) bool) (data []byte, err error) {
+	var m = map[string]interface{}{}
+
+	if err = yaml.Unmarshal([]byte(cfg), &m); err != nil {
+		return
+	}
+	for k := range m {
+		if !shouldSelect(k) {
+			delete(m, k)
+		}
+	}
+	return json.Marshal(m)
+}
+
 // validateDescriptors
+//
+// Enums as struct fields can be symbolic names.
+// However enums inside maps *cannot* be symbolic names.
 // TODO add validation beyond proto parse
 func (p *validator) validateDescriptors(key string, cfg string) (ce *adapter.ConfigErrors) {
-	var m = &pb.GlobalConfig{}
-	if err := yaml.Unmarshal([]byte(cfg), m); err != nil {
-		return ce.Appendf("GlobalConfig", "failed to unmarshal config into proto with err: %v", err)
+	var err error
+	var data []byte
+
+	if data, err = compatfilterConfig(cfg, func(s string) bool {
+		return s != "adapters"
+	}); err != nil {
+		return ce.Appendf("DescriptorConfig", "failed to unmarshal config into proto with err: %v", err)
 	}
+	m := &pb.GlobalConfig{}
+	um := jsonpb.Unmarshaler{AllowUnknownFields: true}
+
+	if err = um.Unmarshal(bytes.NewReader(data), m); err != nil {
+		return ce.Appendf("DescriptorConfig", "failed to unmarshal <%s> config into proto with err: %v", string(data), err)
+	}
+
 	p.validated.descriptor[key] = m
 	return
 }
@@ -213,8 +250,17 @@ func (p *validator) validateDescriptors(key string, cfg string) (ce *adapter.Con
 // validateAdapters consumes a yml config string with adapter config.
 // It is validated in the presence of validators.
 func (p *validator) validateAdapters(key string, cfg string) (ce *adapter.ConfigErrors) {
+	var ferr error
+	var data []byte
+
+	if data, ferr = compatfilterConfig(cfg, func(s string) bool {
+		return s == "adapters"
+	}); ferr != nil {
+		return ce.Appendf("DescriptorConfig", "failed to unmarshal config into proto with err: %v", ferr)
+	}
+
 	var m = &pb.GlobalConfig{}
-	if err := yaml.Unmarshal([]byte(cfg), m); err != nil {
+	if err := yaml.Unmarshal(data, m); err != nil {
 		return ce.Appendf("GlobalConfig", "failed to unmarshal config into proto with err: %v", err)
 	}
 

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -8,7 +8,7 @@ adapters:
   - name: default
     impl: stdioLogger
     params:
-      logStream: 0 # STDERR
+      logStream: STDERR
   - name: prometheus
     kind: metrics
     impl: prometheus
@@ -20,36 +20,45 @@ manifests:
     revision: "1"
     attributes:
     - name: source.name
-      value_type: 1 # STRING
+      value_type: STRING
+    - name: source.labels
+      value_type: STRING_MAP
     - name: target.name
-      value_type: 1 # STRING
+      value_type: STRING
+    - name: target.service
+      value_type: STRING
     - name: origin.ip
-      value_type: 6 # IP_ADDRESS
+      value_type: IP_ADDRESS
     - name: origin.user
-      value_type: 1 # STRING
+      value_type: STRING
     - name: request.time
-      value_type: 5 # TIMESTAMP
+      value_type: TIMESTAMP
     - name: request.method
-      value_type: 1 # STRING
+      value_type: STRING
     - name: request.path
-      value_type: 1 # STRING
+      value_type: STRING
+    - name: request.headers
+      value_type: STRING_MAP
     - name: request.scheme
-      value_type: 1 # STRING
+      value_type: STRING
     - name: response.size
-      value_type: 2 # INT64
+      value_type: INT64
     - name: response.code
-      value_type: 2 # INT64
+      value_type: INT64
     - name: response.duration
-      value_type: 10 # DURATION
+      value_type: DURATION
     # TODO: we really need to remove these, they're not part of the attribute vocab.
     - name: api.name
-      value_type: 1 # STRING
+      value_type: STRING
     - name: api.method
-      value_type: 1 # STRING
+      value_type: STRING
+
+# Enums as struct fields can be symbolic names.
+# However enums inside maps *cannot* be symbolic names.
 metrics:
   - name: request_count
-    kind: 2 # COUNTER
-    value: 2 # INT64
+    kind: COUNTER
+    value: INT64
     description: request count by source, target, service, and code
     labels:
       source: 1 # STRING
@@ -58,8 +67,8 @@ metrics:
       method: 1 # STRING
       response_code: 2 # INT64
   - name: request_latency
-    kind: 2 # COUNTER
-    value: 10 # DURATION
+    kind: COUNTER
+    value: DURATION
     description: request latency by source, target, and service
     labels:
       source: 1 # STRING
@@ -70,8 +79,7 @@ metrics:
 quotas:
   - name: RequestCount
     max_amount: 5
-    expiration:
-      seconds: 1
+    expiration: 1s
 logs:
   - name: accesslog.common
     display_name: Apache Common Log Format
@@ -99,4 +107,3 @@ logs:
       responseSize: 2 # INT64
       referer: 1 # STRING
       userAgent: 1 # STRING
-


### PR DESCRIPTION
Descriptors are now parsed using the same method as aspects and adapters.
That ensures camelCase and snake_case both work.

It also ensures that we can use symbolic enum names.
symbolic enums can be used in most cases, except when they are inside a proto map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/553)
<!-- Reviewable:end -->
