### PR TITLE
Add descriptors for new metrics to global descriptors

### DIFF
--- a/testdata/configroot/scopes/global/descriptors.yml
+++ b/testdata/configroot/scopes/global/descriptors.yml
@@ -52,6 +52,8 @@ manifests:
       value_type: STRING_MAP
     - name: request.scheme
       value_type: STRING
+    - name: request.size
+      value_type: INT64
     - name: response.size
       value_type: INT64
     - name: response.code
@@ -100,12 +102,57 @@ metrics:
       service: 1 # STRING
       method: 1 # STRING
       response_code: 2 # INT64
+  - name: request_size
+    kind: DISTRIBUTION
+    value: INT64
+    description: request size by source, target, and service
+    buckets:
+      exponentialBuckets:
+        numFiniteBuckets: 8
+        scale: 1
+        growthFactor: 10
+    # Examples of other possible bucket configurations:
+    #      explicit_buckets:
+    #         bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+    #      linear_buckets:
+    #         num_finite_buckets: 10
+    #         offset: 0.001
+    #         width: 0.1
+    labels:
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
+  - name: response_size
+    kind: DISTRIBUTION
+    value: INT64
+    description: response size by source, target, and service
+    buckets:
+      exponentialBuckets:
+        numFiniteBuckets: 8
+        scale: 1
+        growthFactor: 10
+    # Examples of other possible bucket configurations:
+    #      explicitBuckets:
+    #         bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+    #      linearBuckets:
+    #         numFiniteBuckets: 10
+    #         offset: 0.001
+    #         width: 0.1
+    labels:
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
 quotas:
   - name: RequestCount
     rate_limit: true
 logs:
   - name: accesslog.common
     display_name: Apache Common Log Format
+    payload_format: TEXT
     log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}'
     labels:
       originIp: 6 # IP_ADDRESS
@@ -118,6 +165,7 @@ logs:
       responseSize: 2 # INT64
   - name: accesslog.combined
     display_name: Apache Combined Log Format
+    payload_format: TEXT
     log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}} {{or (.referer) "-"}} {{or (.userAgent) "-"}}'
     labels:
       originIp: 6 # IP_ADDRESS


### PR DESCRIPTION
This PR adds a couple of new descriptors to the global config for mixer (in testdata/configroot).

Notably, these are not added to the rules for any scope/subject. This is by design at this point (to allow for adding them as part of a Task on configuring metrics -- since you there is no way for adding metric descriptors currently supported).

The new metrics are:
- request_size
- response_size

Some of the other descriptors are also updated to support validation.

Tested with minikube (pushed a local docker image in place of mixer, updated via `istioctl mixer` commands).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/624)
<!-- Reviewable:end -->
