### PR TITLE
Documented but unimplemented routes should return 501 not 404

### DIFF
--- a/pkg/config/apiserver.go
+++ b/pkg/config/apiserver.go
@@ -72,6 +72,22 @@ func (a *API) register(c *restful.Container) {
 	ws.Produces(restful.MIME_JSON)
 	ws.Path(a.rootPath)
 
+	// List the scopes
+	ws.Route(ws.
+		GET("/scopes").
+		To(a.getScopes).
+		Doc("Gets scopes associated with Mixer").
+		Writes(APIResponse{}))
+
+	// Create a policy
+	ws.Route(ws.
+		POST("/scopes/{scope}/subjects/{subject}").
+		To(a.createPolicy).
+		Doc("Create a policy").
+		// TODO Reads(...).
+		Writes(APIResponse{}))
+
+	// List the rules for a scope and subject
 	ws.Route(ws.
 		GET("/scopes/{scope}/subjects/{subject}/rules").
 		To(a.getRules).
@@ -88,6 +104,58 @@ func (a *API) register(c *restful.Container) {
 		Param(ws.PathParameter("subject", "subject").DataType("string")).
 		Reads(&pb.ServiceConfig{}).
 		Writes(APIResponse{}))
+
+	// Creates or replaces a rule's list of aspects
+	ws.Route(ws.
+		PUT("/scopes/{scope}/subjects/{subject}/rules/{ruleid}/aspects/{aspect}").
+		To(a.putAspect).
+		Doc("Creates or replaces a rule’s list of aspects.").
+		Param(ws.PathParameter("scope", "scope").DataType("string")).
+		Param(ws.PathParameter("subject", "subject").DataType("string")).
+		Param(ws.PathParameter("aspect", "aspect").DataType("string")).
+		Reads(&pb.Aspect{}).
+		Writes(APIResponse{}))
+
+	ws.Route(ws.
+		DELETE("/scopes/{scope}/subjects/{subject}/rules/{ruleid}").
+		To(a.deleteRule).
+		Doc("Replaces rules associated with the given scope and subject").
+		Param(ws.PathParameter("scope", "scope").DataType("string")).
+		Param(ws.PathParameter("subject", "subject").DataType("string")).
+		Param(ws.PathParameter("ruleid", "rule id").DataType("string")))
+
+	// Creates or replaces a named adapter configuration
+	ws.Route(ws.
+		PUT("/scopes/{scope}/adapters/{adapter_name}/{config_name}").
+		To(a.putAdapter).
+		Doc("Creates or replaces a named adapter configuration.").
+		Param(ws.PathParameter("scope", "scope").DataType("string")).
+		Param(ws.PathParameter("adapter_name", "adapter name").DataType("string")).
+		Param(ws.PathParameter("config_name", "config name").DataType("string")).
+		Reads(&pb.Adapter{}).
+		Writes(APIResponse{}))
+
+	// Gets a descriptor
+	ws.Route(ws.
+		GET("/scopes/{scope}/descriptors/{descriptor_type}/{descriptor_name}").
+		To(a.getDescriptor).
+		Doc("Gets a descriptor.").
+		Param(ws.PathParameter("scope", "scope").DataType("string")).
+		Param(ws.PathParameter("descriptor_type", "descriptor type").DataType("string")).
+		Param(ws.PathParameter("descriptor_name", "descriptor name").DataType("string")).
+		Writes(APIResponse{}))
+
+	// Creates or replaces a descriptor
+	ws.Route(ws.
+		PUT("/scopes/{scope}/descriptors/{descriptor_type}/{descriptor_name}").
+		To(a.putDescriptor).
+		Doc("Creates or replaces a descriptor.").
+		Param(ws.PathParameter("scope", "scope").DataType("string")).
+		Param(ws.PathParameter("descriptor_type", "descriptor type").DataType("string")).
+		Param(ws.PathParameter("descriptor_name", "descriptor name").DataType("string")).
+		// TODO Reads(&pb.Descriptor{}).
+		Writes(APIResponse{}))
+
 	c.Add(ws)
 }
 
@@ -119,6 +187,12 @@ func NewAPI(version string, port uint16, eval expr.Validator, aspectFinder Aspec
 // Run calls listen and serve on the API server
 func (a *API) Run() {
 	glog.Warning(a.server.ListenAndServe())
+}
+
+// getScopes returns the scopes
+// "/scopes"
+func (a *API) getScopes(req *restful.Request, resp *restful.Response) {
+	writeErrorResponse(http.StatusNotImplemented, "Listing scopes not implemented", resp)
 }
 
 // getRules returns the rules document for the scope and the subject.
@@ -185,6 +259,42 @@ func (a *API) putRules(req *restful.Request, resp *restful.Response) {
 	// TODO send index back to the client
 	writeResponse(http.StatusOK, fmt.Sprintf("Created %s", key),
 		vd.rule[*parseRulesKey(key)], resp)
+}
+
+// createPolicy creates a policy
+// "/scopes/{scope}/subjects/{subject}"
+func (a *API) createPolicy(req *restful.Request, resp *restful.Response) {
+	writeErrorResponse(http.StatusNotImplemented, "create policy not implemented", resp) // TODO
+}
+
+// putAspect creates or replaces a rule’s list of aspects.
+// "/scopes/{scope}/subjects/{subject}/rules/{ruleid}/aspects/{aspect}"
+func (a *API) putAspect(req *restful.Request, resp *restful.Response) {
+	writeErrorResponse(http.StatusNotImplemented, "put aspect not implemented", resp) // TODO
+}
+
+// deleteRule deletes a rule
+// "/scopes/{scope}/subjects/{subject}/rules/{ruleid}"
+func (a *API) deleteRule(req *restful.Request, resp *restful.Response) {
+	writeErrorResponse(http.StatusNotImplemented, "delete rule not implemented", resp) // TODO
+}
+
+// putAdapter creates or replaces an adapter configuration
+// "/scopes/{scope}/adapters/{adapter_name}/{config_name}"
+func (a *API) putAdapter(req *restful.Request, resp *restful.Response) {
+	writeErrorResponse(http.StatusNotImplemented, "put adapter not implemented", resp) // TODO
+}
+
+// getDescriptor returns a descriptor
+// "/scopes/{scope}/descriptors/{descriptor_type}/{descriptor_name}"
+func (a *API) getDescriptor(req *restful.Request, resp *restful.Response) {
+	writeErrorResponse(http.StatusNotImplemented, "get descriptor not implemented", resp) // TODO
+}
+
+// putDescriptor creates or replaces a descriptor
+// "/scopes/{scope}/descriptors/{descriptor_type}/{descriptor_name}"
+func (a *API) putDescriptor(req *restful.Request, resp *restful.Response) {
+	writeErrorResponse(http.StatusNotImplemented, "put descriptor not implemented", resp) // TODO
 }
 
 // a subset of restful.Response

--- a/pkg/config/apiserver.go
+++ b/pkg/config/apiserver.go
@@ -105,17 +105,7 @@ func (a *API) register(c *restful.Container) {
 		Reads(&pb.ServiceConfig{}).
 		Writes(APIResponse{}))
 
-	// Creates or replaces a rule's list of aspects
-	ws.Route(ws.
-		PUT("/scopes/{scope}/subjects/{subject}/rules/{ruleid}/aspects/{aspect}").
-		To(a.putAspect).
-		Doc("Creates or replaces a rule’s list of aspects.").
-		Param(ws.PathParameter("scope", "scope").DataType("string")).
-		Param(ws.PathParameter("subject", "subject").DataType("string")).
-		Param(ws.PathParameter("aspect", "aspect").DataType("string")).
-		Reads(&pb.Aspect{}).
-		Writes(APIResponse{}))
-
+	// Delete a rule
 	ws.Route(ws.
 		DELETE("/scopes/{scope}/subjects/{subject}/rules/{ruleid}").
 		To(a.deleteRule).
@@ -123,6 +113,18 @@ func (a *API) register(c *restful.Container) {
 		Param(ws.PathParameter("scope", "scope").DataType("string")).
 		Param(ws.PathParameter("subject", "subject").DataType("string")).
 		Param(ws.PathParameter("ruleid", "rule id").DataType("string")))
+
+	// Creates or replaces a rule's list of aspects
+	ws.Route(ws.
+		PUT("/scopes/{scope}/subjects/{subject}/rules/{ruleid}/aspects/{aspect}").
+		To(a.putAspect).
+		Doc("Creates or replaces a rule’s list of aspects.").
+		Param(ws.PathParameter("scope", "scope").DataType("string")).
+		Param(ws.PathParameter("subject", "subject").DataType("string")).
+		Param(ws.PathParameter("ruleid", "rule id").DataType("string")).
+		Param(ws.PathParameter("aspect", "aspect").DataType("string")).
+		Reads(&pb.Aspect{}).
+		Writes(APIResponse{}))
 
 	// Creates or replaces a named adapter configuration
 	ws.Route(ws.

--- a/pkg/config/apiserver_test.go
+++ b/pkg/config/apiserver_test.go
@@ -118,6 +118,210 @@ func TestAPI_getRules(t *testing.T) {
 
 }
 
+func TestAPI_getScopes(t *testing.T) {
+
+	for _, ctx := range []struct {
+		key    string
+		val    string
+		status int
+	}{
+		{"/scopes", "", http.StatusNotImplemented}, // TODO expect http.StatusOK
+	} {
+		t.Run(ctx.key, func(t *testing.T) {
+			store := &fakeMemStore{
+				data: map[string]string{
+					ctx.key: ctx.val,
+				},
+			}
+			api := NewAPI("v1", 0, nil, nil,
+				nil, nil, store)
+
+			sc, _ := makeAPIRequest(api.handler, "GET", api.rootPath+ctx.key, []byte{}, t)
+			if sc != ctx.status {
+				t.Errorf("http status got %d, want %d", sc, ctx.status)
+			}
+			// TODO validate the returned body
+		})
+	}
+}
+
+func TestAPI_createPolicy(t *testing.T) {
+
+	for _, ctx := range []struct {
+		key    string
+		body   []byte
+		status int
+	}{
+		{"/scopes/global/subjects/newTestSubject",
+			[]byte(`{"scope":"global","subject":"subject001","revision":"some-uuid","rules":[]}`),
+			http.StatusNotImplemented}, // TODO expect http.StatusCreated
+	} {
+		t.Run(ctx.key, func(t *testing.T) {
+			store := &fakeMemStore{
+				data: map[string]string{},
+			}
+			api := NewAPI("v1", 0, nil, nil,
+				nil, nil, store)
+
+			sc, _ := makeAPIRequest(api.handler, "POST", api.rootPath+ctx.key, ctx.body, t)
+			if sc != ctx.status {
+				t.Errorf("http status got %d, want %d", sc, ctx.status)
+			} else if sc <= http.StatusAccepted {
+				// TODO verify the expected data is present in store rather than just non-empty
+				if len(store.data) == 0 {
+					t.Errorf("%v did not create %v", ctx.key, string(ctx.body))
+				}
+			}
+		})
+	}
+}
+
+func TestAPI_putAspect(t *testing.T) {
+
+	for _, ctx := range []struct {
+		key    string
+		body   []byte
+		status int
+	}{
+		{"/scopes/global/subjects/subject001/rules/rule001/aspects/aspect001",
+			[]byte(`{"scope":"global","subject":"subject001","ruleid":"rule001","aspect":"aspect001","revision":"some-uuid","aspects":[]}`),
+			http.StatusNotImplemented}, // TODO expect http.StatusCreated
+	} {
+		t.Run(ctx.key, func(t *testing.T) {
+			store := &fakeMemStore{
+				data: map[string]string{},
+			}
+			api := NewAPI("v1", 0, nil, nil,
+				nil, nil, store)
+
+			sc, _ := makeAPIRequest(api.handler, "PUT", api.rootPath+ctx.key, ctx.body, t)
+			if sc != ctx.status {
+				t.Errorf("http status got %d, want %d", sc, ctx.status)
+			} else if sc <= http.StatusAccepted {
+				// TODO verify the expected data is present in store rather than just non-empty
+				if len(store.data) == 0 {
+					t.Errorf("%v did not create %v", ctx.key, string(ctx.body))
+				}
+			}
+		})
+	}
+}
+
+func TestAPI_deleteRule(t *testing.T) {
+
+	for _, ctx := range []struct {
+		key    string
+		val    string
+		status int
+	}{
+		{"/scopes/global/subjects/testSubject/rules/rule001", "", http.StatusNotImplemented}, // TODO expect http.StatusNoContent
+	} {
+		t.Run(ctx.key, func(t *testing.T) {
+			store := &fakeMemStore{
+				data: map[string]string{
+					ctx.key: ctx.val,
+				},
+			}
+			api := NewAPI("v1", 0, nil, nil,
+				nil, nil, store)
+
+			sc, _ := makeAPIRequest(api.handler, "DELETE", api.rootPath+ctx.key, []byte{}, t)
+			if sc != ctx.status {
+				t.Errorf("http status got %d, want %d", sc, ctx.status)
+			}
+		})
+	}
+}
+
+func TestAPI_putAdapter(t *testing.T) {
+
+	for _, ctx := range []struct {
+		key    string
+		body   []byte
+		status int
+	}{
+		{"/scopes/global/adapters/adapter001/config001",
+			[]byte(`{"params":{}}`),
+			http.StatusNotImplemented}, // TODO expect http.StatusCreated
+	} {
+		t.Run(ctx.key, func(t *testing.T) {
+			store := &fakeMemStore{
+				data: map[string]string{},
+			}
+			api := NewAPI("v1", 0, nil, nil,
+				nil, nil, store)
+
+			sc, _ := makeAPIRequest(api.handler, "PUT", api.rootPath+ctx.key, ctx.body, t)
+			if sc != ctx.status {
+				t.Errorf("http status got %d, want %d", sc, ctx.status)
+			} else if sc <= http.StatusAccepted {
+				// TODO verify the expected data is present in store rather than just non-empty
+				if len(store.data) == 0 {
+					t.Errorf("%v did not create %v", ctx.key, string(ctx.body))
+				}
+			}
+		})
+	}
+}
+
+func TestAPI_getDescriptor(t *testing.T) {
+
+	for _, ctx := range []struct {
+		key    string
+		val    string
+		status int
+	}{
+		{"/scopes/global/descriptors/type001/descriptor001", "", http.StatusNotImplemented}, // TODO expect http.StatusOK
+	} {
+		t.Run(ctx.key, func(t *testing.T) {
+			store := &fakeMemStore{
+				data: map[string]string{
+					ctx.key: ctx.val,
+				},
+			}
+			api := NewAPI("v1", 0, nil, nil,
+				nil, nil, store)
+
+			sc, _ := makeAPIRequest(api.handler, "GET", api.rootPath+ctx.key, []byte{}, t)
+			if sc != ctx.status {
+				t.Errorf("http status got %d, want %d", sc, ctx.status)
+			}
+			// TODO validate the returned body
+		})
+	}
+}
+
+func TestAPI_putDescriptor(t *testing.T) {
+
+	for _, ctx := range []struct {
+		key    string
+		body   []byte
+		status int
+	}{
+		{"/scopes/global/descriptors/type001/descriptor001",
+			[]byte(`{}`),
+			http.StatusNotImplemented}, // TODO expect http.StatusCreated
+	} {
+		t.Run(ctx.key, func(t *testing.T) {
+			store := &fakeMemStore{
+				data: map[string]string{},
+			}
+			api := NewAPI("v1", 0, nil, nil,
+				nil, nil, store)
+
+			sc, _ := makeAPIRequest(api.handler, "PUT", api.rootPath+ctx.key, ctx.body, t)
+			if sc != ctx.status {
+				t.Errorf("http status got %d, want %d", sc, ctx.status)
+			} else if sc <= http.StatusAccepted {
+				// TODO verify the expected data is present in store rather than just non-empty
+				if len(store.data) == 0 {
+					t.Errorf("%v did not create %v", ctx.key, string(ctx.body))
+				}
+			}
+		})
+	}
+}
+
 func readBody(err string) readBodyFunc {
 	return func(r io.Reader) (b []byte, e error) {
 		if err != "" {


### PR DESCRIPTION
The routes documented by Swagger should return 501 instead of 404 because it is not a client error to invoke them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/632)
<!-- Reviewable:end -->
