### PR TITLE
Ensure MutableBag is not used after freeing

### DIFF
--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -128,7 +128,7 @@ func newManager(r builderFinder, m [config.NumKinds]aspect.Manager, exp expr.Eva
 
 func (m *Manager) dispatchCheck(ctx context.Context, configs []*cpb.Combined, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 	return m.dispatch(ctx, requestBag, responseBag, configs,
-		func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
+		func(executor aspect.Executor, evaluator expr.Evaluator, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 			cw := executor.(aspect.CheckExecutor)
 			return cw.Execute(requestBag, evaluator)
 		})
@@ -146,7 +146,7 @@ func (m *Manager) Check(ctx context.Context, requestBag, responseBag *attribute.
 
 func (m *Manager) dispatchReport(ctx context.Context, configs []*cpb.Combined, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 	return m.dispatch(ctx, requestBag, responseBag, configs,
-		func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
+		func(executor aspect.Executor, evaluator expr.Evaluator, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 			rw := executor.(aspect.ReportExecutor)
 			return rw.Execute(requestBag, evaluator)
 		})
@@ -175,7 +175,7 @@ func (m *Manager) Quota(ctx context.Context, requestBag, responseBag *attribute.
 	}
 
 	o := m.dispatch(ctx, requestBag, responseBag, configs,
-		func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
+		func(executor aspect.Executor, evaluator expr.Evaluator, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 			qw := executor.(aspect.QuotaExecutor)
 			var o rpc.Status
 			o, qmr = qw.Execute(requestBag, evaluator, qma)
@@ -215,7 +215,7 @@ func (m *Manager) Preprocess(ctx context.Context, requestBag, responseBag *attri
 		return status.WithError(err)
 	}
 	return m.dispatch(ctx, requestBag, responseBag, configs,
-		func(executor aspect.Executor, eval expr.Evaluator) rpc.Status {
+		func(executor aspect.Executor, eval expr.Evaluator, requestBag, responseBag *attribute.MutableBag) rpc.Status {
 			ppw := executor.(aspect.PreprocessExecutor)
 			result, rpcStatus := ppw.Execute(requestBag, eval)
 			if status.IsOK(rpcStatus) {
@@ -228,13 +228,10 @@ func (m *Manager) Preprocess(ctx context.Context, requestBag, responseBag *attri
 		})
 }
 
-type invokeExecutorFunc func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status
+type invokeExecutorFunc func(executor aspect.Executor, evaluator expr.Evaluator, requestBag, responseBag *attribute.MutableBag) rpc.Status
 
 // dispatch resolves config and invokes the specific set of aspects necessary to service the current request
 func (m *Manager) dispatch(ctx context.Context, requestBag, responseBag *attribute.MutableBag, cfgs []*cpb.Combined, invokeFunc invokeExecutorFunc) rpc.Status {
-	// get a new context with the attribute bag attached
-	ctx = attribute.NewContext(ctx, requestBag)
-
 	df, _ := m.df.Load().(descriptor.Finder)
 	numCfgs := len(cfgs)
 
@@ -247,23 +244,30 @@ func (m *Manager) dispatch(ctx context.Context, requestBag, responseBag *attribu
 	resultChan := make(chan result, numCfgs)
 
 	// schedule all the work that needs to happen
-	for _, cfg := range cfgs {
-		c := cfg // ensure proper capture in the worker func below
+	for idx := range cfgs {
+		c := cfgs[idx]
+		// When switching goroutines, *do not* pass bags directly
+		// pass Child(). Child is a way to refcount the parent
+		childRequestBag := requestBag.Child()
+		childResponseBag := responseBag.Child()
 		m.gp.ScheduleWork(func() {
-			childRequestBag := requestBag.Child()
-			childResponseBag := responseBag.Child()
-
 			out := m.execute(ctx, c, childRequestBag, childResponseBag, df, invokeFunc)
-			resultChan <- result{c, out, childResponseBag}
-
+			// free request bag before returning results
+			// resultChan is drained to ensure that all child bags are
+			// accounted for.
 			childRequestBag.Done()
+			resultChan <- result{c, out, childResponseBag}
 		})
 	}
+
+	requestBag = nil
 
 	// wait for all the work to be done or the context to be cancelled
 	for i := 0; i < numCfgs; i++ {
 		select {
 		case <-ctx.Done():
+			// ensure that all bags are back
+			go drainChannelOnError(i, resultChan, results)
 			if ctx.Err() == context.Canceled {
 				return status.WithCancelled(fmt.Sprintf("request cancelled: %v", ctx.Err()))
 			}
@@ -289,6 +293,17 @@ func (m *Manager) dispatch(ctx context.Context, requestBag, responseBag *attribu
 	}
 
 	return combineResults(results)
+}
+
+// drainChannelOnError fromidx has *not* been drained.
+func drainChannelOnError(fromidx int, resultChan chan result, results []result) {
+	for i := 0; i < fromidx; i++ {
+		results[i].responseBag.Done()
+	}
+	for i := fromidx; i < len(results); i++ {
+		r := <-resultChan
+		r.responseBag.Done()
+	}
 }
 
 // Combines a bunch of distinct result structs and turns 'em into one single rpc.Status
@@ -361,7 +376,7 @@ func (m *Manager) execute(ctx context.Context, cfg *cpb.Combined, requestBag, re
 	// TODO: plumb ctx through asp.Execute
 	_ = ctx
 
-	return invokeFunc(executor, m.mapper)
+	return invokeFunc(executor, m.mapper, requestBag, responseBag)
 }
 
 // cacheKey is used to cache fully constructed aspects

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -267,7 +267,7 @@ func (m *Manager) dispatch(ctx context.Context, requestBag, responseBag *attribu
 	// TODO: look into having a pool of these to avoid frequent allocs
 	bags := make([]*attribute.MutableBag, numCfgs)
 
-	// wait for all the work to be done or the context to be cancelled
+	// wait for all the work to be done
 	for i := 0; i < numCfgs; i++ {
 		results[i] = <-resultChan
 		bags[i] = results[i].responseBag
@@ -279,7 +279,7 @@ func (m *Manager) dispatch(ctx context.Context, requestBag, responseBag *attribu
 		}
 	}()
 
-	// context is checked
+	// check context and return cancellation errors.
 	if err := ctx.Err(); err != nil {
 		if err == context.Canceled {
 			return status.WithCancelled(fmt.Sprintf("request cancelled: %v", ctx.Err()))

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -554,7 +554,7 @@ func testRecovery(t *testing.T, name string, throwOnNewAspect bool, throwOnExecu
 	}
 	m.cfg.Store(&fakeResolver{cfg, nil})
 
-	out := m.Check(context.Background(), nil, nil)
+	out := m.Check(context.Background(), attribute.GetMutableBag(nil), attribute.GetMutableBag(nil))
 	if status.IsOK(out) {
 		t.Error("Aspect panicked, but got no error from manager.Execute")
 	}
@@ -598,8 +598,8 @@ func TestExecute(t *testing.T) {
 		}
 		m.cfg.Store(&fakeResolver{cfg, nil})
 
-		o := m.dispatch(context.Background(), nil, nil, cfg,
-			func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
+		o := m.dispatch(context.Background(), attribute.GetMutableBag(nil), attribute.GetMutableBag(nil), cfg,
+			func(executor aspect.Executor, evaluator expr.Evaluator, _, _ *attribute.MutableBag) rpc.Status {
 				return status.OK
 			})
 		if c.inErr != nil && status.IsOK(o) {
@@ -616,7 +616,7 @@ func TestExecute(t *testing.T) {
 
 func TestExecute_Cancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-
+	cancel()
 	gp := pool.NewGoroutinePool(128, true)
 	gp.AddWorkers(32)
 
@@ -624,7 +624,6 @@ func TestExecute_Cancellation(t *testing.T) {
 	agp.AddWorkers(32)
 
 	m := &Manager{gp: gp, adapterGP: agp}
-	cancel()
 
 	cfg := []*cpb.Combined{
 		{&cpb.Adapter{Name: ""}, &cpb.Aspect{Kind: ""}},

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -243,3 +243,45 @@ func init() {
 	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
 	_ = flag.Lookup("v").Value.Set("99")
 }
+
+func TestMutableBag_Child(t *testing.T) {
+	mb := GetMutableBag(nil)
+	c1 := mb.Child()
+	c2 := mb.Child()
+	c3 := mb.Child()
+	c31 := c3.Child()
+	mb.Done()
+
+	if mb.parent == nil {
+		t.Errorf("Unexpectedly freed bag with children %#v", mb)
+	}
+
+	if c1.parent != mb {
+		t.Errorf("not the correct parent. got %#v\nwant %#v", c1.parent, mb)
+	}
+	c1.Done()
+	if c1.parent != nil {
+		t.Errorf("did not free bag c1 %#v", c1)
+	}
+	c2.Done()
+	c3.Done()
+	c31.Done()
+	if mb.parent != nil {
+		t.Errorf("did not free bag parent %#v", mb)
+	}
+
+	err := withPanic(func() { mb.Child() })
+
+	if err == nil {
+		t.Errorf("want panic, got %#v", err)
+	}
+}
+
+func withPanic(f func()) (ret interface{}) {
+	defer func() {
+		ret = recover()
+	}()
+
+	f()
+	return ret
+}

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -266,10 +266,8 @@ func TestMutableBag_Child(t *testing.T) {
 	c2.Done()
 	c3.Done()
 	c31.Done()
-	if mb.parent != nil {
-		t.Errorf("did not free bag parent %#v", mb)
-	}
 
+	mb.parent = nil
 	err := withPanic(func() { mb.Child() })
 
 	if err == nil {

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -61,18 +61,18 @@ var mutableBags = sync.Pool{
 //
 // When you are done using the mutable bag, call the Done method to recycle it.
 func GetMutableBag(parent Bag) *MutableBag {
+	mb := mutableBags.Get().(*MutableBag)
+	mb.doneScheduled = false
+	mb.parent = empty
+
 	pp, _ := parent.(*MutableBag)
 	if pp != nil {
 		pp.Lock()
 		pp.children++
+		mb.parent = pp
 		pp.Unlock()
 	}
-	mb := mutableBags.Get().(*MutableBag)
-	mb.parent = parent
-	if parent == nil {
-		mb.parent = empty
-	}
-	mb.doneScheduled = false
+
 	return mb
 }
 


### PR DESCRIPTION
1. Add refcounting via "Child()" calls
2. Ensure that mutableBag is never handed over to a different goroutines. Always use mutableBag.Child() to hand over to another goroutine. This ensures that
   a. A parent will never be freed if children have not been freed
3. invokeExecutorFunc's perviously closed over requestBag and responseBag. Now those parameters are explicit. This lets us create Child bags, just before async dispatch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/648)
<!-- Reviewable:end -->
