### PR TITLE
First pass at attempting to wire up monitored resources

### DIFF
--- a/pkg/adapter/BUILD
+++ b/pkg/adapter/BUILD
@@ -4,20 +4,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "accessLogs.go",
-        "adapter.go",
-        "applicationLogs.go",
-        "attributes.go",
-        "builder.go",
-        "configError.go",
-        "denials.go",
-        "labels.go",
-        "lists.go",
-        "metrics.go",
-        "quotas.go",
-        "registrar.go",
-    ],
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
@@ -28,11 +18,6 @@ go_library(
 go_test(
     name = "small_tests",
     size = "small",
-    srcs = [
-        "applicationLogs_test.go",
-        "builder_test.go",
-        "configError_test.go",
-        "metrics_test.go",
-    ],
+    srcs = glob(["*_test.go"]),
     library = ":go_default_library",
 )

--- a/pkg/adapter/monitoredResource.go
+++ b/pkg/adapter/monitoredResource.go
@@ -1,0 +1,25 @@
+// Copyright 2017 the Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+type (
+	// MonitoredResource is a runtime monitored resource.
+	MonitoredResource struct {
+		Name string
+		// Labels are the names of keys for dimensional data that will
+		// be generated at runtime and passed along with quota values.
+		Labels map[string]interface{}
+	}
+)

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -148,7 +148,8 @@ func (m *Manager) dispatchReport(ctx context.Context, configs []*cpb.Combined, r
 	return m.dispatch(ctx, requestBag, responseBag, configs,
 		func(executor aspect.Executor, evaluator expr.Evaluator) rpc.Status {
 			rw := executor.(aspect.ReportExecutor)
-			return rw.Execute(requestBag, evaluator)
+			// TODO: figure out wiring of the monitored resource finder.
+			return rw.Execute(requestBag, evaluator, nil)
 		})
 }
 

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -134,7 +134,7 @@ func (f *fakeCheckExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator) 
 }
 func (f *fakeCheckExecutor) Close() error { return nil }
 
