### PR TITLE
Sanitize error messages

### DIFF
--- a/adapter/statsd/statsd.go
+++ b/adapter/statsd/statsd.go
@@ -79,7 +79,7 @@ func (b *builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	}
 	for metricName, s := range params.MetricNameTemplateStrings {
 		if _, err := template.New(metricName).Parse(s); err != nil {
-			ce = ce.Appendf("MetricNameTemplateStrings", "failed to parse template '%s' for metric '%s' with err: %s", s, metricName, err)
+			ce = ce.Appendf("MetricNameTemplateStrings", "failed to parse template '%s' for metric '%s': %v", s, metricName, err)
 		}
 	}
 	return
@@ -108,7 +108,7 @@ func (*builder) NewMetricsAspect(env adapter.Env, cfg adapter.Config, metrics ma
 		t, _ := template.New(metricName).Parse(s)
 		if err := t.Execute(ioutil.Discard, def.Labels); err != nil {
 			env.Logger().Warningf(
-				"skipping custom statsd metric name for metric '%s', could not satisfy template '%s' with labels '%v' with err: %s",
+				"skipping custom statsd metric name for metric '%s', could not satisfy template '%s' with labels '%v': %v",
 				metricName, s, def.Labels, err)
 			continue
 		}
@@ -147,14 +147,14 @@ func (a *aspect) record(value adapter.Value) error {
 	case adapter.Gauge:
 		v, err := value.Int64()
 		if err != nil {
-			return fmt.Errorf("could not record gauge '%s' with err: %s", mname, err)
+			return fmt.Errorf("could not record gauge '%s': %v", mname, err)
 		}
 		result = a.client.Gauge(mname, v, a.rate)
 
 	case adapter.Counter:
 		v, err := value.Int64()
 		if err != nil {
-			return fmt.Errorf("could not record counter '%s' with err: %s", mname, err)
+			return fmt.Errorf("could not record counter '%s': %v", mname, err)
 		}
 		result = a.client.Inc(mname, v, a.rate)
 	}

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -116,12 +116,12 @@ func serverCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 	serverCmd.PersistentFlags().StringVarP(&sa.configIdentityAttribute, "configIdentityAttribute", "", "target.service",
 		"Attribute that is used to identify applicable scopes.")
 	if err := serverCmd.PersistentFlags().MarkHidden("configIdentityAttribute"); err != nil {
-		fatalf("unable to hide: %s", err.Error())
+		fatalf("unable to hide: %v", err)
 	}
 	serverCmd.PersistentFlags().StringVarP(&sa.configIdentityAttributeDomain, "configIdentityAttributeDomain", "", "svc.cluster.local",
 		"The domain to which all values of the configIdentityAttribute belong. For kubernetes services it is svc.cluster.local")
 	if err := serverCmd.PersistentFlags().MarkHidden("configIdentityAttributeDomain"); err != nil {
-		fatalf("unable to hide: %s", err.Error())
+		fatalf("unable to hide: %v", err)
 	}
 
 	// serviceConfig and gobalConfig are for compatibility only
@@ -139,7 +139,7 @@ func configStore(url, serviceConfigFile, globalConfigFile string, printf, fatalf
 	var err error
 	if url != "" {
 		if store, err = config.NewStore(url); err != nil {
-			fatalf("Failed to get config store: %s", err.Error())
+			fatalf("Failed to get config store: %v", err)
 		}
 		return store
 	}
@@ -148,7 +148,7 @@ func configStore(url, serviceConfigFile, globalConfigFile string, printf, fatalf
 	}
 	printf("*** serviceConfigFile and globalConfigFile are deprecated, use configStoreURL")
 	if store, err = config.NewCompatFSStore(globalConfigFile, serviceConfigFile); err != nil {
-		fatalf("Failed to get config store: %s", err.Error())
+		fatalf("Failed to get config store: %v", err)
 	}
 	return store
 }

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -257,7 +257,7 @@ func (m *Manager) dispatch(ctx context.Context, requestBag, responseBag *attribu
 			if ctx.Err() == context.Canceled {
 				return status.WithCancelled(fmt.Sprintf("request cancelled: %v", ctx.Err()))
 			}
-			return status.WithDeadlineExceeded(fmt.Sprintf("deadline exceeded waiting for adapter results with err: %v", ctx.Err()))
+			return status.WithDeadlineExceeded(fmt.Sprintf("deadline exceeded waiting for adapter results: %v", ctx.Err()))
 		case res := <-resultChan:
 			results[i] = res
 		}

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -173,7 +173,7 @@ func TestCheck(t *testing.T) {
 				close(waitc)
 				return
 			} else if err != nil {
-				t.Errorf("Failed to receive a response : %v", err)
+				t.Errorf("Failed to receive a response: %v", err)
 				return
 			} else {
 				waitc <- response.RequestIndex
@@ -230,7 +230,7 @@ func TestReport(t *testing.T) {
 				close(waitc)
 				return
 			} else if err != nil {
-				t.Errorf("Failed to receive a response : %v", err)
+				t.Errorf("Failed to receive a response: %v", err)
 				return
 			} else {
 				waitc <- response.RequestIndex
@@ -287,7 +287,7 @@ func TestQuota(t *testing.T) {
 				close(waitc)
 				return
 			} else if err != nil {
-				t.Errorf("Failed to receive a response : %v", err)
+				t.Errorf("Failed to receive a response: %v", err)
 				return
 			} else {
 				waitc <- response
@@ -350,7 +350,7 @@ func TestOverload(t *testing.T) {
 				close(waitc)
 				return
 			} else if err != nil {
-				t.Errorf("Failed to receive a response : %v", err)
+				t.Errorf("Failed to receive a response: %v", err)
 				return
 			} else {
 				waitc <- response.RequestIndex
@@ -409,7 +409,7 @@ func TestBadAttr(t *testing.T) {
 	if err == io.EOF {
 		t.Error("Got EOF from stream")
 	} else if err != nil {
-		t.Errorf("Failed to receive a response : %v", err)
+		t.Errorf("Failed to receive a response: %v", err)
 	} else {
 		if response.Result.Code != int32(rpc.INVALID_ARGUMENT) {
 			t.Errorf("Got result %d, expecting %d", response.Result.Code, rpc.INVALID_ARGUMENT)
@@ -461,7 +461,7 @@ func TestRudeClose(t *testing.T) {
 	if err == io.EOF {
 		t.Error("Got EOF from stream")
 	} else if err != nil {
-		t.Errorf("Failed to receive a response : %v", err)
+		t.Errorf("Failed to receive a response: %v", err)
 	}
 }
 
@@ -552,7 +552,7 @@ func TestPreprocessFailure(t *testing.T) {
 				close(waitc)
 				return
 			} else if err != nil {
-				t.Errorf("Failed to receive a response : %v", err)
+				t.Errorf("Failed to receive a response: %v", err)
 				return
 			} else {
 				waitc <- response.Result

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -62,7 +62,7 @@ func (m accessLogsManager) NewReportExecutor(c *cpb.Combined, a adapter.Builder,
 
 	asp, err := a.(adapter.AccessLogsBuilder).NewAccessLogsAspect(env, c.Builder.Params.(adapter.Config))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create aspect for log %s with err: %s", cfg.LogName, err)
+		return nil, fmt.Errorf("failed to create aspect for log %s: %v", cfg.LogName, err)
 	}
 
 	return &accessLogsExecutor{
@@ -102,7 +102,7 @@ func (accessLogsManager) ValidateConfig(c config.AspectParams, v expr.Validator,
 	// against the expressions: while the keys to the template may be correct, the values will be wrong which could result
 	// in non-nil error returns even when things would be valid at runtime.
 	if _, err := template.New(desc.Name).Parse(desc.LogTemplate); err != nil {
-		ce = ce.Appendf(fmt.Sprintf("LogDescriptor[%s].LogTemplate", desc.Name), "failed to parse template with err: %v", err)
+		ce = ce.Appendf(fmt.Sprintf("LogDescriptor[%s].LogTemplate", desc.Name), "failed to parse template: %v", err)
 	}
 	return
 }
@@ -118,7 +118,7 @@ func (e *accessLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator)
 	buf := pool.GetBuffer()
 	if err := e.template.Execute(buf, templateVals); err != nil {
 		pool.PutBuffer(buf)
-		return status.WithError(fmt.Errorf("failed to execute payload template for log %s with err: %s", e.name, err))
+		return status.WithError(fmt.Errorf("failed to execute payload template for log %s: %v", e.name, err))
 	}
 	payload := buf.String()
 	pool.PutBuffer(buf)
@@ -129,7 +129,7 @@ func (e *accessLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator)
 		TextPayload: payload,
 	}
 	if err := e.aspect.LogAccess([]adapter.LogEntry{entry}); err != nil {
-		return status.WithError(fmt.Errorf("failed to log to %s with err: %s", e.name, err))
+		return status.WithError(fmt.Errorf("failed to log to %s: %v", e.name, err))
 	}
 	return status.OK
 }

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -92,7 +92,7 @@ func (applicationLogsManager) NewReportExecutor(c *cpb.Combined, a adapter.Build
 
 	asp, err := a.(adapter.ApplicationLogsBuilder).NewApplicationLogsAspect(env, c.Builder.Params.(adapter.Config))
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct application logs aspect with err: %v", err)
+		return nil, fmt.Errorf("failed to construct application logs aspect: %v", err)
 	}
 
 	return &applicationLogsExecutor{
@@ -122,10 +122,10 @@ func (applicationLogsManager) ValidateConfig(c config.AspectParams, v expr.Valid
 		}
 
 		if err := v.AssertType(log.Severity, df, dpb.STRING); err != nil {
-			ce = ce.Appendf(fmt.Sprintf("Logs[%s].Severity", log.DescriptorName), "failed type checking with err: %v", err)
+			ce = ce.Appendf(fmt.Sprintf("Logs[%s].Severity", log.DescriptorName), "failed type checking: %v", err)
 		}
 		if err := v.AssertType(log.Timestamp, df, dpb.TIMESTAMP); err != nil {
-			ce = ce.Appendf(fmt.Sprintf("Logs[%s].Timestamp", log.DescriptorName), "failed type checking with err: %v", err)
+			ce = ce.Appendf(fmt.Sprintf("Logs[%s].Timestamp", log.DescriptorName), "failed type checking: %v", err)
 		}
 		ce = ce.Extend(validateLabels(fmt.Sprintf("Logs[%s].Labels", log.DescriptorName), log.Labels, desc.Labels, v, df))
 		ce = ce.Extend(validateTemplateExpressions(fmt.Sprintf("LogDescriptor[%s].TemplateExpressions", desc.Name), log.TemplateExpressions, v, df))
@@ -134,7 +134,7 @@ func (applicationLogsManager) ValidateConfig(c config.AspectParams, v expr.Valid
 		// against the expressions: while the keys to the template may be correct, the values will be wrong which could result
 		// in non-nil error returns even when things would be valid at runtime.
 		if _, err := template.New(desc.Name).Parse(desc.LogTemplate); err != nil {
-			ce = ce.Appendf(fmt.Sprintf("LogDescriptor[%s].LogTemplate", desc.Name), "failed to parse template with err: %v", err)
+			ce = ce.Appendf(fmt.Sprintf("LogDescriptor[%s].LogTemplate", desc.Name), "failed to parse template: %v", err)
 		}
 	}
 	return
@@ -149,13 +149,13 @@ func (e *applicationLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evalu
 	for name, md := range e.metadata {
 		labels, err := evalAll(md.labels, attrs, mapper)
 		if err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to eval labels for log entry '%s' with err: %s", name, err))
+			result = multierror.Append(result, fmt.Errorf("failed to eval labels for log entry '%s': %v", name, err))
 			continue
 		}
 
 		templateVals, err := evalAll(md.tmplExprs, attrs, mapper)
 		if err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to eval template values for log entry '%s' with err: %s", name, err))
+			result = multierror.Append(result, fmt.Errorf("failed to eval template values for log entry '%s': %v", name, err))
 			continue
 		}
 
@@ -164,14 +164,14 @@ func (e *applicationLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evalu
 		if err != nil {
 			pool.PutBuffer(buf)
 			result = multierror.Append(result, fmt.Errorf(
-				"failed to construct payload string for log entry '%s' with template execution err: %s", name, err))
+				"failed to construct payload string for log entry '%s' with template execution error: %v", name, err))
 			continue
 		}
 
 		sevStr, err := mapper.EvalString(md.severity, attrs)
 		if err != nil {
 			result = multierror.Append(result,
-				fmt.Errorf("failed to eval severity for log entry '%s', continuing with DEFAULT severity. Eval err: %s", name, err))
+				fmt.Errorf("failed to eval severity for log entry '%s' (continuing with DEFAULT severity): %v", name, err))
 			sevStr = ""
 		}
 		// If we can't parse the string we'll get the default severity, so we don't care about the success return.
@@ -180,7 +180,7 @@ func (e *applicationLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evalu
 		et, err := mapper.Eval(md.timestamp, attrs)
 		if err != nil {
 			result = multierror.Append(result,
-				fmt.Errorf("failed to eval time for log entry '%s', continuing with time.Now(). Eval err: %s", name, err))
+				fmt.Errorf("failed to eval time for log entry '%s' (continuing with time.Now()): %v", name, err))
 			et = time.Now()
 		}
 		t, _ := et.(time.Time) // we don't check the cast because expression type checking ensures we get a time.
@@ -197,7 +197,7 @@ func (e *applicationLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evalu
 			entry.TextPayload = buf.String()
 		case JSON:
 			if err := json.Unmarshal(buf.Bytes(), &entry.StructPayload); err != nil {
-				result = multierror.Append(result, fmt.Errorf("failed to unmarshall json payload for log entry %s with err: %s", name, err))
+				result = multierror.Append(result, fmt.Errorf("failed to unmarshall json payload for log entry %s: %v", name, err))
 				continue
 			}
 		}

--- a/pkg/aspect/attrgenmgr.go
+++ b/pkg/aspect/attrgenmgr.go
@@ -54,7 +54,7 @@ func (attrGenMgr) ValidateConfig(c config.AspectParams, v expr.Validator, df des
 	params := c.(*apb.AttributesGeneratorParams)
 	for n, expr := range params.InputExpressions {
 		if _, err := v.TypeCheck(expr, df); err != nil {
-			cerrs = cerrs.Appendf("input_expressions", "failed to parse expression '%s' with err: %v", n, err)
+			cerrs = cerrs.Appendf("input_expressions", "failed to parse expression '%s': %v", n, err)
 		}
 	}
 

--- a/pkg/aspect/common.go
+++ b/pkg/aspect/common.go
@@ -31,7 +31,7 @@ func evalAll(expressions map[string]string, attrs attribute.Bag, eval expr.Evalu
 	for label, texpr := range expressions {
 		val, err := eval.Eval(texpr, attrs)
 		if err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to construct value for label '%s' with err: %v", label, err))
+			result = multierror.Append(result, fmt.Errorf("failed to construct value for label '%s': %v", label, err))
 			continue
 		}
 		labels[label] = val
@@ -62,7 +62,7 @@ func validateTemplateExpressions(ceField string, expressions map[string]string, 
 	// make sure they're syntactically correct and we have the attributes they need available in the system.
 	for name, exp := range expressions {
 		if _, err := v.TypeCheck(exp, df); err != nil {
-			ce = ce.Appendf(ceField, "failed to parse expression '%s' with err: %v", name, err)
+			ce = ce.Appendf(ceField, "failed to parse expression '%s': %v", name, err)
 		}
 	}
 	return

--- a/pkg/aspect/quotasManager.go
+++ b/pkg/aspect/quotasManager.go
@@ -98,7 +98,7 @@ func (*quotasManager) ValidateConfig(c config.AspectParams, v expr.Validator, df
 		ce = ce.Extend(validateLabels(fmt.Sprintf("Quotas[%s].Labels", desc.Name), quota.Labels, desc.Labels, v, df))
 
 		if _, err := quotaDefinitionFromProto(desc); err != nil {
-			ce = ce.Appendf(fmt.Sprintf("Descriptor[%s]", desc.Name), "failed to marshal descriptor into its adapter representation with err: %v", err)
+			ce = ce.Appendf(fmt.Sprintf("Descriptor[%s]", desc.Name), "failed to marshal descriptor into its adapter representation: %v", err)
 		}
 
 		if quota.MaxAmount < 0 {
@@ -130,7 +130,7 @@ func (w *quotasExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator, qma
 
 	labels, err := evalAll(info.labels, attrs, mapper)
 	if err != nil {
-		msg := fmt.Sprintf("Unable to evaluate labels for quota '%s' with err: %s", qma.Quota, err)
+		msg := fmt.Sprintf("Unable to evaluate labels for quota '%s': %v", qma.Quota, err)
 		glog.Error(msg)
 		return status.WithInvalidArgument(msg), nil
 	}
@@ -182,7 +182,7 @@ func quotaDefinitionFromProto(desc *dpb.QuotaDescriptor) (*adapter.QuotaDefiniti
 	for name, labelType := range desc.Labels {
 		l, err := valueTypeToLabelType(labelType)
 		if err != nil {
-			return nil, fmt.Errorf("descriptor '%s' label '%v' failed to convert label type value '%v' from proto with err: %s",
+			return nil, fmt.Errorf("descriptor '%s' label '%v' failed to convert label type value '%v' from proto: %v",
 				desc.Name, name, labelType, err)
 		}
 		labels[name] = l

--- a/pkg/config/apiserver.go
+++ b/pkg/config/apiserver.go
@@ -139,7 +139,7 @@ func getRules(store KeyValueStore, path string) (statusCode int, msg string, dat
 
 	m := &pb.ServiceConfig{}
 	if err := yaml.Unmarshal([]byte(val), m); err != nil {
-		msg := fmt.Sprintf("unable to parse rules at %s: %s", path, err.Error())
+		msg := fmt.Sprintf("unable to parse rules at '%s': %v", path, err)
 		glog.Warning(msg)
 		return http.StatusInternalServerError, msg, nil
 	}

--- a/pkg/config/fsstore.go
+++ b/pkg/config/fsstore.go
@@ -90,7 +90,7 @@ func (f *fsStore) Get(key string) (value string, index int, found bool) {
 
 	if b, err = f.readfile(p); err != nil {
 		if !os.IsNotExist(err) {
-			glog.Warningf("Could not access %s: %s", p, err)
+			glog.Warningf("Could not access '%s': %v", p, err)
 		}
 		return "", indexNotSupported, false
 	}

--- a/pkg/config/fsstore_test.go
+++ b/pkg/config/fsstore_test.go
@@ -84,7 +84,7 @@ func testStore(t *testing.T, kvMgrfn func() *KVMgr) {
 				kc := getContents(key)
 				_, err := s.Set(key, kc)
 				if err != nil {
-					t.Errorf("Unexpected error for %s: %s", key, err)
+					t.Errorf("Unexpected error for %s: %v", key, err)
 				}
 				val, _, found = s.Get(key)
 				if !found || kc != val {
@@ -100,7 +100,7 @@ func testStore(t *testing.T, kvMgrfn func() *KVMgr) {
 			}
 			err = s.Delete(k[1])
 			if err != nil {
-				t.Errorf("unexpected error: %s", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 
 			_, _, found = s.Get(k[1])
@@ -238,7 +238,7 @@ func TestFSStore_Delete(t *testing.T) {
 			}
 			err := f.Delete("K1")
 			if tst.success && err != nil {
-				t.Errorf("unexpected error: %s", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 
 		})

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -163,7 +163,7 @@ func (c *Manager) fetch() (*runtime, descriptor.Finder, error) {
 
 	vd, finder, cerr = c.validate(data)
 	if cerr != nil {
-		glog.Warningf("Validation failed: %s", cerr.String())
+		glog.Warningf("Validation failed: %v", cerr)
 		return nil, nil, cerr
 	}
 	c.lastFetchIndex = index

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -237,13 +237,13 @@ func (p *validator) validateDescriptors(key string, cfg string) (ce *adapter.Con
 	if data, err = compatfilterConfig(cfg, func(s string) bool {
 		return s != "adapters"
 	}); err != nil {
-		return ce.Appendf("DescriptorConfig", "failed to unmarshal config into proto with err: %v", err)
+		return ce.Appendf("DescriptorConfig", "failed to unmarshal config into proto: %v", err)
 	}
 	m := &pb.GlobalConfig{}
 	um := jsonpb.Unmarshaler{AllowUnknownFields: true}
 
 	if err = um.Unmarshal(bytes.NewReader(data), m); err != nil {
-		return ce.Appendf("DescriptorConfig", "failed to unmarshal <%s> config into proto with err: %v", string(data), err)
+		return ce.Appendf("DescriptorConfig", "failed to unmarshal <%s> config into proto: %v", string(data), err)
 	}
 
 	p.validated.descriptor[key] = m
@@ -273,7 +273,7 @@ func (p *validator) validateAdapters(key string, cfg string) (ce *adapter.Config
 	p.validated.adapterByName = make(map[adapterKey]*pb.Adapter)
 	for _, aa := range m.GetAdapters() {
 		if acfg, err = convertAdapterParams(p.adapterFinder, aa.Impl, aa.Params, p.strict); err != nil {
-			ce = ce.Appendf("Adapter: "+aa.Impl, "failed to convert aspect params to proto with err: %v", err)
+			ce = ce.Appendf("Adapter: "+aa.Impl, "failed to convert aspect params to proto: %v", err)
 			continue
 		}
 		aa.Params = acfg
@@ -311,7 +311,7 @@ func (p *validator) validateAspectRules(rules []*pb.AspectRule, path string, val
 		path = path + "/" + rule.GetSelector()
 		for idx, aa := range rule.GetAspects() {
 			if acfg, err = convertAspectParams(p.managerFinder, aa.Kind, aa.GetParams(), p.strict, p.descriptorFinder); err != nil {
-				ce = ce.Appendf(fmt.Sprintf("%s:%s[%d]", path, aa.Kind, idx), "failed to parse params with err: %v", err)
+				ce = ce.Appendf(fmt.Sprintf("%s:%s[%d]", path, aa.Kind, idx), "failed to parse params: %v", err)
 				continue
 			}
 			aa.Params = acfg
@@ -490,7 +490,7 @@ func convertAspectParams(f AspectValidatorFinder, name string, params interface{
 func decode(src interface{}, dst proto.Message, strict bool) error {
 	ba, err := json.Marshal(src)
 	if err != nil {
-		return fmt.Errorf("failed to marshal config into json with err: %v", err)
+		return fmt.Errorf("failed to marshal config into json: %v", err)
 	}
 	um := jsonpb.Unmarshaler{AllowUnknownFields: !strict}
 	if err := um.Unmarshal(bytes.NewReader(ba), dst); err != nil {

--- a/pkg/expr/eval_test.go
+++ b/pkg/expr/eval_test.go
@@ -215,13 +215,13 @@ func TestGoodEval(tt *testing.T) {
 			attrs := &bag{attrs: tst.tmap}
 			exp, err := Parse(tst.src)
 			if err != nil {
-				t.Errorf("[%d] unexpected error: %s", idx, err)
+				t.Errorf("[%d] unexpected error: %v", idx, err)
 				return
 			}
 			res, err := exp.Eval(attrs, FuncMap())
 			if err != nil {
 				if tst.err == "" {
-					t.Errorf("[%d] unexpected error: %s", idx, err)
+					t.Errorf("[%d] unexpected error: %v", idx, err)
 				} else if !strings.Contains(err.Error(), tst.err) {
 					t.Errorf("[%d] got %s\nwant %s", idx, err, tst.err)
 				}
@@ -255,7 +255,7 @@ func TestCEXLEval(tt *testing.T) {
 			map[string]interface{}{
 				"a": int64(2),
 			},
-			true, "parse error", anyType,
+			true, "unable to parse", anyType,
 		},
 		{
 			"a == 2",
@@ -349,7 +349,7 @@ func TestCexlValidate(tt *testing.T) {
 		err string
 	}{
 		{"a", success},
-		{"a=b", "parse error"},
+		{"a=b", "unable to parse"},
 	}
 
 	ev := NewCEXLEvaluator()

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -375,7 +375,7 @@ func processFunc(fn *Function, args []ast.Expr) (err error) {
 func Parse(src string) (ex *Expression, err error) {
 	a, err := parser.ParseExpr(src)
 	if err != nil {
-		return nil, fmt.Errorf("parse error: %s %s", src, err)
+		return nil, fmt.Errorf("unable to parse expression '%s': %v", src, err)
 	}
 	if glog.V(4) {
 		glog.Infof("Parsed expression '%s' into '%s'", src, a)
@@ -432,7 +432,7 @@ func (e *cexl) EvalPredicate(s string, attrs attribute.Bag) (ret bool, err error
 func (e *cexl) TypeCheck(expr string, attrFinder AttributeDescriptorFinder) (config.ValueType, error) {
 	v, err := Parse(expr)
 	if err != nil {
-		return config.VALUE_TYPE_UNSPECIFIED, fmt.Errorf("failed to parse expression '%s' with err: %v", expr, err)
+		return config.VALUE_TYPE_UNSPECIFIED, fmt.Errorf("failed to parse expression '%s': %v", expr, err)
 	}
 	return v.TypeCheck(attrFinder, e.fMap)
 }

--- a/pkg/expr/expr_test.go
+++ b/pkg/expr/expr_test.go
@@ -91,8 +91,8 @@ func TestBadParse(t *testing.T) {
 		err string
 	}{
 		{`*a != b`, "unexpected expression"},
-		{"a = bc", `parse error`},
-		{`3 = 10`, "parse error"},
+		{"a = bc", `unable to parse`},
+		{`3 = 10`, "unable to parse"},
 		{`a.b.c() == 20`, "unexpected expression"},
 		{`a.b().c() == 20`, "unexpected expression"},
 		{`(a.c).d == 300`, `unexpected expression`},
@@ -100,7 +100,7 @@ func TestBadParse(t *testing.T) {
 		{`(*a == 20) && 12`, `unexpected expression`},
 		{`!*a`, `unexpected expression`},
 		{`request.headers[*a] == 200`, `unexpected expression`},
-		{`atr == 'aaa'`, "parse error"},
+		{`atr == 'aaa'`, "unable to parse"},
 	}
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.src), func(t *testing.T) {

--- a/pkg/tracing/attributes_test.go
+++ b/pkg/tracing/attributes_test.go
@@ -37,7 +37,7 @@ var (
 func TestContext(t *testing.T) {
 	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
-		t.Errorf("Failed to construct bag with err: %s", err)
+		t.Errorf("Failed to construct bag: %v", err)
 	}
 
 	if c := FromContext(context.Background()); c != nil {
@@ -56,7 +56,7 @@ func TestContext(t *testing.T) {
 func TestSet(t *testing.T) {
 	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
-		t.Errorf("Failed to construct bag with err: %s", err)
+		t.Errorf("Failed to construct bag: %v", err)
 	}
 
 	cases := []struct {
@@ -79,7 +79,7 @@ func TestSet(t *testing.T) {
 func TestForeachKey(t *testing.T) {
 	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
-		t.Errorf("Failed to construct bag with err: %s", err)
+		t.Errorf("Failed to construct bag: %v", err)
 	}
 
 	cases := []struct {
@@ -108,7 +108,7 @@ func TestForeachKey(t *testing.T) {
 func TestForeachKey_PropagatesErr(t *testing.T) {
 	bag, err := attribute.NewManager().NewTracker().ApplyProto(attrs)
 	if err != nil {
-		t.Errorf("Failed to construct bag with err: %s", err)
+		t.Errorf("Failed to construct bag: %v", err)
 	}
 
 	c := NewCarrier(bag)

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -103,7 +103,7 @@ func TestPropagateSpan(t *testing.T) {
 
 	sCtx, err := tracer.Extract(ot.HTTPHeaders, metadataReaderWriter{md})
 	if err != nil {
-		t.Errorf("Failed to extract metadata with err: %s", err)
+		t.Errorf("Failed to extract metadata: %v", err)
 	}
 
 	mockSpan, _ := span.(*mocktracer.MockSpan)


### PR DESCRIPTION
- Remove redundant use of "with err" in many error messages. These
were leading to generally confusing output.

- Try to use %v to format errors instead of %s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/557)
<!-- Reviewable:end -->
