### PR TITLE
Add canonicalization of service names to k8s adapter

### DIFF
--- a/adapter/kubernetes/cache_test.go
+++ b/adapter/kubernetes/cache_test.go
@@ -163,3 +163,22 @@ func TestClusterInfoCache_Run(t *testing.T) {
 		t.Error("Expected cache to have been started.")
 	}
 }
+
+func TestClusterInfoCache_RunLoggerStopInSelect(t *testing.T) {
+	informer := &fakeInformer{}
+	c := &controllerImpl{
+		env:           test.NewEnv(t),
+		pods:          informer,
+		mutationsChan: make(chan resourceMutation),
+	}
+
+	stop := make(chan struct{})
+	go c.Run(stop)
+
+	c.mutationsChan <- resourceMutation{kind: deletion, obj: v1.Pod{}}
+
+	close(stop)
+	if !informer.RunCalled() {
+		t.Error("Expected cache to have been started.")
+	}
+}

--- a/adapter/kubernetes/config/config.proto
+++ b/adapter/kubernetes/config/config.proto
@@ -40,6 +40,7 @@ option (gogoproto.gostring_all) = false;
 // sourceUID and the output value of pod ip, this adapter will output a map
 // that includes a key of "sourcePodIP" (assuming parameter defaults).
 message Params {
+    // next field id: 19
 
     // File path to discover kubeconfig. For in-cluster configuration,
     // this should be left unset. For local configuration, this should
@@ -73,6 +74,19 @@ message Params {
     //
     // Default: originUID
     string origin_uid_input_name = 5;
+
+    // Configures how the identifier for the target service is populated in
+    // the input map (if at all). When supplied, this value will be used (after
+    // successful normalization) in place of the value derived from the pod
+    // cache for the target pod in the generated map of output values.
+    //
+    // Default: targetService
+    string target_service_input_name = 17;
+
+    // Configures the cluster domain name to use for service name normalization.
+    //
+    // Default: svc.cluster.local
+    string cluster_domain_name = 18;
 
     // In order to extract the service associated with a source, target, or
     // origin, this adapter relies on pod labels. In particular, it looks for

--- a/adapter/kubernetes/kubernetes.go
+++ b/adapter/kubernetes/kubernetes.go
@@ -20,7 +20,9 @@
 package kubernetes
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -60,7 +62,8 @@ const (
 	desc = "Provides platform specific functionality for the kubernetes environment"
 
 	// parsing
-	kubePrefix = "kubernetes://"
+	kubePrefix       = "kubernetes://"
+	defaultNamespace = "default"
 
 	// input/output naming
 	sourceUID         = "sourceUID"
@@ -78,6 +81,8 @@ const (
 	serviceVal        = "Service"
 
 	// value extraction
+	targetService   = "targetService"
+	clusterDomain   = "svc.cluster.local"
 	podServiceLabel = "app"
 
 	// cache invaliation
@@ -92,6 +97,8 @@ var (
 		SourceUidInputName:      sourceUID,
 		TargetUidInputName:      targetUID,
 		OriginUidInputName:      originUID,
+		TargetServiceInputName:  targetService,
+		ClusterDomainName:       clusterDomain,
 		PodLabelForService:      podServiceLabel,
 		SourcePrefix:            sourcePrefix,
 		TargetPrefix:            targetPrefix,
@@ -165,6 +172,14 @@ func (*builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	if len(params.PodLabelForService) == 0 {
 		ce = ce.Appendf("pod_label_name", "field must be populated")
 	}
+	if len(params.TargetServiceInputName) == 0 {
+		ce = ce.Appendf("target_service_input_name", "field must be populated")
+	}
+	if len(params.ClusterDomainName) == 0 {
+		ce = ce.Appendf("cluster_domain_name", "field must be populated")
+	} else if len(strings.Split(params.ClusterDomainName, ".")) != 3 {
+		ce = ce.Appendf("cluster_domain_name", "must have three segments, separated by '.' ('svc.cluster.local', for example)")
+	}
 	return
 }
 
@@ -201,7 +216,7 @@ func newCacheFromConfig(kubeconfigPath string, refreshDuration time.Duration, en
 	if err != nil || config == nil {
 		return nil, fmt.Errorf("could not retrieve kubeconfig: %v", err)
 	}
-	env.Logger().Infof("getting k8s client with %#v", config)
+	env.Logger().Infof("getting k8s client from config")
 	clientset, err := k8s.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("could not create clientset for k8s: %v", err)
@@ -220,15 +235,32 @@ func (k *kubegen) Generate(inputs map[string]interface{}) (map[string]interface{
 	values := make(map[string]interface{})
 	if uid, found := inputs[k.params.SourceUidInputName]; found {
 		uidstr := uid.(string)
-		k.addValues(values, uidstr, k.params.SourcePrefix)
+		if len(uidstr) > 0 {
+			k.addValues(values, uidstr, k.params.SourcePrefix)
+		}
 	}
 	if uid, found := inputs[k.params.TargetUidInputName]; found {
 		uidstr := uid.(string)
-		k.addValues(values, uidstr, k.params.TargetPrefix)
+		if len(uidstr) > 0 {
+			k.addValues(values, uidstr, k.params.TargetPrefix)
+		}
 	}
 	if uid, found := inputs[k.params.OriginUidInputName]; found {
 		uidstr := uid.(string)
-		k.addValues(values, uidstr, k.params.OriginPrefix)
+		if len(uidstr) > 0 {
+			k.addValues(values, uidstr, k.params.OriginPrefix)
+		}
+	}
+	if targetSvc, found := inputs[k.params.TargetServiceInputName]; found {
+		svc := targetSvc.(string)
+		if len(svc) > 0 {
+			n, err := canonicalName(svc, defaultNamespace, k.params.ClusterDomainName)
+			if err != nil {
+				k.log.Warningf("could not canonicalize target service: %v", err)
+			} else {
+				values[valueName(k.params.TargetPrefix, k.params.ServiceValueName)] = n
+			}
+		}
 	}
 	return values, nil
 }
@@ -243,9 +275,6 @@ func (k *kubegen) addValues(vals map[string]interface{}, uid, valPrefix string) 
 }
 
 func keyFromUID(uid string) string {
-	if len(uid) == 0 {
-		return ""
-	}
 	fullname := strings.TrimPrefix(uid, kubePrefix)
 	if strings.Contains(fullname, ".") {
 		parts := strings.Split(fullname, ".")
@@ -260,17 +289,76 @@ func addPodValues(m map[string]interface{}, prefix string, params config.Params,
 	if p == nil {
 		return
 	}
-	m[valueName(prefix, params.LabelsValueName)] = p.Labels
-	m[valueName(prefix, params.PodNameValueName)] = p.Name
-	m[valueName(prefix, params.NamespaceValueName)] = p.Namespace
-	m[valueName(prefix, params.ServiceAccountValueName)] = p.Spec.ServiceAccountName
-	m[valueName(prefix, params.PodIpValueName)] = p.Status.PodIP
-	m[valueName(prefix, params.HostIpValueName)] = p.Status.HostIP
+	if len(p.Labels) > 0 {
+		m[valueName(prefix, params.LabelsValueName)] = p.Labels
+	}
+	if len(p.Name) > 0 {
+		m[valueName(prefix, params.PodNameValueName)] = p.Name
+	}
+	if len(p.Namespace) > 0 {
+		m[valueName(prefix, params.NamespaceValueName)] = p.Namespace
+	}
+	if len(p.Spec.ServiceAccountName) > 0 {
+		m[valueName(prefix, params.ServiceAccountValueName)] = p.Spec.ServiceAccountName
+	}
+	if len(p.Status.PodIP) > 0 {
+		m[valueName(prefix, params.PodIpValueName)] = p.Status.PodIP
+	}
+	if len(p.Status.HostIP) > 0 {
+		m[valueName(prefix, params.HostIpValueName)] = p.Status.HostIP
+	}
 	if app, found := p.Labels[params.PodLabelForService]; found {
-		m[valueName(prefix, params.ServiceValueName)] = app
+		n, err := canonicalName(app, p.Namespace, params.ClusterDomainName)
+		if err == nil {
+			m[valueName(prefix, params.ServiceValueName)] = n
+		}
 	}
 }
 
 func valueName(prefix, value string) string {
 	return fmt.Sprintf("%s%s", prefix, value)
+}
+
+// name format examples that can be currently canonicalized:
+//
+// "hello:80",
+// "hello",
+// "hello.default:80",
+// "hello.default",
+// "hello.default.svc:80",
+// "hello.default.svc",
+// "hello.default.svc.cluster:80",
+// "hello.default.svc.cluster",
+// "hello.default.svc.cluster.local:80",
+// "hello.default.svc.cluster.local",
+func canonicalName(service, namespace, clusterDomain string) (string, error) {
+	if len(service) == 0 {
+		return "", errors.New("invalid service name: cannot be empty")
+	}
+	// remove any port suffixes (ex: ":80")
+	splits := strings.SplitN(service, ":", 2)
+	s := splits[0]
+	if len(s) == 0 {
+		return "", errors.New("invalid service name: starts with ':'")
+	}
+	// error on ip addresses for now
+	if ip := net.ParseIP(s); ip != nil {
+		return "", errors.New("invalid service name: cannot canonicalize ip addresses at this time")
+	}
+	parts := strings.SplitN(s, ".", 5)
+	if len(parts) == 1 {
+		return fmt.Sprintf("%s.%s.%s", parts[0], namespace, clusterDomain), nil
+	}
+	if len(parts) == 2 {
+		return fmt.Sprintf("%s.%s", s, clusterDomain), nil
+	}
+	if len(parts) == 3 {
+		dom := strings.SplitAfterN(clusterDomain, ".", 2)
+		return fmt.Sprintf("%s.%s", s, dom[1]), nil
+	}
+	if len(parts) == 4 {
+		dom := strings.SplitAfterN(clusterDomain, ".", 3)
+		return fmt.Sprintf("%s.%s", s, dom[2]), nil
+	}
+	return s, nil
 }

--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -22,7 +22,7 @@ adapters:
       # when running from mixer root, use the following config after adding a
       # symbolic link to a kubernetes config file via:
       #
-      # $ ln -s ~/.kube/config adapter/kubernets/kubeconfig
+      # $ ln -s ~/.kube/config adapter/kubernetes/kubeconfig
       #
       # kubeconfig_path: "adapter/kubernetes/kubeconfig"
 manifests:
@@ -64,6 +64,8 @@ manifests:
     - name: request.method
       value_type: STRING
     - name: request.path
+      value_type: STRING
+    - name: request.host
       value_type: STRING
     - name: request.headers
       value_type: STRING_MAP

--- a/testdata/serviceconfig.yml
+++ b/testdata/serviceconfig.yml
@@ -3,12 +3,16 @@ revision: "2022"
 rules:
 - selector: # must be empty for preprocessing adapters
   aspects:
+  # when running local without a kubeconfig file specified in globalconfig,
+  # this aspect should be commented out. It is only needed when the attributes
+  # it produces are needed elsewhere in the config.
   - kind: attributes
     params:
       input_expressions:
         sourceUID: source.uid | ""
         targetUID: target.uid | ""
         originUID: origin.uid | ""
+        targetService: request.headers["authority"] | request.host | ""
       attribute_bindings:
         source.ip: sourcePodIp
         source.service: sourceService
@@ -16,6 +20,7 @@ rules:
         source.namespace: sourceNamespace
         source.labels: sourceLabels
         source.serviceAccount: sourceServiceAccountName
+        target.service: targetService
   - kind: quotas
     params:
       quotas:


### PR DESCRIPTION
This adds the ability to take an indication of target service and canonicalize it (and other service names) to the kubernetes adapter.

To support this canonicalization, two additional input config params are added to the config.proto:
1. target_service_input_name
1. cluster_domain_name

These new params allow the operator to configure how canonicalization, particularly of target service will work. Example config for using these params (with their default values) can be seen in the updated serviceconfig.yml included in this PR.

This PR also addresses a few minor issues in the kubernetes adapter that were raised, but delayed, from the initial PR (debug-only logging and the need for better stop chan handling in the debug logger).

In addition to unit testing, this PR was tested via cli, as follows:

```shell
./bazel-bin/cmd/server/mixs server --globalConfigFile=testdata/globalconfig.yml --serviceConfigFile=testdata/serviceconfig.yml --alsologtostderr -v=9
```

```shell
$ ./bazel-bin/cmd/client/mixc report -a target.service=svc.cluster.local,request.headers="authority:foo.maze:999" --string_attributes=source.uid="kubernetes://hello-2992298478-qv9f3.ratelimit"
Report RPC returned OK
  Attribute              Type               Value
  source.labels          map[string]string  map[app:hello pod-template-hash:2992298478 version:v1]
  source.name            string             hello-2992298478-qv9f3
  source.namespace       string             ratelimit
  source.service         string             hello.ratelimit.svc.cluster.local
  source.serviceAccount  string             default
  target.service         string             foo.maze.svc.cluster.local

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/580)
<!-- Reviewable:end -->
