### PR TITLE
jsonpb.Parse with better error reporting

### DIFF
--- a/adapter/kubernetes/BUILD
+++ b/adapter/kubernetes/BUILD
@@ -25,7 +25,10 @@ go_library(
 go_test(
     name = "small_tests",
     size = "small",
-    srcs = ["kubernetes_test.go"],
+    srcs = [
+        "cache_test.go",
+        "kubernetes_test.go",
+    ],
     library = ":go_default_library",
     deps = ["//pkg/adapter/test:go_default_library"],
 )

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -18,8 +18,7 @@ mixer_docker_build(
     entrypoint = [
         "/usr/local/bin/mixs",
         "server",
-        "--globalConfigFile=/etc/opt/mixer/globalconfig.yml",
-        "--serviceConfigFile=/etc/opt/mixer/serviceconfig.yml",
+        "--configStoreURL=fs:///etc/opt/mixer/configroot",
         "--logtostderr",
         "--v=2",
     ],
@@ -35,6 +34,7 @@ mixer_docker_build(
     ],
     ports = [
         "9091",
+        "9094",
         "42422",
     ],
     repository = "istio",

--- a/pkg/config/descriptor/BUILD
+++ b/pkg/config/descriptor/BUILD
@@ -6,8 +6,13 @@ go_library(
     name = "go_default_library",
     srcs = ["descriptor.go"],
     deps = [
+        "//pkg/adapter:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
+        "@com_github_ghodss_yaml//:go_default_library",
+        "@com_github_gogo_protobuf//jsonpb:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
         "@com_github_istio_api//:mixer/v1/config/descriptor",
     ],
 )

--- a/pkg/config/descriptor/descriptor.go
+++ b/pkg/config/descriptor/descriptor.go
@@ -15,7 +15,18 @@
 package descriptor
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/ghodss/yaml"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/glog"
+
 	dpb "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/mixer/pkg/adapter"
 	pb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
 )
@@ -47,6 +58,105 @@ type finder struct {
 	principals         map[string]*dpb.PrincipalDescriptor
 	quotas             map[string]*dpb.QuotaDescriptor
 	attributes         map[string]*dpb.AttributeDescriptor
+}
+
+type newMsg func() (message proto.Message)
+
+var typeMap = map[string]newMsg{
+	"logs":               func() proto.Message { return &dpb.LogEntryDescriptor{} },
+	"metrics":            func() proto.Message { return &dpb.MetricDescriptor{} },
+	"monitoredResources": func() proto.Message { return &dpb.MonitoredResourceDescriptor{} },
+	"principals":         func() proto.Message { return &dpb.PrincipalDescriptor{} },
+	"quotas":             func() proto.Message { return &dpb.QuotaDescriptor{} },
+	"manifests":          func() proto.Message { return &dpb.AttributeDescriptor{} },
+}
+
+// Parse parses a descriptor config in its parts.
+func Parse(cfg string) (dcfg *pb.GlobalConfig, ce *adapter.ConfigErrors) {
+	m := map[string]interface{}{}
+	var err error
+
+	if err = yaml.Unmarshal([]byte(cfg), &m); err != nil {
+		return nil, ce.Append("DescriptorConfig", err)
+	}
+	dcfg = &pb.GlobalConfig{}
+	var cerr *adapter.ConfigErrors
+	var oarr interface{}
+
+	//flatten manifest
+	k := "manifests"
+	val := m[k]
+	if val != nil {
+		mani := []*pb.AttributeManifest{}
+		for _, msft := range val.([]interface{}) {
+			manifest := msft.(map[string]interface{})
+			attr := manifest["attributes"].([]interface{})
+			if oarr, cerr = processArray(fmt.Sprintf("%s/%v", k, manifest["name"]), attr, typeMap[k]); cerr != nil {
+				ce = ce.Extend(cerr)
+				continue
+			}
+
+			mani = append(mani, &pb.AttributeManifest{
+				Attributes: oarr.([]*dpb.AttributeDescriptor),
+			})
+		}
+		dcfg.Manifests = mani
+	}
+
+	for k, kfn := range typeMap {
+		if k == "manifests" {
+			continue
+		}
+		val = m[k]
+		if val == nil {
+			if glog.V(2) {
+				glog.Warningf("%s missing", k)
+			}
+			continue
+		}
+
+		if oarr, cerr = processArray(k, val.([]interface{}), kfn); cerr != nil {
+			ce = ce.Extend(cerr)
+			continue
+		}
+		switch k {
+		case "logs":
+			dcfg.Logs = oarr.([]*dpb.LogEntryDescriptor)
+		case "metrics":
+			dcfg.Metrics = oarr.([]*dpb.MetricDescriptor)
+		case "quotas":
+			dcfg.Quotas = oarr.([]*dpb.QuotaDescriptor)
+		}
+	}
+
+	return
+}
+
+// processArray and return typed array
+func processArray(name string, arr []interface{}, newMessage newMsg) (interface{}, *adapter.ConfigErrors) {
+	var enc []byte
+	var err error
+	var ce *adapter.ConfigErrors
+	nm := newMessage()
+	ptrType := reflect.TypeOf(nm)
+	valType := (reflect.Indirect(reflect.ValueOf(nm))).Type()
+	outarr := reflect.MakeSlice(reflect.SliceOf(ptrType), 0, len(arr))
+	for idx, attr := range arr {
+		if enc, err = json.Marshal(attr); err != nil {
+			ce = ce.Append(fmt.Sprintf("%s[%d]", name, idx), err)
+			continue
+		}
+		dm := reflect.New(valType).Elem().Addr().Interface().(proto.Message)
+
+		if err = jsonpb.Unmarshal(bytes.NewReader(enc), dm); err != nil {
+			ce = ce.Append(fmt.Sprintf("%s[%d]", name, idx), fmt.
+				Errorf("%s: %s", err.Error(), fmt.Sprintf(string(enc))))
+			continue
+
+		}
+		outarr = reflect.Append(outarr, reflect.ValueOf(dm))
+	}
+	return outarr.Interface(), ce
 }
 
 // NewFinder constructs a new Finder for the provided global config.

--- a/pkg/config/descriptor/descriptor.go
+++ b/pkg/config/descriptor/descriptor.go
@@ -55,6 +55,7 @@ type Finder interface {
 
 type dname string
 
+// NOTE: Update this list when new fields are added to the GlobalConfig message.
 const (
 	logs               dname = "logs"
 	metrics                  = "metrics"
@@ -75,22 +76,45 @@ type finder struct {
 }
 
 // typeMap maps descriptor types to example messages of those types.
-// Add example descriptors for all here instead of empty ones.
 var typeMap = map[dname]proto.Message{
-	logs:               &dpb.LogEntryDescriptor{},
-	metrics:            &dpb.MetricDescriptor{},
+	logs: &dpb.LogEntryDescriptor{
+		Name:        "accesslog.common",
+		DisplayName: "Apache Common Log Format",
+		LogTemplate: `{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}}`,
+		Labels: map[string]dpb.ValueType{
+			"sourceUser": dpb.STRING,
+			"timestamp":  dpb.TIMESTAMP,
+			"originIp":   dpb.IP_ADDRESS,
+		},
+	},
+	metrics: &dpb.MetricDescriptor{
+		Kind:        dpb.COUNTER,
+		Value:       dpb.DURATION,
+		Description: "request latency by source, target, and service",
+		Labels: map[string]dpb.ValueType{
+			"source":        dpb.STRING,
+			"target":        dpb.STRING,
+			"service":       dpb.STRING,
+			"response_code": dpb.INT64,
+		},
+	},
+	// Add example for monitoredResources, principals descriptors.
 	monitoredResources: &dpb.MonitoredResourceDescriptor{},
 	principals:         &dpb.PrincipalDescriptor{},
 	quotas: &dpb.QuotaDescriptor{
-		Name:        "testQuota",
-		DisplayName: "The big Quota",
-		Description: "The very big Quota",
+		Name:        "RateLimitByService",
+		DisplayName: "RateLimit",
+		Description: "RateLimit By Service",
 		Labels: map[string]dpb.ValueType{
-			"n1": dpb.BOOL,
+			"target": dpb.STRING,
 		},
-		RateLimit: false,
+		RateLimit: true,
 	},
-	manifests: &dpb.AttributeDescriptor{},
+	manifests: &dpb.AttributeDescriptor{
+		Name:        "target.service",
+		ValueType:   dpb.STRING,
+		Description: "Intended destination of a request",
+	},
 }
 
 // Parse parses a descriptor config into its parts.

--- a/pkg/config/descriptor/descriptor.go
+++ b/pkg/config/descriptor/descriptor.go
@@ -183,8 +183,8 @@ func updateMsg(ctx string, obj interface{}, dm proto.Message, example proto.Mess
 		msg := fmt.Sprintf("%v: [%s]", err, string(enc))
 		if example != nil {
 			um := &jsonpb.Marshaler{}
-			example, _ := um.MarshalToString(example)
-			msg += ", example: " + example
+			exampleStr, _ := um.MarshalToString(example)
+			msg += ", example: " + exampleStr
 		}
 		return ce.Append(ctx, errors.New(msg))
 	}

--- a/pkg/config/descriptor/descriptor_test.go
+++ b/pkg/config/descriptor/descriptor_test.go
@@ -226,7 +226,7 @@ func TestParse_BadInput(t *testing.T) {
 
 	t.Run("NonJsonInput", func(t *testing.T) {
 		nonjson := make(chan int)
-		err := updateMsg("bad", nonjson, nil, nil)
+		err := updateMsg("bad", nonjson, nil, nil, false)
 		checkError(err, "unsupported type", t)
 	})
 }

--- a/pkg/config/descriptor/descriptor_test.go
+++ b/pkg/config/descriptor/descriptor_test.go
@@ -15,10 +15,17 @@
 package descriptor
 
 import (
+	"bytes"
+	"flag"
 	"fmt"
 	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/ghodss/yaml"
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
@@ -171,4 +178,246 @@ func execute(t *testing.T, tests cases) {
 			}
 		})
 	}
+}
+
+func testParser(mutations map[string]interface{}, wantErr string, t *testing.T) {
+	m := map[string]interface{}{}
+	var ba []byte
+	var err error
+	if err := yaml.Unmarshal([]byte(allGoodConfig), &m); err != nil {
+		t.Fatalf("unable unmarshal %s", err)
+	}
+
+	for path, val := range mutations {
+		mutate(m, path, val)
+	}
+
+	if ba, err = yaml.Marshal(m); err != nil {
+		t.Fatalf("unable to marshal %s", err)
+	}
+
+	_, ce := Parse(string(ba))
+	gotErr := ""
+	if ce != nil {
+		gotErr = ce.Error()
+	}
+
+	if !strings.Contains(gotErr, wantErr) {
+		t.Errorf("got %s\nwant %s", gotErr, wantErr)
+	}
+
+}
+
+func checkError(got error, want string, t *testing.T) {
+	msg := "nothing"
+	if got != nil {
+		msg = got.Error()
+	}
+	if !strings.Contains(msg, want) {
+		t.Errorf("got %s\nwant %s", msg, want)
+	}
+}
+
+func TestParse_BadInput(t *testing.T) {
+	t.Run("Bad_Yaml", func(t *testing.T) {
+		_, err := Parse("<badyaml></badyaml>")
+		checkError(err, "DescriptorConfig: error unmarshaling JSON", t)
+	})
+
+	t.Run("NonJsonInput", func(t *testing.T) {
+		nonjson := make(chan int)
+		err := updateMsg("bad", nonjson, nil, nil)
+		checkError(err, "unsupported type", t)
+	})
+}
+
+func TestParseErrors(t *testing.T) {
+	for _, tt := range []struct {
+		m       map[string]interface{}
+		wantErr string
+	}{{map[string]interface{}{
+		"manifests[0].attributes[0].value_type": "WRONG_STRING"},
+		"manifests[0].attributes[0]: unknown value"},
+		{map[string]interface{}{
+			"quotas[0].unknown_attribute": "unknown_value"},
+			"quotas[0]: unknown field"},
+		{map[string]interface{}{
+			"manifests[0].unknown_attribute": "unknown_value"},
+			"manifests[0]: unknown field"},
+	} {
+		t.Run(tt.wantErr, func(tx *testing.T) {
+			testParser(tt.m, tt.wantErr, tx)
+		})
+	}
+}
+
+// ensure that Parse and jsonpb.Parse are equivalent
+func TestParseValid(t *testing.T) {
+	dcfg, ce := Parse(allGoodConfig)
+	if ce != nil {
+		t.Fatalf("Unexpected error %s", ce)
+	}
+
+	jsonConfig, err := yaml.YAMLToJSON([]byte(allGoodConfig))
+	if err != nil {
+		t.Fatalf("could not convert to json %s", err)
+	}
+
+	cfg := &pb.GlobalConfig{}
+	if err := jsonpb.Unmarshal(bytes.NewReader(jsonConfig), cfg); err != nil {
+		t.Fatalf("unable to parse %s", err)
+	}
+	m := jsonpb.Marshaler{
+		Indent: " ",
+	}
+	sCsg, _ := m.MarshalToString(cfg)
+	sDcfg, _ := m.MarshalToString(dcfg)
+	if sCsg != sDcfg {
+		t.Fatalf("%s != %s", sCsg, sDcfg)
+	}
+}
+
+var sepRegex = regexp.MustCompile(`\[|\]|\.`)
+
+// mutates the json at given path with val
+func mutate(m interface{}, path string, val interface{}) interface{} {
+	var idx int
+	var key string
+	var err error
+	var qa []interface{}
+	var qm map[string]interface{}
+
+	v := m
+
+	tokens := sepRegex.Split(path, -1)
+	for tidx, tok := range tokens {
+		if len(tok) == 0 {
+			continue
+		}
+		idx, err = strconv.Atoi(tok)
+		qa, qm = nil, nil
+		if err == nil { // array
+			qa, _ = v.([]interface{})
+			if qa == nil {
+				panic(fmt.Sprintf("%s is not an array", tokens[:tidx]))
+			}
+			v = qa[idx]
+		} else { // map
+			qm, _ = v.(map[string]interface{})
+			if qm == nil {
+				panic(fmt.Sprintf("%s is not a map", tokens[:tidx]))
+			}
+			v = qm[tok]
+			key = tok
+		}
+	}
+
+	if qm != nil {
+		qm[key] = val
+	} else {
+		qa[idx] = val
+	}
+	return m
+}
+
+const allGoodConfig = `
+revision: "2022"
+manifests:
+  - name: istio-proxy
+    revision: "1"
+    attributes:
+    - name: source.name
+      value_type: STRING
+    - name: source.labels
+      value_type: STRING_MAP
+    - name: target.name
+      value_type: STRING
+    - name: target.service
+      value_type: STRING
+    - name: origin.ip
+      value_type: IP_ADDRESS
+    - name: origin.user
+      value_type: STRING
+    - name: request.time
+      value_type: TIMESTAMP
+    - name: request.method
+      value_type: STRING
+    - name: request.path
+      value_type: STRING
+    - name: request.headers
+      value_type: STRING_MAP
+    - name: request.scheme
+      value_type: STRING
+    - name: response.size
+      value_type: INT64
+    - name: response.code
+      value_type: INT64
+    - name: response.duration
+      value_type: DURATION
+    # TODO: we really need to remove these, they're not part of the attribute vocab.
+    - name: api.name
+      value_type: STRING
+    - name: api.method
+      value_type: STRING
+
+# Enums as struct fields can be symbolic names.
+# However enums inside maps *cannot* be symbolic names.
+metrics:
+  - name: request_count
+    kind: COUNTER
+    value: INT64
+    description: request count by source, target, service, and code
+    labels:
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
+  - name: request_latency
+    kind: COUNTER
+    value: DURATION
+    description: request latency by source, target, and service
+    labels:
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
+
+quotas:
+- name: RequestCount
+  rate_limit: true
+
+logs:
+  - name: accesslog.common
+    display_name: Apache Common Log Format
+    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} '
+    labels:
+      originIp: 6 # IP_ADDRESS
+      sourceUser: 1 # STRING
+      timestamp: 5 # TIMESTAMP
+      method: 1 # STRING
+      url: 1 # STRING
+      protocol: 1 # STRING
+      responseCode: 2 # INT64
+      responseSize: 2 # INT64
+  - name: accesslog.combined
+    display_name: Apache Combined Log Format
+    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} '
+    labels:
+      originIp: 6 # IP_ADDRESS
+      sourceUser: 1 # STRING
+      timestamp: 5 # TIMESTAMP
+      method: 1 # STRING
+      url: 1 # STRING
+      protocol: 1 # STRING
+      responseCode: 2 # INT64
+      responseSize: 2 # INT64
+      referer: 1 # STRING
+      userAgent: 1 # STRING
+`
+
+func init() {
+	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
+	_ = flag.Lookup("v").Value.Set("99")
 }

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -188,7 +188,7 @@ func (c *Manager) fetchAndNotify() {
 		return
 	}
 
