### PR TITLE
Introduce "strict" selector evaluation during config resolution.

### DIFF
--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -128,7 +128,7 @@ func newManager(r builderFinder, m [config.NumKinds]aspect.Manager, exp expr.Eva
 
 // Check dispatches to the set of aspects associated with the Check API method
 func (m *Manager) Check(ctx context.Context, requestBag, responseBag *attribute.MutableBag) rpc.Status {
-	configs, err := m.loadConfigs(requestBag, m.checkKindSet, false)
+	configs, err := m.loadConfigs(requestBag, m.checkKindSet, false, true /* fail if unable to eval all selectors */)
 	if err != nil {
 		glog.Error(err)
 		return status.WithError(err)
@@ -142,7 +142,7 @@ func (m *Manager) Check(ctx context.Context, requestBag, responseBag *attribute.
 
 // Report dispatches to the set of aspects associated with the Report API method
 func (m *Manager) Report(ctx context.Context, requestBag, responseBag *attribute.MutableBag) rpc.Status {
-	configs, err := m.loadConfigs(requestBag, m.reportKindSet, false)
+	configs, err := m.loadConfigs(requestBag, m.reportKindSet, false, false /* carry on if unable to eval all selectors */)
 	if err != nil {
 		glog.Error(err)
 		return status.WithError(err)
@@ -160,7 +160,7 @@ func (m *Manager) Quota(ctx context.Context, requestBag, responseBag *attribute.
 
 	var qmr *aspect.QuotaMethodResp
 
-	configs, err := m.loadConfigs(requestBag, m.quotaKindSet, false)
+	configs, err := m.loadConfigs(requestBag, m.quotaKindSet, false, true /* fail if unable to eval all selectors */)
 	if err != nil {
 		glog.Error(err)
 		return qmr, status.WithError(err)
@@ -177,16 +177,19 @@ func (m *Manager) Quota(ctx context.Context, requestBag, responseBag *attribute.
 	return qmr, o
 }
 
-func (m *Manager) loadConfigs(attrs attribute.Bag, ks config.KindSet, isPreprocess bool) ([]*cpb.Combined, error) {
+func (m *Manager) loadConfigs(attrs attribute.Bag, ks config.KindSet, isPreprocess bool, strict bool) ([]*cpb.Combined, error) {
 	cfg, _ := m.cfg.Load().(config.Resolver)
 	if cfg == nil {
 		return nil, errors.New("configuration is not yet available")
 	}
-	resolveFn := cfg.Resolve
+
+	var configs []*cpb.Combined
+	var err error
 	if isPreprocess {
-		resolveFn = cfg.ResolveUnconditional
+		configs, err = cfg.ResolveUnconditional(attrs, ks)
+	} else {
+		configs, err = cfg.Resolve(attrs, ks, strict)
 	}
-	configs, err := resolveFn(attrs, ks)
 	if err != nil {
 		return nil, fmt.Errorf("unable to resolve config: %v", err)
 	}
@@ -199,7 +202,7 @@ func (m *Manager) loadConfigs(attrs attribute.Bag, ks config.KindSet, isPreproce
 // Preprocess dispatches to the set of aspects that must run before any other
 // configured aspects.
 func (m *Manager) Preprocess(ctx context.Context, requestBag, responseBag *attribute.MutableBag) rpc.Status {
-	configs, err := m.loadConfigs(requestBag, m.preprocessKindSet, true)
+	configs, err := m.loadConfigs(requestBag, m.preprocessKindSet, true, true /* fail if unable to eval all selectors */)
 	if err != nil {
 		glog.Error(err)
 		return status.WithError(err)

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -116,7 +116,7 @@ func (f *fakeResolver) Resolve(bag attribute.Bag, kindSet config.KindSet, strict
 	return f.ret, f.err
 }
 
-func (f *fakeResolver) ResolveUnconditional(bag attribute.Bag, kindSet config.KindSet) ([]*cpb.Combined, error) {
+func (f *fakeResolver) ResolveUnconditional(bag attribute.Bag, kindSet config.KindSet, strict bool) ([]*cpb.Combined, error) {
 	return f.ret, f.err
 }
 

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -112,7 +112,7 @@ type (
 	}
 )
 
-func (f *fakeResolver) Resolve(bag attribute.Bag, kindSet config.KindSet) ([]*cpb.Combined, error) {
+func (f *fakeResolver) Resolve(bag attribute.Bag, kindSet config.KindSet, strict bool) ([]*cpb.Combined, error) {
 	return f.ret, f.err
 }
 

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -33,7 +33,7 @@ import (
 // Resolver resolves configuration to a list of combined configs.
 type Resolver interface {
 	// Resolve resolves configuration to a list of combined configs.
-	Resolve(bag attribute.Bag, kindSet KindSet) ([]*pb.Combined, error)
+	Resolve(bag attribute.Bag, kindSet KindSet, strict bool) ([]*pb.Combined, error)
 	// ResolveUnconditional resolves configuration for unconditioned rules.
 	// Unconditioned rules are those rules with the empty selector ("").
 	ResolveUnconditional(bag attribute.Bag, kindSet KindSet) ([]*pb.Combined, error)

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -36,7 +36,7 @@ type Resolver interface {
 	Resolve(bag attribute.Bag, kindSet KindSet, strict bool) ([]*pb.Combined, error)
 	// ResolveUnconditional resolves configuration for unconditioned rules.
 	// Unconditioned rules are those rules with the empty selector ("").
-	ResolveUnconditional(bag attribute.Bag, kindSet KindSet) ([]*pb.Combined, error)
+	ResolveUnconditional(bag attribute.Bag, kindSet KindSet, strict bool) ([]*pb.Combined, error)
 }
 
 // ChangeListener listens for config change notifications.

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -98,7 +98,9 @@ func (r *runtime) Resolve(bag attribute.Bag, set KindSet, strict bool) (dlist []
 // attributes and kindset based on resolution of unconditional rules. That is,
 // it only attempts to find aspects in rules that have an empty selector. This
 // method is primarily used for pre-process aspect configuration retrieval.
-func (r *runtime) ResolveUnconditional(bag attribute.Bag, set KindSet) (out []*pb.Combined, err error) {
+// If strict is true, resolution will fail if any selector evaluations fail; otherwise it will log errors and return
+// as much config as we were able to resolve.
+func (r *runtime) ResolveUnconditional(bag attribute.Bag, set KindSet, strict bool) (out []*pb.Combined, err error) {
 	if glog.V(2) {
 		glog.Infof("unconditionally resolving for kinds: %s", set)
 		defer func() { glog.Infof("unconditionally resolved configs (err=%v): %s", err, out) }()
@@ -111,7 +113,7 @@ func (r *runtime) ResolveUnconditional(bag attribute.Bag, set KindSet) (out []*p
 		true, /* unconditional resolve */
 		r.identityAttribute,
 		r.identityAttributeDomain,
-		true /* enable strict eval; doesn't matter since selectors are "" */)
+		strict)
 }
 
 // Make this a reasonable number so that we don't reallocate slices often.

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -76,13 +76,22 @@ func GetScopes(attr string, domain string, scopes []string) ([]string, error) {
 // It will only return config from the requested set of aspects.
 // For example the Check handler and Report handler will request
 // a disjoint set of aspects check: {iplistChecker, iam}, report: {Log, metrics}
-func (r *runtime) Resolve(bag attribute.Bag, set KindSet) (dlist []*pb.Combined, err error) {
+// If strict is true, resolution will fail if any selector evaluations fail; otherwise it will log errors and return
+// as much config as we were able to resolve.
+func (r *runtime) Resolve(bag attribute.Bag, set KindSet, strict bool) (dlist []*pb.Combined, err error) {
 	if glog.V(4) {
 		glog.Infof("resolving for kinds: %s", set)
 		defer func() { glog.Infof("resolved configs (err=%v): %s", err, dlist) }()
 	}
-	return resolve(bag, set, r.rule, r.resolveRules, false, /* conditional full resolve */
-		r.identityAttribute, r.identityAttributeDomain)
+	return resolve(
+		bag,
+		set,
+		r.rule,
+		r.resolveRules,
+		false, /* conditional full resolve */
+		r.identityAttribute,
+		r.identityAttributeDomain,
+		strict)
 }
 
 // ResolveUnconditional returns the list of CombinedConfigs for the supplied
@@ -94,8 +103,15 @@ func (r *runtime) ResolveUnconditional(bag attribute.Bag, set KindSet) (out []*p
 		glog.Infof("unconditionally resolving for kinds: %s", set)
 		defer func() { glog.Infof("unconditionally resolved configs (err=%v): %s", err, out) }()
 	}
-	return resolve(bag, set, r.rule, r.resolveRules, true, /* unconditional resolve */
-		r.identityAttribute, r.identityAttributeDomain)
+	return resolve(
+		bag,
+		set,
+		r.rule,
+		r.resolveRules,
+		true, /* unconditional resolve */
+		r.identityAttribute,
+		r.identityAttributeDomain,
+		true /* enable strict eval; doesn't matter since selectors are "" */)
 }
 
 // Make this a reasonable number so that we don't reallocate slices often.
@@ -103,7 +119,7 @@ const resolveSize = 50
 
 // resolve - the main config resolution function.
 func resolve(bag attribute.Bag, kindSet KindSet, rules map[rulesKey]*pb.ServiceConfig, resolveRules resolveRulesFunc,
-	onlyEmptySelectors bool, identityAttribute string, identityAttributeDomain string) (dlist []*pb.Combined, err error) {
+	onlyEmptySelectors bool, identityAttribute string, identityAttributeDomain string, strictSelectorEval bool) (dlist []*pb.Combined, err error) {
 	scopes := make([]string, 0, 10)
 
 	attr, _ := bag.Get(identityAttribute)
@@ -136,7 +152,7 @@ func resolve(bag attribute.Bag, kindSet KindSet, rules map[rulesKey]*pb.ServiceC
 			}
 			// empty the slice, do not re allocate
 			dlist = dlist[:0]
-			if dlist, err = resolveRules(bag, kindSet, rule.GetRules(), "/", dlist, onlyEmptySelectors); err != nil {
+			if dlist, err = resolveRules(bag, kindSet, rule.GetRules(), "/", dlist, onlyEmptySelectors, strictSelectorEval); err != nil {
 				return dlist, err
 			}
 
@@ -169,11 +185,13 @@ func (r *runtime) evalPredicate(selector string, bag attribute.Bag) (bool, error
 }
 
 type resolveRulesFunc func(bag attribute.Bag, kindSet KindSet, rules []*pb.AspectRule, path string,
-	dlist []*pb.Combined, onlyEmptySelectors bool) ([]*pb.Combined, error)
+	dlist []*pb.Combined, onlyEmptySelectors bool, strictSelectorEval bool) ([]*pb.Combined, error)
 
-// resolveRules recurses through the config struct and returns a list of combined aspects
+// resolveRules recurses through the config struct and returns a list of combined aspects. If `strictSelectorEval` is
+// true we will return an error when we fail the evaluate a selector; when it's false we'll return a nil error and as
+// many chunks of config as we were able to resolve.
 func (r *runtime) resolveRules(bag attribute.Bag, kindSet KindSet, rules []*pb.AspectRule, path string,
-	dlist []*pb.Combined, onlyEmptySelectors bool) ([]*pb.Combined, error) {
+	dlist []*pb.Combined, onlyEmptySelectors bool, strictSelectorEval bool) ([]*pb.Combined, error) {
 	var selected bool
 	var lerr error
 	var err error
@@ -191,7 +209,12 @@ func (r *runtime) resolveRules(bag attribute.Bag, kindSet KindSet, rules []*pb.A
 			continue
 		}
 		if selected, lerr = r.evalPredicate(sel, bag); lerr != nil {
-			err = multierror.Append(err, lerr)
+			if glog.V(3) {
+				glog.Infof("Failed to eval selector '%s': %v", sel, lerr)
+			}
+			if strictSelectorEval {
+				err = multierror.Append(err, lerr)
+			}
 			continue
 		}
 		if !selected {
@@ -225,7 +248,7 @@ func (r *runtime) resolveRules(bag attribute.Bag, kindSet KindSet, rules []*pb.A
 		if len(rs) == 0 {
 			continue
 		}
-		if dlist, lerr = r.resolveRules(bag, kindSet, rs, path, dlist, onlyEmptySelectors); lerr != nil {
+		if dlist, lerr = r.resolveRules(bag, kindSet, rs, path, dlist, onlyEmptySelectors, strictSelectorEval); lerr != nil {
 			err = multierror.Append(err, lerr)
 		}
 	}

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -459,7 +459,7 @@ func TestRuntime_ResolveUnconditional(t *testing.T) {
 		}
 		rt := newRuntime(v, fe, keyTargetService, keyServiceDomain)
 
-		al, err := rt.ResolveUnconditional(bag, kinds)
+		al, err := rt.ResolveUnconditional(bag, kinds, true)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -117,7 +117,7 @@ func newFakeResolver(kinds []string, kind KindSet, re error) *fakeresolver {
 }
 
 func (fr *fakeresolver) rrf(bag attribute.Bag, kindSet KindSet, rules []*pb.AspectRule, path string,
-	dlist []*pb.Combined, onlyEmptySelectors bool) ([]*pb.Combined, error) {
+	dlist []*pb.Combined, onlyEmptySelectors bool, strictSelectorEval bool) ([]*pb.Combined, error) {
 	if fr.resolveError != nil {
 		return nil, fr.resolveError
 	}
@@ -245,7 +245,7 @@ func TestResolve(t *testing.T) {
 			b := &bag{attrs}
 			var ks KindSet = 0xff
 			fr := newFakeResolver(tt.kinds, ks, tt.resolveError)
-			dl, err := resolve(b, ks, rules, fr.rrf, tt.onlyEmptySelectors, keyTargetService, keyServiceDomain)
+			dl, err := resolve(b, ks, rules, fr.rrf, tt.onlyEmptySelectors, keyTargetService, keyServiceDomain, true)
 			if err != nil {
 				if tt.err == nil {
 					t1.Fatal("Unexpected Error", err)
@@ -353,7 +353,7 @@ func TestRuntime(t *testing.T) {
 		}
 		rt := newRuntime(v, fe, keyTargetService, keyServiceDomain)
 
-		al, err := rt.Resolve(bag, kinds)
+		al, err := rt.Resolve(bag, kinds, true)
 
 		if tt.err != nil {
 			if err != tt.err {


### PR DESCRIPTION
Add the concept of strict selector evaluation to config resolution: when resolution is not strict we allow selector evaluation to fail but report success in config resolution, returning as many configs as we have. Otherwise we fail resolution. We wire it up so that `Check` and `Quota` are strict while `Report` is non-strict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/572)
<!-- Reviewable:end -->
