### PR TITLE
Benchmark test for adapterManager dispatch code.

### DIFF
--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -51,6 +51,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//adapter:go_default_library",
+        "//adapter/noop:go_default_library",
         "//pkg/config/descriptor:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",

--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -46,13 +46,13 @@ go_test(
     name = "dispatch_benchmark_test",
     size = "small",
     srcs = [
-        "managerDispatchBenchmark_test.go"
+        "managerDispatchBenchmark_test.go",
     ],
     library = ":go_default_library",
     deps = [
+        "//adapter:go_default_library",
         "//pkg/config/descriptor:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
-        "//adapter:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_istio_api//:mixer/v1/config",
         "@com_github_istio_api//:mixer/v1/config/descriptor",

--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -41,3 +41,20 @@ go_test(
         "@com_github_istio_api//:mixer/v1/config/descriptor",
     ],
 )
+
+go_test(
+    name = "dispatch_benchmark_test",
+    size = "small",
+    srcs = [
+        "managerDispatchBenchmark_test.go"
+    ],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/config/descriptor:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "//adapter:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_istio_api//:mixer/v1/config",
+        "@com_github_istio_api//:mixer/v1/config/descriptor",
+    ],
+)

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -126,6 +126,13 @@ func newManager(r builderFinder, m [config.NumKinds]aspect.Manager, exp expr.Eva
 	return mg
 }
 
+func (m *Manager) dispatchCheck(ctx context.Context, configs []*cpb.Combined, requestBag, responseBag *attribute.MutableBag) rpc.Status {
+	return m.dispatch(ctx, requestBag, responseBag, configs,
+		func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
+			cw := executor.(aspect.CheckExecutor)
+			return cw.Execute(requestBag, evaluator)
+		})
+}
 // Check dispatches to the set of aspects associated with the Check API method
 func (m *Manager) Check(ctx context.Context, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 	configs, err := m.loadConfigs(requestBag, m.checkKindSet, false, true /* fail if unable to eval all selectors */)
@@ -133,10 +140,14 @@ func (m *Manager) Check(ctx context.Context, requestBag, responseBag *attribute.
 		glog.Error(err)
 		return status.WithError(err)
 	}
+	return m.dispatchCheck(ctx, configs, requestBag, responseBag)
+}
+
+func (m *Manager) dispatchReport(ctx context.Context, configs []*cpb.Combined, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 	return m.dispatch(ctx, requestBag, responseBag, configs,
 		func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
-			cw := executor.(aspect.CheckExecutor)
-			return cw.Execute(requestBag, evaluator)
+			rw := executor.(aspect.ReportExecutor)
+			return rw.Execute(requestBag, evaluator)
 		})
 }
 
@@ -147,11 +158,7 @@ func (m *Manager) Report(ctx context.Context, requestBag, responseBag *attribute
 		glog.Error(err)
 		return status.WithError(err)
 	}
-	return m.dispatch(ctx, requestBag, responseBag, configs,
-		func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
-			rw := executor.(aspect.ReportExecutor)
-			return rw.Execute(requestBag, evaluator)
-		})
+	return m.dispatchReport(ctx, configs, requestBag, responseBag)
 }
 
 // Quota dispatches to the set of aspects associated with the Quota API method

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -133,6 +133,7 @@ func (m *Manager) dispatchCheck(ctx context.Context, configs []*cpb.Combined, re
 			return cw.Execute(requestBag, evaluator)
 		})
 }
