### PR TITLE
Fix the break in Benchmark test and make it more robust.

### DIFF
--- a/bin/perftest.sh
+++ b/bin/perftest.sh
@@ -8,7 +8,7 @@ cd $ROOT
 
 
 echo "Perf test"
-DIRS="pkg/expr pkg/attribute"
+DIRS="pkg/expr pkg/attribute pkg/adapterManager"
 cd $ROOT
 for pkgdir in ${DIRS}; do
     cd ${ROOT}/${pkgdir} 

--- a/pkg/adapterManager/managerDispatchBenchmark_test.go
+++ b/pkg/adapterManager/managerDispatchBenchmark_test.go
@@ -66,16 +66,16 @@ manifests:
   - name: istio-proxy
     revision: "1"
     attributes:
-    - name: source.name
-      value_type: STRING
-    - name: target.name
-      value_type: STRING
-    - name: response.code
-      value_type: INT64
-    - name: api.name
-      value_type: STRING
-    - name: api.method
-      value_type: STRING
+      source.name:
+        valueType: STRING
+      target.name:
+        valueType: STRING
+      response.code:
+        valueType: INT64
+      api.name:
+        valueType: STRING
+      api.method:
+        valueType: STRING
 
 metrics:
   - name: request_count
@@ -177,7 +177,11 @@ func benchmarkAdapterManagerDispatch(b *testing.B, declarativeSrvcCnfgFilePath s
 	adapterMgr := NewManager([]pkgAdapter.RegisterFn{
 		noop.Register,
 	}, aspect.Inventory(), eval, gp, adapterGP)
-	store, _ := config.NewCompatFSStore(declaredGlobalCnfgFilePath, declarativeSrvcCnfgFilePath)
+	store, err := config.NewCompatFSStore(declaredGlobalCnfgFilePath, declarativeSrvcCnfgFilePath)
+	if err != nil {
+		b.Errorf("NewCompatFSStore failed: %v", err)
+		return
+	}
 
 	cnfgMgr := config.NewManager(eval, adapterMgr.AspectValidatorFinder, adapterMgr.BuilderValidatorFinder,
 		adapterMgr.SupportedKinds, store,
@@ -188,7 +192,11 @@ func benchmarkAdapterManagerDispatch(b *testing.B, declarativeSrvcCnfgFilePath s
 
 	requestBag := attribute.GetMutableBag(nil)
 	requestBag.Set(identityAttribute, identityDomainAttribute)
-	configs, _ := adapterMgr.loadConfigs(requestBag, adapterMgr.reportKindSet, false, false)
+	configs, err := adapterMgr.loadConfigs(requestBag, adapterMgr.reportKindSet, false, false)
+	if err != nil {
+		b.Errorf("adapterMgr.loadConfigs failed: %v", err)
+		return
+	}
 
 	b.ResetTimer()
 	var r google_rpc.Status
@@ -196,6 +204,9 @@ func benchmarkAdapterManagerDispatch(b *testing.B, declarativeSrvcCnfgFilePath s
 		r = adapterMgr.dispatchReport(context.Background(), configs, requestBag, attribute.GetMutableBag(nil))
 	}
 	rpcStatus = r
+	if rpcStatus.Code != 0 {
+		b.Errorf("dispatchReport benchmark test returned status code %d; expected 0", rpcStatus.Code)
+	}
 }
 
 func BenchmarkOneSimpleAspect(b *testing.B) {


### PR DESCRIPTION
The benchmark test broke after recent change to mixer. This was not caught because the test was not getting executed as part of perftest.sh and was also not checking for success. Added both of these to ensure that the test does not break silently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/657)
<!-- Reviewable:end -->
