### PR TITLE
Tolerate missing identity attribute for pre-process adapters

### DIFF
--- a/adapter/kubernetes/config/BUILD
+++ b/adapter/kubernetes/config/BUILD
@@ -7,7 +7,7 @@ gogoslick_proto_library(
         "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
     },
     imports = [
-        "../../../../external/com_github_gogo_protobuf",
+        "external/com_github_gogo_protobuf",
         "external/com_github_google_protobuf/src",
     ],
     inputs = [


### PR DESCRIPTION
Tolerate missing identity attribute for pre-process adapters.

if identity attribute is available, perform normal operation.
If not and if `onlyEmptySelectors==true` then use `global` scope which is always in scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/576)
<!-- Reviewable:end -->