-	glog.Infof("Loaded new config %s ", c.store)
+	glog.Infof("Loaded new config %s", c.store)
 	for _, cl := range c.cl {
 		cl.ConfigChange(rt, df)
 	}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -148,6 +148,9 @@ func readdb(store KeyValueStore, prefix string) (map[string]string, map[string][
 func (c *Manager) fetch() (*runtime, descriptor.Finder, error) {
 
 	data, shas, index, err := readdb(c.store, "/")
+	if glog.V(9) {
+		glog.Info(data)
+	}
 	if err != nil {
 		return nil, nil, errors.New("Unable to read database: " + err.Error())
 	}
@@ -179,13 +182,13 @@ func (c *Manager) fetchAndNotify() {
 		c.Lock()
 		c.lastError = err
 		c.Unlock()
-		glog.Warningf("Error installing new config %s", err)
+		glog.Warningf("Error loading new config %v", err)
 	}
 	if rt == nil {
 		return
 	}
 
-	glog.Infof("Installing new config from %s ", c.store)
+	glog.Infof("Loaded new config %s ", c.store)
 	for _, cl := range c.cl {
 		cl.ConfigChange(rt, df)
 	}

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -123,14 +123,6 @@ const resolveSize = 50
 func resolve(bag attribute.Bag, kindSet KindSet, rules map[rulesKey]*pb.ServiceConfig, resolveRules resolveRulesFunc,
 	onlyEmptySelectors bool, identityAttribute string, identityAttributeDomain string, strictSelectorEval bool) (dlist []*pb.Combined, err error) {
 	scopes := make([]string, 0, 10)
-	if glog.V(2) {
-		pfx := ""
-		if onlyEmptySelectors {
-			pfx = "unconditionally "
-		}
-		glog.Infof("%sresolving for kinds: %s", pfx, kindSet)
-		defer func() { glog.Infof("%sresolved configs (err=%v): %s", pfx, err, dlist) }()
-	}
 
 	attr, _ := bag.Get(identityAttribute)
 	if attr == nil {
@@ -140,6 +132,7 @@ func resolve(bag attribute.Bag, kindSet KindSet, rules map[rulesKey]*pb.ServiceC
 		if onlyEmptySelectors {
 			scopes = []string{global}
 		} else {
+			glog.Warningf("%s attribute not found in %p", identityAttribute, bag)
 			return nil, fmt.Errorf("%s attribute not found", identityAttribute)
 		}
 	} else if scopes, err = GetScopes(attr.(string), identityAttributeDomain, scopes); err != nil {

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -219,7 +219,7 @@ func TestResolve(t *testing.T) {
 			fP("global", "global", "metric0", "metric1")},
 			[]string{"metric0"},
 			true,
-			errors.New("interal error: scope"), nil,
+			errors.New("internal error: scope"), nil,
 			map[string]string{
 				"metric0": "global/global",
 			}, false,

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -211,19 +211,23 @@ func (a adapterKey) String() string {
 // compatfilterConfig
 // given a yaml file, filter specific keys from it
 // globalConfig contains descriptors and adapters which will be split shortly.
-func compatfilterConfig(cfg string, shouldSelect func(string) bool) (data []byte, m map[string]interface{}, err error) {
-	m = map[string]interface{}{}
+func compatfilterConfig(cfg string, shouldSelect func(string) bool) ([]byte, map[string]interface{}, error) {
+	//data []byte, m map[string]interface{}, err error
+	var m map[string]interface{}
+	var data []byte
+	var err error
 
 	if err = yaml.Unmarshal([]byte(cfg), &m); err != nil {
-		return
+		return data, nil, err
 	}
+
 	for k := range m {
 		if !shouldSelect(k) {
 			delete(m, k)
 		}
 	}
 	data, err = json.Marshal(m)
-	return
+	return data, m, err
 }
 
 // validateDescriptors

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -211,8 +211,8 @@ func (a adapterKey) String() string {
 // compatfilterConfig
 // given a yaml file, filter specific keys from it
 // globalConfig contains descriptors and adapters which will be split shortly.
-func compatfilterConfig(cfg string, shouldSelect func(string) bool) (data []byte, err error) {
-	var m = map[string]interface{}{}
+func compatfilterConfig(cfg string, shouldSelect func(string) bool) (data []byte, m map[string]interface{}, err error) {
+	m = map[string]interface{}{}
 
 	if err = yaml.Unmarshal([]byte(cfg), &m); err != nil {
 		return
@@ -222,7 +222,8 @@ func compatfilterConfig(cfg string, shouldSelect func(string) bool) (data []byte
 			delete(m, k)
 		}
 	}
-	return json.Marshal(m)
+	data, err = json.Marshal(m)
+	return
 }
 
 // validateDescriptors
@@ -231,23 +232,9 @@ func compatfilterConfig(cfg string, shouldSelect func(string) bool) (data []byte
 // However enums inside maps *cannot* be symbolic names.
 // TODO add validation beyond proto parse
 func (p *validator) validateDescriptors(key string, cfg string) (ce *adapter.ConfigErrors) {
-	var err error
-	var data []byte
-
-	if data, err = compatfilterConfig(cfg, func(s string) bool {
-		return s != "adapters"
-	}); err != nil {
-		return ce.Appendf("DescriptorConfig", "failed to unmarshal config into proto: %v", err)
-	}
-	m := &pb.GlobalConfig{}
-	um := jsonpb.Unmarshaler{AllowUnknownFields: true}
-
-	if err = um.Unmarshal(bytes.NewReader(data), m); err != nil {
-		return ce.Appendf("DescriptorConfig", "failed to unmarshal <%s> config into proto: %v", string(data), err)
-	}
-
+	m, ce := descriptor.Parse(cfg)
 	p.validated.descriptor[key] = m
-	return
+	return ce
 }
 
 // validateAdapters consumes a yml config string with adapter config.
@@ -256,15 +243,15 @@ func (p *validator) validateAdapters(key string, cfg string) (ce *adapter.Config
 	var ferr error
 	var data []byte
 
-	if data, ferr = compatfilterConfig(cfg, func(s string) bool {
+	if data, _, ferr = compatfilterConfig(cfg, func(s string) bool {
 		return s == "adapters"
 	}); ferr != nil {
-		return ce.Appendf("DescriptorConfig", "failed to unmarshal config into proto with err: %v", ferr)
+		return ce.Appendf("AdapterConfig", "failed to unmarshal config into proto with err: %v", ferr)
 	}
 
 	var m = &pb.GlobalConfig{}
 	if err := yaml.Unmarshal(data, m); err != nil {
-		return ce.Appendf("GlobalConfig", "failed to unmarshal config into proto: %v", err)
+		return ce.Appendf("AdapterConfig", "failed to unmarshal config into proto: %v", err)
 	}
 
 	var acfg adapter.Config
@@ -387,13 +374,13 @@ func (p *validator) validate(cfg map[string]string) (rt *Validated, ce *adapter.
 
 	for _, kk := range keymap[descriptors] {
 		if re := p.validateDescriptors(kk, cfg[kk]); re != nil {
-			return rt, ce.Appendf("GlobalConfig", "failed validation").Extend(re)
+			return rt, ce.Appendf("DescriptorConfig", "failed validation").Extend(re)
 		}
 	}
 
 	for _, kk := range keymap[adapters] {
 		if re := p.validateAdapters(kk, cfg[kk]); re != nil {
-			return rt, ce.Appendf("GlobalConfig", "failed validation").Extend(re)
+			return rt, ce.Appendf("AdapterConfig", "failed validation").Extend(re)
 		}
 	}
 
@@ -494,7 +481,8 @@ func decode(src interface{}, dst proto.Message, strict bool) error {
 	}
 	um := jsonpb.Unmarshaler{AllowUnknownFields: !strict}
 	if err := um.Unmarshal(bytes.NewReader(ba), dst); err != nil {
-		return fmt.Errorf("failed to unmarshal config into proto: %v", err)
+		b2, _ := json.Marshal(dst)
+		return fmt.Errorf("failed to unmarshal config <%s> into proto: %v %s", string(ba), err, string(b2))
 	}
 	return nil
 }

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -5,12 +5,12 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 pkg_tar(
     name = "configs_tar",
     extension = "tar.gz",
-    files = [
-        "globalconfig.yml",
-        "serviceconfig.yml",
-    ],
+    files = glob([
+        "**/*.yml",
+    ]),
     mode = "0755",
     package_dir = "/etc/opt/mixer",
+    strip_prefix = "./",
     tags = ["manual"],
     visibility = ["//docker:__pkg__"],
 )

--- a/testdata/configroot/scopes/global/adapters.yml
+++ b/testdata/configroot/scopes/global/adapters.yml
@@ -8,7 +8,7 @@ adapters:
   - name: default
     impl: stdioLogger
     params:
-      logStream: 0 # STDERR
+      logStream: STDERR # STDERR
   - name: prometheus
     kind: metrics
     impl: prometheus

--- a/testdata/configroot/scopes/global/adapters.yml
+++ b/testdata/configroot/scopes/global/adapters.yml
@@ -8,7 +8,7 @@ adapters:
   - name: default
     impl: stdioLogger
     params:
-      logStream: STDERR # STDERR
+      logStream: STDERR
   - name: prometheus
     kind: metrics
     impl: prometheus

--- a/testdata/configroot/scopes/global/descriptors.yml
+++ b/testdata/configroot/scopes/global/descriptors.yml
@@ -1,109 +1,95 @@
 subject: namespace:ns
 revision: "2022"
-attributes:
-  # TODO: we really need to remove these, they're not part of the attribute vocab.
-  - name: api.name
-    value_type: 1 # STRING
-  - name: api.method
-    value_type: 1 # STRING
-  - name: source.name
-    value_type: 1 # STRING
-  - name: target.name
-    value_type: 1 # STRING
-  - name: origin.ip
-    value_type: 6 # IP_ADDRESS
-  - name: origin.user
-    value_type: 1 # STRING
-  - name: request.time
-    value_type: 5 # TIMESTAMP
-  - name: request.method
-    value_type: 1 # STRING
-  - name: request.path
-    value_type: 1 # STRING
-  - name: request.scheme
-    value_type: 1 # STRING
-  - name: response.size
-    value_type: 2 # INT64
-  - name: response.code
-    value_type: 2 # INT64
-  - name: response.latency
-    value_type: 10 # DURATION
+manifests:
+  - name: istio-proxy
+    revision: "1"
+    attributes:
+    - name: source.name
+      value_type: STRING
+    - name: source.labels
+      value_type: STRING_MAP
+    - name: target.name
+      value_type: STRING
+    - name: target.service
+      value_type: STRING
+    - name: origin.ip
+      value_type: IP_ADDRESS
+    - name: origin.user
+      value_type: STRING
+    - name: request.time
+      value_type: TIMESTAMP
+    - name: request.method
+      value_type: STRING
+    - name: request.path
+      value_type: STRING
+    - name: request.headers
+      value_type: STRING_MAP
+    - name: request.scheme
+      value_type: STRING
+    - name: response.size
+      value_type: INT64
+    - name: response.code
+      value_type: INT64
+    - name: response.duration
+      value_type: DURATION
+    # TODO: we really need to remove these, they're not part of the attribute vocab.
+    - name: api.name
+      value_type: STRING
+    - name: api.method
+      value_type: STRING
+
+# Enums as struct fields can be symbolic names.
+# However enums inside maps *cannot* be symbolic names.
 metrics:
   - name: request_count
-    kind: 2 # COUNTER
-    value: 2 # INT64
+    kind: COUNTER
+    value: INT64
     description: request count by source, target, service, and code
     labels:
-    - name: source
-      value_type: 1 # STRING
-    - name: target
-      value_type: 1 # STRING
-    - name: service
-      value_type: 1 # STRING
-    - name: method
-      value_type: 1 # STRING
-    - name: response_code
-      value_type: 2 # INT64
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
   - name: request_latency
-    kind: 2 # COUNTER
-    value: 10 # DURATION
+    kind: COUNTER
+    value: DURATION
     description: request latency by source, target, and service
     labels:
-    - name: source
-      value_type: 1 # STRING
-    - name: target
-      value_type: 1 # STRING
-    - name: service
-      value_type: 1 # STRING
-    - name: method
-      value_type: 1 # STRING
-    - name: response_code
-      value_type: 2 # INT64
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
+
 quotas:
 - name: RequestCount
   rate_limit: true
+
 logs:
   - name: accesslog.common
     display_name: Apache Common Log Format
     log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}'
     labels:
-    - name: originIp
-      value_type: 6 # IP_ADDRESS
-    - name: sourceUser
-      value_type: 1 # STRING
-    - name: timestamp
-      value_type: 5 # TIMESTAMP
-    - name: method
-      value_type: 1 # STRING
-    - name: url
-      value_type: 1 # STRING
-    - name: protocol
-      value_type: 1 # STRING
-    - name: responseCode
-      value_type: 2 # INT64
-    - name: responseSize
-      value_type: 2 # INT64
+      originIp: 6 # IP_ADDRESS
+      sourceUser: 1 # STRING
+      timestamp: 5 # TIMESTAMP
+      method: 1 # STRING
+      url: 1 # STRING
+      protocol: 1 # STRING
+      responseCode: 2 # INT64
+      responseSize: 2 # INT64
   - name: accesslog.combined
     display_name: Apache Combined Log Format
     log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}} {{or (.referer) "-"}} {{or (.userAgent) "-"}}'
     labels:
-    - name: originIp
-      value_type: 6 # IP_ADDRESS
-    - name: sourceUser
-      value_type: 1 # STRING
-    - name: timestamp
-      value_type: 5 # TIMESTAMP
-    - name: method
-      value_type: 1 # STRING
-    - name: url
-      value_type: 1 # STRING
-    - name: protocol
-      value_type: 1 # STRING
-    - name: responseCode
-      value_type: 2 # INT64
-    - name: responseSize
-      value_type: 2 # INT64
-    - name: referer
-      value_type: 1 # STRING
-    - name: userAgent
-      value_type: 1 # STRING
+      originIp: 6 # IP_ADDRESS
+      sourceUser: 1 # STRING
+      timestamp: 5 # TIMESTAMP
+      method: 1 # STRING
+      url: 1 # STRING
+      protocol: 1 # STRING
+      responseCode: 2 # INT64
+      responseSize: 2 # INT64
+      referer: 1 # STRING
+      userAgent: 1 # STRING

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -33,9 +33,10 @@ rules:
   aspects:
   - kind: quotas
     params:
-      descriptor_name: RequestCount
-      max_amount: 5
-      expiration: 1s
+      quotas:
+      - descriptorName: RequestCount
+        maxAmount: 5
+        expiration: 1s
   - kind: metrics
     adapter: prometheus
     params:
@@ -50,7 +51,7 @@ rules:
           method: api.method | "unknown"
           response_code: response.code | 200
       - descriptor_name:  request_latency
-        value: response.latency | "0ms"
+        value: response.duration | "0ms"
         labels:
           source: source.name | "unknown"
           target: target.name | "unknown"


### PR DESCRIPTION
This PR implements better error reporting for descriptors.
It ensures that adapters.Params, aspects.Params and all descriptors are parsed in the same way.

Errors are reported with a context.
The following errors says that the problem is in the 0th manifest, 6th attribute
```
* manifests[0].attributes[6]: unknown value "TIMESTAMP2" for enum istio.mixer.v1.config.descriptor.ValueType: [{"name":"request.time","value_type":"TIMESTAMP2"}],
```


Note: re cache_test.go
My PR build was failing, so I had to update this test to be more resilient. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/585)
<!-- Reviewable:end -->