-func (f *fakeReportExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator) (output rpc.Status) {
+func (f *fakeReportExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator, _ aspect.MonitoredResourceFinder) (output rpc.Status) {
 	f.called++
 	return
 }

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -4,19 +4,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "accessLogsManager.go",
-        "applicationLogsManager.go",
-        "attrgenmgr.go",
-        "common.go",
-        "denialsManager.go",
-        "descriptors.go",
-        "inventory.go",
-        "listsManager.go",
-        "manager.go",
-        "metricsManager.go",
-        "quotasManager.go",
-    ],
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
     deps = [
         "//pkg/adapter:go_default_library",
         "//pkg/aspect/config:go_default_library",
@@ -42,18 +33,7 @@ go_library(
 go_test(
     name = "small_tests",
     size = "small",
-    srcs = [
-        "accessLogsManager_test.go",
-        "applicationLogsManager_test.go",
-        "attrgenmgr_test.go",
-        "common_test.go",
-        "denialsManager_test.go",
-        "descriptors_test.go",
-        "inventory_test.go",
-        "listsManager_test.go",
-        "metricsManager_test.go",
-        "quotasManager_test.go",
-    ],
+    srcs = glob(["*_test.go"]),
     library = ":go_default_library",
     deps = [
         "//pkg/adapter/test:go_default_library",

--- a/pkg/aspect/accessLogsManager.go
+++ b/pkg/aspect/accessLogsManager.go
@@ -111,7 +111,7 @@ func (e *accessLogsExecutor) Close() error {
 	return e.aspect.Close()
 }
 
-func (e *accessLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator) rpc.Status {
+func (e *accessLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator, _ MonitoredResourceFinder) rpc.Status {
 	labels := permissiveEval(e.labels, attrs, mapper)
 	templateVals := permissiveEval(e.templateExprs, attrs, mapper)
 

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -270,7 +270,7 @@ func TestAccessLoggerExecutor_Execute(t *testing.T) {
 			l := &test.Logger{}
 			v.exec.aspect = l
 
-			if out := v.exec.Execute(v.bag, v.mapper); !status.IsOK(out) {
+			if out := v.exec.Execute(v.bag, v.mapper, nil); !status.IsOK(out) {
 				t.Fatalf("Execute(): should not have received error for %s (%v)", v.name, out)
 			}
 			if l.EntryCount != len(v.wantEntries) {
@@ -319,7 +319,7 @@ func TestAccessLoggerExecutor_ExecuteFailures(t *testing.T) {
 
 	for idx, v := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			if out := v.exec.Execute(v.bag, v.mapper); status.IsOK(out) {
+			if out := v.exec.Execute(v.bag, v.mapper, nil); status.IsOK(out) {
 				t.Fatalf("Execute(): expected error for %s", v.name)
 			}
 		})

--- a/pkg/aspect/applicationLogsManager.go
+++ b/pkg/aspect/applicationLogsManager.go
@@ -142,7 +142,7 @@ func (applicationLogsManager) ValidateConfig(c config.AspectParams, v expr.Valid
 
 func (e *applicationLogsExecutor) Close() error { return e.aspect.Close() }
 
-func (e *applicationLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator) rpc.Status {
+func (e *applicationLogsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator, _ MonitoredResourceFinder) rpc.Status {
 	result := &multierror.Error{}
 	var entries []adapter.LogEntry
 

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -367,7 +367,7 @@ func TestLogExecutor_Execute(t *testing.T) {
 			l := &test.Logger{}
 			tt.exec.aspect = l
 
-			if out := tt.exec.Execute(tt.bag, tt.mapper); !status.IsOK(out) {
+			if out := tt.exec.Execute(tt.bag, tt.mapper, nil); !status.IsOK(out) {
 				t.Fatalf("Execute(): should not have received error for %s (%v)", tt.name, out)
 			}
 			if l.EntryCount != len(tt.wantEntries) {
@@ -443,7 +443,7 @@ func TestLogExecutor_ExecuteFailures(t *testing.T) {
 	}
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			if out := tt.exec.Execute(tt.bag, tt.mapper); status.IsOK(out) {
+			if out := tt.exec.Execute(tt.bag, tt.mapper, nil); status.IsOK(out) {
 				t.Fatalf("Execute(): should have received error for %s", tt.name)
 			}
 		})

--- a/pkg/aspect/config/BUILD
+++ b/pkg/aspect/config/BUILD
@@ -21,6 +21,7 @@ gogoslick_proto_library(
         "denials.proto",
         "lists.proto",
         "metrics.proto",
+        "monitoredResource.proto",
         "quotas.proto",
     ],
     verbose = 0,

--- a/pkg/aspect/config/accessLogs.proto
+++ b/pkg/aspect/config/accessLogs.proto
@@ -54,9 +54,14 @@ message AccessLogsParams {
 
     // Describes how attributes must be evaluated to produce values for a log message.
     message AccessLog {
+        // Next field number: 6
+
         // Only used if log_format is CUSTOM. Links this AccessLog to a LogEntryDescriptor
         // that describes the log's template.
         string descriptor_name = 2;
+
+        // The name of the monitored resource descriptor to use when attaching metrics to a monitored resource.
+        string monitored_resource_descriptor_name = 5;
 
         // Map of template variable name to expression for the descriptor's log_template. At
         // run time each expression will be evaluated, and together they will provide values

--- a/pkg/aspect/config/applicationLogs.proto
+++ b/pkg/aspect/config/applicationLogs.proto
@@ -29,8 +29,13 @@ message ApplicationLogsParams {
     string log_name = 1;
 
     message ApplicationLog {
+        // Next field number: 8
+
         // Must match the name of some LogEntryDescriptor.
         string descriptor_name = 1;
+
+        // The name of the monitored resource descriptor to use when attaching metrics to a monitored resource.
+        string monitored_resource_descriptor_name = 7;
 
         // The expression to evaluate to determine this log's severity at runtime.
         string severity = 2;

--- a/pkg/aspect/config/metrics.proto
+++ b/pkg/aspect/config/metrics.proto
@@ -51,8 +51,13 @@ message MetricsParams {
     //        # either the attribute named 'responseCode' or the literal int64 500; must eval to an int64
     //        response_code: $responseCode | 500
     message Metric {
+        // Next field number: 5
+
         // Must match the name of some metric_descriptor in the global config.
         string descriptor_name = 1;
+
+        // The name of the monitored resource descriptor to use when attaching metrics to a monitored resource.
+        string monitored_resource_descriptor_name = 4;
 
         // Attribute expression to evaluate to determine the value for this metric;
         // the result of the evaluation must match the value ValueType of the metric_descriptor.

--- a/pkg/aspect/config/monitoredResource.proto
+++ b/pkg/aspect/config/monitoredResource.proto
@@ -1,0 +1,41 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package pkg.aspect.config;
+
+import "gogoproto/gogo.proto";
+
+option go_package="config";
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
+
+message MonitoredResources {
+    message MonitoredResource {
+        // Must match the name of some metric_descriptor in the global config.
+        string descriptor_name = 1;
+
+        // Attribute expression to evaluate to determine the name for this monitored resource;
+        // e.g. the name of the pod you're monitoring.
+        string name_expression = 2;
+
+        // Map of MonitoredResourceDescriptor label name to attribute expression. At run time each
+        // expression will be evaluated to determine the value provided to the aspect. The result
+        // of evaluating the expression must match the ValueType of the label in the MonitoredResourceDescriptor.
+        map<string, string> labels = 3;
+    }
+    repeated MonitoredResource resources = 1;
+}

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -93,7 +93,7 @@ type (
 		Executor
 
 		// Execute dispatches to the aspect manager.
-		Execute(attrs attribute.Bag, mapper expr.Evaluator) rpc.Status
+		Execute(attrs attribute.Bag, mapper expr.Evaluator, mr MonitoredResourceFinder) rpc.Status
 	}
 
 	// QuotaExecutor encapsulates a single QuotaManager aspect and allows it to be invoked.

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -104,7 +104,7 @@ func (*metricsManager) ValidateConfig(c config.AspectParams, v expr.Validator, d
 	return
 }
 
-func (w *metricsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator) rpc.Status {
+func (w *metricsExecutor) Execute(attrs attribute.Bag, mapper expr.Evaluator, _ MonitoredResourceFinder) rpc.Status {
 	result := &multierror.Error{}
 	var values []adapter.Value
 

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -347,7 +347,7 @@ func TestMetricsExecutor_Execute(t *testing.T) {
 				}},
 				metadata: c.mdin,
 			}
-			out := executor.Execute(test.NewBag(), c.eval)
+			out := executor.Execute(test.NewBag(), c.eval, nil)
 
 			errString := out.Message
 			if !strings.Contains(errString, c.errString) {

--- a/pkg/aspect/monitoredResourceManager.go
+++ b/pkg/aspect/monitoredResourceManager.go
@@ -1,0 +1,98 @@
+// Copyright 2017 the Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aspect
+
+import (
+	"fmt"
+
+	dpb "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/mixer/pkg/adapter"
+	aconfig "istio.io/mixer/pkg/aspect/config"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/descriptor"
+	"istio.io/mixer/pkg/expr"
+)
+
+type (
+	// MonitoredResourceFinder describes the ability to produce a MonitoredResource given a name and the
+	// ability to evaluate expressions in a context.
+	MonitoredResourceFinder interface {
+		Find(name string, attrs attribute.Bag, eval expr.Evaluator) (*adapter.MonitoredResource, error)
+	}
+
+	mrInfo struct {
+		nameExpr string
+		labels   map[string]string
+	}
+
+	mrProvider struct {
+		info map[string]mrInfo
+	}
+)
+
+// NewMRFinder produces a MonitoredResourceFinder given a set of aspect level monitored resources.
+func NewMRFinder(params *aconfig.MonitoredResources) MonitoredResourceFinder {
+	byName := make(map[string]mrInfo, len(params.Resources))
+	for _, mr := range params.Resources {
+		byName[mr.DescriptorName] = mrInfo{
+			nameExpr: mr.NameExpression,
+			labels:   mr.Labels,
+		}
+	}
+	return &mrProvider{byName}
+}
+
+func (m *mrProvider) Find(name string, attrs attribute.Bag, eval expr.Evaluator) (*adapter.MonitoredResource, error) {
+	info, found := m.info[name]
+	if !found {
+		return nil, fmt.Errorf("could not find unknown monitored resource descriptor '%s'", name)
+	}
+	concreteName, err := eval.Eval(info.nameExpr, attrs)
+	if err != nil {
+		return nil, err
+	}
+	// Validated ensures info.nameExpr has type STRING
+	nameString, _ := concreteName.(string)
+
+	labels, err := evalAll(info.labels, attrs, eval)
+	if err != nil {
+		return nil, err
+	}
+	return &adapter.MonitoredResource{
+		Name:   nameString,
+		Labels: labels,
+	}, nil
+}
+
+// TODO: wire into pkg/config; we need to figure out how this will work since MRs are different than other aspect kinds.
+func (*mrProvider) ValidateConfig(c config.AspectParams, v expr.Validator, df descriptor.Finder) (ce *adapter.ConfigErrors) {
+	cfg := c.(*aconfig.MonitoredResources)
+	for idx, mr := range cfg.Resources {
+		if err := v.AssertType(mr.NameExpression, df, dpb.STRING); err != nil {
+			ce = ce.Append(fmt.Sprintf("MonitoredResources.Resources[%d].NameExpression", idx), err)
+		}
+
+		desc := df.GetMonitoredResource(mr.DescriptorName)
+		if desc == nil {
+			ce = ce.Appendf(
+				fmt.Sprintf("MonitoredResources.Resources[%d].DescriptorName", idx),
+				"could not find a MonitoredResourceDescriptor named '%s'", mr.DescriptorName)
+			continue
+		}
+		ce = ce.Extend(validateLabels(fmt.Sprintf("MonitoredResources.Resources[%d].Labels", idx), mr.Labels, desc.Labels, v, df))
+	}
+	return
+}

--- a/pkg/aspect/monitoredResourceManager_test.go
+++ b/pkg/aspect/monitoredResourceManager_test.go
@@ -1,0 +1,147 @@
+// Copyright 2017 the Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aspect
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	dpb "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/mixer/pkg/adapter"
+	aconfig "istio.io/mixer/pkg/aspect/config"
+	"istio.io/mixer/pkg/aspect/test"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config/descriptor"
+	cfgpb "istio.io/mixer/pkg/config/proto"
+	"istio.io/mixer/pkg/expr"
+)
+
+var params = func(resources ...*aconfig.MonitoredResources_MonitoredResource) *aconfig.MonitoredResources {
+	return &aconfig.MonitoredResources{Resources: resources}
+}
+
+func TestMRFind(t *testing.T) {
+	eval := test.NewFakeEval(func(expr string, _ attribute.Bag) (interface{}, error) {
+		if expr == "invalid" {
+			return nil, errors.New("expected")
+		}
+		return expr, nil
+	})
+
+	tests := []struct {
+		name   string
+		params *aconfig.MonitoredResources
+		out    *adapter.MonitoredResource
+		err    string
+	}{
+		{"empty", params(), nil, "could not find"},
+		{"valid", params(&aconfig.MonitoredResources_MonitoredResource{
+			DescriptorName: "valid",
+			NameExpression: "name",
+			Labels:         map[string]string{"1": "label1val"},
+		}), &adapter.MonitoredResource{
+			Name:   "name",
+			Labels: map[string]interface{}{"1": "label1val"},
+		}, ""},
+		{"invalid-name", params(&aconfig.MonitoredResources_MonitoredResource{
+			DescriptorName: "invalid-name",
+			NameExpression: "invalid",
+			Labels:         map[string]string{"1": "label1val"},
+		}), nil, "expected"},
+		{"invalid-labels", params(&aconfig.MonitoredResources_MonitoredResource{
+			DescriptorName: "invalid-labels",
+			NameExpression: "name",
+			Labels:         map[string]string{"1": "invalid"},
+		}), nil, "expected"},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			finder := NewMRFinder(tt.params)
+			if res, err := finder.Find(tt.name, test.NewBag(), eval); err != nil || tt.err != "" {
+				if tt.err == "" {
+					t.Fatalf("Find(%s, ...) = '%s', wanted no err", tt.name, err.Error())
+				} else if err == nil {
+					t.Fatalf("Find(%s, ...) = nil, wanted %s", tt.name, tt.err)
+				} else if !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("Expected errors containing the string '%s', actual: '%s'", tt.err, err.Error())
+				}
+			} else if !reflect.DeepEqual(res, tt.out) {
+				t.Fatalf("Find(%s, ...) = %v, wanted %v", tt.name, res, tt.out)
+			}
+		})
+	}
+}
+
+func TestValidateMRConfig(t *testing.T) {
+	f := test.NewDescriptorFinder(map[string]interface{}{
+		"desc": &dpb.MonitoredResourceDescriptor{
+			Name: "desc",
+			Labels: map[string]dpb.ValueType{
+				"str": dpb.STRING,
+				"i64": dpb.INT64,
+			},
+		},
+		"string": &cfgpb.AttributeManifest_AttributeInfo{ValueType: dpb.STRING},
+		"int64":  &cfgpb.AttributeManifest_AttributeInfo{ValueType: dpb.INT64},
+	})
+	v := expr.NewCEXLEvaluator()
+
+	tests := []struct {
+		name string
+		cfg  *aconfig.MonitoredResources
+		v    expr.Validator
+		df   descriptor.Finder
+		err  string
+	}{
+		{"empty config", params(), v, f, ""},
+		{"valid", params(&aconfig.MonitoredResources_MonitoredResource{
+			DescriptorName: "desc",
+			NameExpression: "string",
+			Labels:         map[string]string{"str": "string", "i64": "int64"},
+		}), v, f, ""},
+		{"invalid name", params(&aconfig.MonitoredResources_MonitoredResource{
+			DescriptorName: "desc",
+			NameExpression: "name",
+			Labels:         map[string]string{"str": "string", "i64": "int64"},
+		}), v, f, "MonitoredResources.Resources[0].NameExpression"},
+		{"no desc", params(&aconfig.MonitoredResources_MonitoredResource{
+			DescriptorName: "missing",
+			NameExpression: "string",
+			Labels:         map[string]string{"str": "string", "i64": "int64"},
+		}), v, f, "MonitoredResources.Resources[0].DescriptorName"},
+		{"bad label", params(&aconfig.MonitoredResources_MonitoredResource{
+			DescriptorName: "desc",
+			NameExpression: "string",
+			Labels:         map[string]string{"str": "missing", "i64": "int64"},
+		}), v, f, "MonitoredResources.Resources[0].Labels"},
+	}
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			errs := (&mrProvider{}).ValidateConfig(tt.cfg, tt.v, tt.df)
+			if errs != nil || tt.err != "" {
+				if tt.err == "" {
+					t.Fatalf("ValidateConfig(tt.cfg, tt.v, tt.df) = '%s', wanted no err", errs.Error())
+				} else if !strings.Contains(errs.Error(), tt.err) {
+					t.Fatalf("Expected errors containing the string '%s', actual: '%s'", tt.err, errs.Error())
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This is how I'm planning to pass monitored resources through Mixer, today just to `Report` aspect kinds. This PR doesn't yet wire up things yet, but the basic structure for that plumbing exists. PTAL, if there's not opposition to this approach then I'll carry on wiring things up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/655)
<!-- Reviewable:end -->
