### PR TITLE
Remove inputs indirection in listchecker

### DIFF
--- a/pkg/aspect/listsManager.go
+++ b/pkg/aspect/listsManager.go
@@ -34,7 +34,6 @@ type (
 	listsManager struct{}
 
 	listsExecutor struct {
-		inputs map[string]string
 		aspect adapter.ListsAspect
 		params *aconfig.ListsParams
 	}
@@ -55,7 +54,6 @@ func (listsManager) NewCheckExecutor(cfg *cpb.Combined, ga adapter.Builder, env 
 		return nil, err
 	}
 	return &listsExecutor{
-		inputs: cfg.Aspect.Inputs,
 		aspect: asp,
 		params: cfg.Aspect.Params.(*aconfig.ListsParams),
 	}, nil
@@ -86,14 +84,7 @@ func (a *listsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator) rpc.
 	var err error
 
 	var symbol string
-	var symbolExpr string
-
-	// CheckExpression should be processed and sent to input
-	if symbolExpr, found = a.inputs[a.params.CheckExpression]; !found {
-		return status.WithError(fmt.Errorf("mapping for %s not found", a.params.CheckExpression))
-	}
-
-	if symbol, err = mapper.EvalString(symbolExpr, attrs); err != nil {
+	if symbol, err = mapper.EvalString(a.params.CheckExpression, attrs); err != nil {
 		return status.WithError(err)
 	}
 

--- a/pkg/aspect/listsManager_test.go
+++ b/pkg/aspect/listsManager_test.go
@@ -140,17 +140,16 @@ func (l *testList) CheckList(symbol string) (bool, error) {
 func TestListsExecutor_Execute(t *testing.T) {
 	cases := []struct {
 		name   string
-		inputs map[string]string
 		aspect adapter.ListsAspect
 		params *aconfig.ListsParams
 	}{
-		{"not blacklisted", map[string]string{"ipAddr": "source.ip"}, &testList{}, &aconfig.ListsParams{CheckExpression: "ipAddr", Blacklist: true}},
-		{"whitelisted", map[string]string{"ipAddr": "source.ip"}, &testList{inList: true}, &aconfig.ListsParams{CheckExpression: "ipAddr", Blacklist: false}},
+		{"not blacklisted", &testList{}, &aconfig.ListsParams{CheckExpression: "source.ip", Blacklist: true}},
+		{"whitelisted", &testList{inList: true}, &aconfig.ListsParams{CheckExpression: "source.ip", Blacklist: false}},
 	}
 
 	for _, v := range cases {
 		t.Run(v.name, func(t *testing.T) {
-			e := &listsExecutor{v.inputs, v.aspect, v.params}
+			e := &listsExecutor{v.aspect, v.params}
 			got := e.Execute(test.NewBag(), test.NewIDEval())
 			if got.Code != int32(rpc.OK) {
 				t.Errorf("Execute() => %v, wanted status with code: %v", got, int32(rpc.OK))
@@ -161,28 +160,27 @@ func TestListsExecutor_Execute(t *testing.T) {
 
 func TestListsExecutor_ExecuteErrors(t *testing.T) {
 
-	attrParam := &aconfig.ListsParams{CheckExpression: "ipAddr"}
-	blacklistParam := &aconfig.ListsParams{CheckExpression: "ipAddr", Blacklist: true}
+	attrParam := &aconfig.ListsParams{CheckExpression: "source.ip"}
+	blacklistParam := &aconfig.ListsParams{CheckExpression: "source.ip", Blacklist: true}
 	internal := int32(rpc.INTERNAL)
 	permDenied := int32(rpc.PERMISSION_DENIED)
-	inputMap := map[string]string{"ipAddr": "source.ip"}
 
 	cases := []struct {
 		name     string
-		inputs   map[string]string
 		aspect   adapter.ListsAspect
 		params   *aconfig.ListsParams
+		eval     expr.Evaluator
 		wantCode int32
 	}{
-		{"no inputs", map[string]string{}, &testList{}, attrParam, internal},
-		{"checklist error", inputMap, &testList{returnErr: true}, attrParam, internal},
-		{"blacklisted", inputMap, &testList{inList: true}, blacklistParam, permDenied},
+		{"eval error", &testList{returnErr: true}, attrParam, test.NewErrEval(), internal},
+		{"checklist error", &testList{returnErr: true}, attrParam, test.NewIDEval(), internal},
+		{"blacklisted", &testList{inList: true}, blacklistParam, test.NewIDEval(), permDenied},
 	}
 
 	for _, v := range cases {
 		t.Run(v.name, func(t *testing.T) {
-			e := &listsExecutor{v.inputs, v.aspect, v.params}
-			got := e.Execute(test.NewBag(), test.NewIDEval())
+			e := &listsExecutor{v.aspect, v.params}
+			got := e.Execute(test.NewBag(), v.eval)
 			if got.Code != v.wantCode {
 				t.Errorf("Execute() => %v, wanted status with code: %v", got, v.wantCode)
 			}

--- a/pkg/aspect/test/evaluator.go
+++ b/pkg/aspect/test/evaluator.go
@@ -43,7 +43,7 @@ func NewIDEval() expr.Evaluator {
 	})
 }
 
-// NewErrEval constructs a new Evaluator that allows returns an error.
+// NewErrEval constructs a new Evaluator that always returns an error.
 func NewErrEval() expr.Evaluator {
 	return NewFakeEval(func(_ string, _ attribute.Bag) (interface{}, error) {
 		return nil, errors.New("eval error")
@@ -56,5 +56,8 @@ func (f *fakeEval) Eval(expression string, attrs attribute.Bag) (interface{}, er
 
 func (f *fakeEval) EvalString(expression string, attrs attribute.Bag) (string, error) {
 	r, err := f.body(expression, attrs)
+	if err != nil {
+		return "", err
+	}
 	return r.(string), err
 }


### PR DESCRIPTION
In istio/api#78, `inputs` was removed. The internal copy of that config proto was not updated to match, but it causes some confusion with ongoing work to have aspect config using `inputs`. ListChecker was still using the `inputs` indirection, but with the updated validation logic, was requiring both sides of the map to be a valid attribute.

This PR cleans up that mess a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/595)
<!-- Reviewable:end -->
