### PR TITLE
Add handling of distributions to prometheus

### DIFF
--- a/testdata/globalconfig.yml
+++ b/testdata/globalconfig.yml
@@ -96,9 +96,21 @@ metrics:
       method: 1 # STRING
       response_code: 2 # INT64
   - name: request_latency
-    kind: COUNTER
+    kind: DISTRIBUTION
     value: DURATION
     description: request latency by source, target, and service
+    buckets:
+      explicit_buckets:
+        bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+# Examples of other possible bucket configurations:
+#      linear_buckets:
+#         num_finite_buckets: 10
+#         offset: 0.001
+#         width: 0.1
+#      exponential_buckets:
+#        num_finite_buckets: 15
+#        scale: 0.001
+#        growth_factor: 4
     labels:
       source: 1 # STRING
       target: 1 # STRING


### PR DESCRIPTION
Adds support for distributions (histograms) to prometheus metrics adapter. This will allow more natural monitoring and alerting based on request durations, etc.

Tested with `mixs` and `mixc`, as follows:

```shell
$ ./bazel-bin/cmd/server/mixs server --globalConfigFile=testdata/globalconfig.yml --serviceConfigFile=testdata/serviceconfig.yml
```

```shell
$ ./bazel-bin/cmd/client/mixc report -a target.service=foo.default.svc.cluster.local,request.host=foo.default --string_attributes=source.uid="kubernetes://curl-2421989462-b2g2d.default" --duration_attributes=response.duration=13ms
Report RPC returned OK
...
$ ./bazel-bin/cmd/client/mixc report -a target.service=foo.default.svc.cluster.local,request.host=foo.default --string_attributes=source.uid="kubernetes://curl-2421989462-b2g2d.default" --duration_attributes=response.duration=164ms
Report RPC returned OK
...
$ ./bazel-bin/cmd/client/mixc report -a target.service=foo.default.svc.cluster.local,request.host=foo.default --string_attributes=source.uid="kubernetes://curl-2421989462-b2g2d.default" --duration_attributes=response.duration=14234ms
Report RPC returned OK
...
$ ./bazel-bin/cmd/client/mixc report -a target.service=foo.default.svc.cluster.local,request.host=foo.default --string_attributes=source.uid="kubernetes://curl-2421989462-b2g2d.default" --duration_attributes=response.duration=1ns
Report RPC returned OK
...
```

And looking at `localhost:42422/metrics`:

```
# HELP request_count request count by source, target, service, and code
# TYPE request_count counter
request_count{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown"} 4
# HELP request_latency request latency by source, target, and service
# TYPE request_latency histogram
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="0.005"} 1
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="0.01"} 1
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="0.025"} 2
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="0.05"} 2
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="0.1"} 2
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="0.25"} 3
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="0.5"} 3
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="1"} 3
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="2.5"} 3
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="5"} 3
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="10"} 3
request_latency_bucket{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown",le="+Inf"} 4
request_latency_sum{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown"} 14.411000001
request_latency_count{method="unknown",response_code="200",service="unknown",source="curl-2421989462-b2g2d",target="unknown"} 4
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/599)
<!-- Reviewable:end -->
