### PR TITLE
Add handling of DISTRIBUTION to metrics manager.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -178,7 +178,7 @@ load("//:repositories.bzl", "new_git_or_local_repository")
 new_git_or_local_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
-    commit = "86f8a709b94340ad381ea8ac2778d469b85bd928",  # Apr 14, 2017 (no releases)
+    commit = "f3bc6f65dc815d51a71a68b7165bc7e1a82d7e78",  # Apr 20, 2017 (no releases)
     path = "../api",
     remote = "https://github.com/istio/api.git",
     # Change this to True to use ../api directory

--- a/pkg/adapter/metrics.go
+++ b/pkg/adapter/metrics.go
@@ -21,8 +21,9 @@ import (
 
 // Metric kinds supported by mixer.
 const (
-	Gauge   MetricKind = iota // records instantaneous (non-cumulative) measurements
-	Counter                   // records increasing cumulative values
+	Gauge        MetricKind = iota // records instantaneous (non-cumulative) measurements
+	Counter                        // records increasing cumulative values
+	Distribution                   // aggregates values in buckets (values still reported un-aggregated)
 )
 
 type (
@@ -83,6 +84,81 @@ type (
 		// Labels are the names of keys for dimensional data that will
 		// be generated at runtime and passed along with metric values.
 		Labels map[string]LabelType
+
+		Buckets BucketDefinition
+	}
+
+	// BucketDefinition provides a common interface for the various types
+	// of bucket definitions.
+	BucketDefinition interface{}
+
+	// LinearBuckets describes a linear sequence of buckets that all have
+	// the same width (except for underflow and overflow).
+	//
+	// There are `Count + 2` (= N) buckets. The two additional
+	// buckets are the underflow and overflow buckets.
+	//
+	// Bucket `i` has the following boundaries:
+	//    Upper bound (0 <= i < N-1):     offset + (width * i).
+	//    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
+	LinearBuckets struct {
+		BucketDefinition
+
+		// Count is the number of buckets in this bucket definition.
+		// Must be greater than 0.
+		Count int32
+
+		// Width describes the size of each individual bucket. Must be
+		// greater than 0.
+		Width float64
+
+		// Offset is the lower bound of the first specified bucket.
+		Offset float64
+	}
+
+	// ExponentialBuckets describes an exponential sequence of buckets that
+	// have a width that is proportional to the value of the lower bound.
+	//
+	// There are `Count + 2` (= N) buckets. The two additional
+	// buckets are the underflow and overflow buckets.
+	//
+	// Bucket `i` has the following boundaries:
+	//    Upper bound (0 <= i < N-1):     scale * (growth_factor ^ i).
+	//    Lower bound (1 <= i < N):       scale * (growth_factor ^ (i - 1)).
+	ExponentialBuckets struct {
+		BucketDefinition
+
+		// Count is the number of buckets in this bucket definition.
+		// Must be greater than 0.
+		Count int32
+
+		// GrowthFactor controls the rate of increase in size of the
+		// buckets. Must be greater than 1.
+		GrowthFactor float64
+
+		// Scale controls the relative size of the buckets. Must be
+		// greater than 0.
+		Scale float64
+	}
+
+	// ExplicitBuckets specifies a set of buckets with arbitrary widths.
+	//
+	// There are `size(bounds) + 1` (= N) buckets. Bucket `i` has the following
+	// boundaries:
+	//
+	//    Upper bound (0 <= i < N-1):     bounds[i]
+	//    Lower bound (1 <= i < N);       bounds[i - 1]
+	//
+	// If `Bounds` has only one element, then there are no finite buckets,
+	// and that single element is the common boundary of the overflow and
+	// underflow buckets.
+	ExplicitBuckets struct {
+		BucketDefinition
+
+		// Bounds describes the explicit bounds of the buckets being
+		// defined. Must be at least 1 element long and have
+		// monotonically increasing values.
+		Bounds []float64
 	}
 )
 

--- a/pkg/aspect/descriptors.go
+++ b/pkg/aspect/descriptors.go
@@ -58,6 +58,8 @@ func metricKindFromProto(pbk dpb.MetricDescriptor_MetricKind) (adapter.MetricKin
 		return adapter.Gauge, nil
 	case dpb.COUNTER:
 		return adapter.Counter, nil
+	case dpb.DISTRIBUTION:
+		return adapter.Distribution, nil
 	default:
 		return 0, fmt.Errorf("invalid proto MetricKind %v", pbk)
 	}

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -412,6 +412,99 @@ func TestMetrics_DescToDef(t *testing.T) {
 		},
 		{
 			&dpb.MetricDescriptor{
+				Name:   "without buckets",
+				Kind:   dpb.DISTRIBUTION,
+				Labels: map[string]dpb.ValueType{"string": dpb.STRING},
+			},
+			nil,
+			"distribution",
+		},
+		{
+			&dpb.MetricDescriptor{
+				Name:    "bad buckets",
+				Kind:    dpb.DISTRIBUTION,
+				Labels:  map[string]dpb.ValueType{"string": dpb.STRING},
+				Buckets: &dpb.MetricDescriptor_BucketsDefinition{},
+			},
+			nil,
+			"definitions",
+		},
+		{
+			in: &dpb.MetricDescriptor{
+				Name:   "explicit buckets",
+				Kind:   dpb.DISTRIBUTION,
+				Labels: map[string]dpb.ValueType{"string": dpb.STRING},
+				Buckets: &dpb.MetricDescriptor_BucketsDefinition{
+					Definition: &dpb.MetricDescriptor_BucketsDefinition_ExplicitBuckets{
+						ExplicitBuckets: &dpb.MetricDescriptor_BucketsDefinition_Explicit{
+							Bounds: []float64{3, 5, 9, 234},
+						},
+					},
+				},
+			},
+			out: &adapter.MetricDefinition{
+				Name:   "explicit buckets",
+				Kind:   adapter.Distribution,
+				Labels: map[string]adapter.LabelType{"string": adapter.String},
+				Buckets: &adapter.ExplicitBuckets{
+					Bounds: []float64{3, 5, 9, 234},
+				},
+			},
+		},
+		{
+			in: &dpb.MetricDescriptor{
+				Name:   "exponential buckets",
+				Kind:   dpb.DISTRIBUTION,
+				Labels: map[string]dpb.ValueType{"string": dpb.STRING},
+				Buckets: &dpb.MetricDescriptor_BucketsDefinition{
+					Definition: &dpb.MetricDescriptor_BucketsDefinition_ExponentialBuckets{
+						ExponentialBuckets: &dpb.MetricDescriptor_BucketsDefinition_Exponential{
+							NumFiniteBuckets: 3,
+							GrowthFactor:     10,
+							Scale:            0.1,
+						},
+					},
+				},
+			},
+			out: &adapter.MetricDefinition{
+				Name:   "exponential buckets",
+				Kind:   adapter.Distribution,
+				Labels: map[string]adapter.LabelType{"string": adapter.String},
+				Buckets: &adapter.ExponentialBuckets{
+					Count:        3,
+					GrowthFactor: 10,
+					Scale:        0.1,
+				},
+			},
+		},
+		{
+			in: &dpb.MetricDescriptor{
+				Name:   "linear buckets",
+				Kind:   dpb.DISTRIBUTION,
+				Labels: map[string]dpb.ValueType{"string": dpb.STRING},
+				Buckets: &dpb.MetricDescriptor_BucketsDefinition{
+					Definition: &dpb.MetricDescriptor_BucketsDefinition_LinearBuckets{
+						LinearBuckets: &dpb.MetricDescriptor_BucketsDefinition_Linear{
+							NumFiniteBuckets: 3,
+							Width:            40,
+							Offset:           0.0001,
+						},
+					},
+				},
+			},
+			out: &adapter.MetricDefinition{
+				Name:   "linear buckets",
+				Kind:   adapter.Distribution,
+				Labels: map[string]adapter.LabelType{"string": adapter.String},
+				Buckets: &adapter.LinearBuckets{
+					Count:  3,
+					Width:  40,
+					Offset: 0.0001,
+				},
+			},
+		},
+		{
+			&dpb.MetricDescriptor{
 				Name:   "good",
 				Kind:   dpb.COUNTER,
 				Value:  dpb.STRING,


### PR DESCRIPTION
This PR adds the manager-level handling of Distributions to mixer.
This PR will be followed by PRs that add support in our existing
metrics backend adapters. This will enable more natural backend
handling of data for metrics naturally understood as aggregated
distributions (such as response.duration).

NOTE: the manager code here does nothing beyond the current work
of deriving a MetricDefinition and passing that down to adapters.
It will be up to the adapters to correctly program the backends
and translate individual report values appropriately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/590)
<!-- Reviewable:end -->