+
 // Check dispatches to the set of aspects associated with the Check API method
 func (m *Manager) Check(ctx context.Context, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 	configs, err := m.loadConfigs(requestBag, m.checkKindSet, false, true /* fail if unable to eval all selectors */)

--- a/pkg/adapterManager/managerDispatchBenchmark_test.go
+++ b/pkg/adapterManager/managerDispatchBenchmark_test.go
@@ -1,0 +1,241 @@
+// Copyright 2016 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapterManager
+
+import (
+	"bytes"
+	"context"
+	"github.com/gogo/protobuf/types"
+	"io/ioutil"
+	"istio.io/mixer/pkg/adapter"
+	pkgAdapter "istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/aspect"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/expr"
+	"istio.io/mixer/pkg/pool"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"github.com/googleapis/googleapis/google/rpc"
+)
+
+/*
+Benchmark tests in this file measure time between start of adapterManager/manager.go:dispatchReport and
+end of metricManager.Execute method (adapter is stubbed out). NOTE: The test does not measure the load config code
+that happens for every call inside check/report/quota methods of adapterManager/manager.go.
+
+How to run the test:
+# make sure the code builds and works with go tools and not just with bazel.
+
+Command:
+go test -run XXXX -bench .
+
+Output: (2017-04-27)
+BenchmarkOneSimpleAspect-12     	   10000	    113880 ns/op
+Benchmark50SimpleAspect-12      	    1000	   1410848 ns/op
+BenchmarkOneComplexAspect-12    	   10000	    157771 ns/op
+Benchmark50ComplexAspect-12     	     500	   2757074 ns/op
+PASS
+ok  	istio.io/mixer/pkg/adapterManager	6.202s
+*/
+
+const (
+	minimalGlobalCnfg = `
+subject: namespace:ns
+revision: "2022"
+adapters:
+  - name: noopMetricKindAdapter
+    kind: metrics
+    impl: noopMetricKindAdapter
+
+manifests:
+  - name: istio-proxy
+    revision: "1"
+    attributes:
+    - name: source.name
+      value_type: STRING
+    - name: target.name
+      value_type: STRING
+    - name: response.code
+      value_type: INT64
+    - name: api.name
+      value_type: STRING
+    - name: api.method
+      value_type: STRING
+
+metrics:
+  - name: request_count
+    kind: COUNTER
+    value: INT64
+    description: request count by source, target, service, and code
+    labels:
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
+  - name: request_latency
+    kind: COUNTER
+    value: DURATION
+    description: request latency by source, target, and service
+    labels:
+      source: 1 # STRING
+      target: 1 # STRING
+      service: 1 # STRING
+      method: 1 # STRING
+      response_code: 2 # INT64
+`
+	srvcCnfgConstInitialSection = `
+subject: namespace:ns
+rules:
+- selector: true
+  aspects:
+`
+	srvcCnfgSimpleAspect = `
+  - kind: metrics
+    adapter: noopMetricKindAdapter
+    params:
+      metrics:
+      - descriptorName: request_count
+        value: response.code | 100
+        labels:
+          source: source.name | "one"
+          target: target.name | "one"
+          service: api.name | "one"
+          method: api.method | "one"
+          response_code: response.code | 111
+`
+
+	srvcCnfgComplexAspect = `
+  - kind: metrics
+    adapter: noopMetricKindAdapter
+    params:
+      metrics:
+      - descriptorName: request_count
+        value: response.code | 100
+        labels:
+          source: source.name | target.name | source.name | target.name | "one"
+          target: source.name | target.name | source.name | "one"
+          service: target.name | api.name | target.name | "one"
+          method: api.method | target.name | api.method | target.name | "one"
+          response_code: response.code | response.code | response.code | response.code | response.code | response.code | response.code | response.code | 111
+`
+)
+
+func registerNoopAdapter(r adapter.Registrar) {
+	r.RegisterMetricsBuilder(&fakeNoopAdapter{adapter.NewDefaultBuilder("noopMetricKindAdapter", "Publishes metrics", &types.Empty{})})
+}
+type fakeNoopAdapter struct {
+	adapter.DefaultBuilder
+}
+func (f *fakeNoopAdapter) NewMetricsAspect(env adapter.Env, cfg adapter.Config, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+	return &fakeNoopAdapter{}, nil
+}
+func (f *fakeNoopAdapter) Record(vals []adapter.Value) error {
+	return nil
+}
+func (*fakeNoopAdapter) Close() error { return nil }
+
+func createYamlConfigs(srvcCnfgAspectFromat string, configRepeatCount int) (declarativeSrvcCnfg *os.File, declaredGlobalCnfg *os.File) {
+	srvcCnfgFile, _ := ioutil.TempFile("", "managerDispatchBenchmarkTest")
+	globalCnfgFile, _ := ioutil.TempFile("", "managerDispatchBenchmarkTest")
+
+	_, _ = globalCnfgFile.Write([]byte(minimalGlobalCnfg))
+	_ = globalCnfgFile.Close()
+
+	var srvcCnfgBuffer bytes.Buffer
+	srvcCnfgBuffer.WriteString(srvcCnfgConstInitialSection)
+	for i := 0; i < configRepeatCount; i++ {
+		srvcCnfgBuffer.WriteString(strings.Replace(srvcCnfgAspectFromat, "$s", strconv.FormatInt(int64(i), 10), 1))
+	}
+	_, _ = srvcCnfgFile.Write([]byte(srvcCnfgBuffer.String()))
+	_ = srvcCnfgFile.Close()
+
+	return srvcCnfgFile, globalCnfgFile
+}
+
+var rpcStatus google_rpc.Status
+func benchmarkAdapterManagerDispatch(b *testing.B, declarativeSrvcCnfgFilePath string, declaredGlobalCnfgFilePath string) {
+	apiPoolSize := 1024
+	adapterPoolSize := 1024
+	identityAttribute := "target.service"
+	identityDomainAttribute := "svc.cluster.local"
+	loopDelay := time.Second * time.Duration(5)
+	singleThreadedGoRoutinePool := false
+
+	gp := pool.NewGoroutinePool(apiPoolSize, singleThreadedGoRoutinePool)
+	gp.AddWorkers(apiPoolSize)
+	gp.AddWorkers(apiPoolSize)
+	defer gp.Close()
+
+	adapterGP := pool.NewGoroutinePool(adapterPoolSize, singleThreadedGoRoutinePool)
+	adapterGP.AddWorkers(adapterPoolSize)
+	defer adapterGP.Close()
+
+	eval := expr.NewCEXLEvaluator()
+	adapterMgr := NewManager([]pkgAdapter.RegisterFn{
+		registerNoopAdapter,
+	}, aspect.Inventory(), eval, gp, adapterGP)
+	store, _ := config.NewCompatFSStore(declaredGlobalCnfgFilePath, declarativeSrvcCnfgFilePath)
+
+	cnfgMgr := config.NewManager(eval, adapterMgr.AspectValidatorFinder, adapterMgr.BuilderValidatorFinder,
+		adapterMgr.SupportedKinds, store,
+		loopDelay,
+		identityAttribute, identityDomainAttribute)
+	cnfgMgr.Register(adapterMgr)
+	cnfgMgr.Start()
+
+	requestBag := attribute.GetMutableBag(nil)
+	requestBag.Set(identityAttribute, identityDomainAttribute)
+	configs, _ := adapterMgr.loadConfigs(requestBag, adapterMgr.reportKindSet, false, false)
+
+	b.ResetTimer()
+	var r google_rpc.Status
+	for n := 0; n < b.N; n++ {
+		r = adapterMgr.dispatchReport(context.Background(), configs, requestBag, attribute.GetMutableBag(nil))
+	}
+	rpcStatus = r
+}
+
+func BenchmarkOneSimpleAspect(b *testing.B) {
+	sc, gsc := createYamlConfigs(srvcCnfgSimpleAspect, 1)
+	defer os.Remove(sc.Name())
+	defer os.Remove(gsc.Name())
+	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+}
+
+func Benchmark50SimpleAspect(b *testing.B) {
+	sc, gsc := createYamlConfigs(srvcCnfgSimpleAspect, 50)
+	defer os.Remove(sc.Name())
+	defer os.Remove(gsc.Name())
+	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+}
+
+func BenchmarkOneComplexAspect(b *testing.B) {
+	sc, gsc := createYamlConfigs(srvcCnfgComplexAspect, 1)
+	defer os.Remove(sc.Name())
+	defer os.Remove(gsc.Name())
+	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+}
+
+func Benchmark50ComplexAspect(b *testing.B) {
+	sc, gsc := createYamlConfigs(srvcCnfgComplexAspect, 50)
+	defer os.Remove(sc.Name())
+	defer os.Remove(gsc.Name())
+	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+}

--- a/pkg/adapterManager/managerDispatchBenchmark_test.go
+++ b/pkg/adapterManager/managerDispatchBenchmark_test.go
@@ -217,28 +217,28 @@ func benchmarkAdapterManagerDispatch(b *testing.B, declarativeSrvcCnfgFilePath s
 
 func BenchmarkOneSimpleAspect(b *testing.B) {
 	sc, gsc := createYamlConfigs(srvcCnfgSimpleAspect, 1)
-	defer os.Remove(sc.Name())
-	defer os.Remove(gsc.Name())
 	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+	_ = os.Remove(sc.Name())
+	_ = os.Remove(gsc.Name())
 }
 
 func Benchmark50SimpleAspect(b *testing.B) {
 	sc, gsc := createYamlConfigs(srvcCnfgSimpleAspect, 50)
-	defer os.Remove(sc.Name())
-	defer os.Remove(gsc.Name())
 	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+	_ = os.Remove(sc.Name())
+	_ = os.Remove(gsc.Name())
 }
 
 func BenchmarkOneComplexAspect(b *testing.B) {
 	sc, gsc := createYamlConfigs(srvcCnfgComplexAspect, 1)
-	defer os.Remove(sc.Name())
-	defer os.Remove(gsc.Name())
 	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+	_ = os.Remove(sc.Name())
+	_ = os.Remove(gsc.Name())
 }
 
 func Benchmark50ComplexAspect(b *testing.B) {
 	sc, gsc := createYamlConfigs(srvcCnfgComplexAspect, 50)
-	defer os.Remove(sc.Name())
-	defer os.Remove(gsc.Name())
 	benchmarkAdapterManagerDispatch(b, sc.Name(), gsc.Name())
+	_ = os.Remove(sc.Name())
+	_ = os.Remove(gsc.Name())
 }

--- a/pkg/adapterManager/managerDispatchBenchmark_test.go
+++ b/pkg/adapterManager/managerDispatchBenchmark_test.go
@@ -17,8 +17,14 @@ package adapterManager
 import (
 	"bytes"
 	"context"
-	"github.com/gogo/protobuf/types"
 	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/googleapis/googleapis/google/rpc"
+
 	"istio.io/mixer/pkg/adapter"
 	pkgAdapter "istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/aspect"
@@ -26,12 +32,6 @@ import (
 	"istio.io/mixer/pkg/config"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/pool"
-	"os"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
-	"github.com/googleapis/googleapis/google/rpc"
 )
 
 /*
@@ -140,9 +140,11 @@ rules:
 func registerNoopAdapter(r adapter.Registrar) {
 	r.RegisterMetricsBuilder(&fakeNoopAdapter{adapter.NewDefaultBuilder("noopMetricKindAdapter", "Publishes metrics", &types.Empty{})})
 }
+
 type fakeNoopAdapter struct {
 	adapter.DefaultBuilder
 }
+
 func (f *fakeNoopAdapter) NewMetricsAspect(env adapter.Env, cfg adapter.Config, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	return &fakeNoopAdapter{}, nil
 }
@@ -170,6 +172,7 @@ func createYamlConfigs(srvcCnfgAspect string, configRepeatCount int) (declarativ
 }
 
 var rpcStatus google_rpc.Status
+
 func benchmarkAdapterManagerDispatch(b *testing.B, declarativeSrvcCnfgFilePath string, declaredGlobalCnfgFilePath string) {
 	apiPoolSize := 1024
 	adapterPoolSize := 1024

--- a/pkg/adapterManager/managerDispatchBenchmark_test.go
+++ b/pkg/adapterManager/managerDispatchBenchmark_test.go
@@ -151,7 +151,7 @@ func (f *fakeNoopAdapter) Record(vals []adapter.Value) error {
 }
 func (*fakeNoopAdapter) Close() error { return nil }
 
-func createYamlConfigs(srvcCnfgAspectFromat string, configRepeatCount int) (declarativeSrvcCnfg *os.File, declaredGlobalCnfg *os.File) {
+func createYamlConfigs(srvcCnfgAspect string, configRepeatCount int) (declarativeSrvcCnfg *os.File, declaredGlobalCnfg *os.File) {
 	srvcCnfgFile, _ := ioutil.TempFile("", "managerDispatchBenchmarkTest")
 	globalCnfgFile, _ := ioutil.TempFile("", "managerDispatchBenchmarkTest")
 
@@ -161,7 +161,7 @@ func createYamlConfigs(srvcCnfgAspectFromat string, configRepeatCount int) (decl
 	var srvcCnfgBuffer bytes.Buffer
 	srvcCnfgBuffer.WriteString(srvcCnfgConstInitialSection)
 	for i := 0; i < configRepeatCount; i++ {
-		srvcCnfgBuffer.WriteString(strings.Replace(srvcCnfgAspectFromat, "$s", strconv.FormatInt(int64(i), 10), 1))
+		srvcCnfgBuffer.WriteString(srvcCnfgAspect)
 	}
 	_, _ = srvcCnfgFile.Write([]byte(srvcCnfgBuffer.String()))
 	_ = srvcCnfgFile.Close()


### PR DESCRIPTION
Add benchmark test for code between adapterManager dispatch and before adapters are invoked (through the aspect managers).

Includes 4 tests: 
- single aspect with simple expressions, 
- 50 aspects with simple expressions, 
- single aspect with complex expressions, 
- 50 aspects with complex expressions,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/634)
<!-- Reviewable:end -->
