### PR TITLE
Add basic monitoring server to Mixer.

### DIFF
--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -30,6 +30,7 @@ go_library(
         "@com_github_istio_api//:mixer/v1/config",
         "@com_github_opentracing_basictracer//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	bt "github.com/opentracing/basictracer-go"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -60,6 +62,9 @@ type serverArgs struct {
 	configFetchIntervalSec        uint
 	configIdentityAttribute       string
 	configIdentityAttributeDomain string
+	monitoringPort                uint16
+	metricsPath                   string
+	versionPath                   string
 
 	// @deprecated
 	serviceConfigFile string
@@ -89,6 +94,9 @@ func serverCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 	}
 	serverCmd.PersistentFlags().Uint16VarP(&sa.port, "port", "p", 9091, "TCP port to use for Mixer's gRPC API")
 	serverCmd.PersistentFlags().Uint16VarP(&sa.configAPIPort, "configAPIPort", "", 9094, "HTTP port to use for Mixer's Configuration API")
+	serverCmd.PersistentFlags().Uint16Var(&sa.monitoringPort, "monitoringPort", 1337, "HTTP port to use for the exposing mixer self-monitoring information")
+	serverCmd.PersistentFlags().StringVar(&sa.metricsPath, "metricsPath", "/metrics", "Request path for metrics data for mixer self-monitoring")
+	serverCmd.PersistentFlags().StringVar(&sa.versionPath, "versionPath", "/version", "Request path for version info for mixer self-monitoring")
 	serverCmd.PersistentFlags().UintVarP(&sa.maxMessageSize, "maxMessageSize", "", 1024*1024, "Maximum size of individual gRPC messages")
 	serverCmd.PersistentFlags().UintVarP(&sa.maxConcurrentStreams, "maxConcurrentStreams", "", 32, "Maximum supported number of concurrent gRPC streams")
 	serverCmd.PersistentFlags().IntVarP(&sa.apiWorkerPoolSize, "apiWorkerPoolSize", "", 1024, "Max # of goroutines in the API worker pool")
@@ -254,6 +262,31 @@ func runServer(sa *serverArgs, printf, fatalf shared.FormatFn) {
 
 	printf("Starting Config API server on port %v", sa.configAPIPort)
 	go configAPIServer.Run()
+
+	var monitoringListener net.Listener
+	// get the network stuff setup
+	if monitoringListener, err = net.Listen("tcp", fmt.Sprintf(":%d", sa.monitoringPort)); err != nil {
+		fatalf("Unable to listen on socket: %v", err)
+	}
+
+	// NOTE: this is a temporary solution for provide bare-bones debug functionality
+	// for mixer. a full design / implementation of self-monitoring and reporting
+	// is coming. that design will include proper coverage of statusz/healthz type
+	// functionality, in addition to how mixer reports its own metrics.
+	srvMux := http.NewServeMux()
+	srvMux.Handle(sa.metricsPath, promhttp.Handler())
+	srvMux.HandleFunc(sa.versionPath, func(out http.ResponseWriter, req *http.Request) {
+		if _, verErr := out.Write([]byte(version.Info.String())); verErr != nil {
+			printf("error printing version info: %v", verErr)
+		}
+	})
+	monitoring := &http.Server{Addr: fmt.Sprintf(":%d", sa.monitoringPort), Handler: srvMux}
+	printf("Starting self-monitoring on port %d", sa.monitoringPort)
+	go func() {
+		if monErr := monitoring.Serve(monitoringListener.(*net.TCPListener)); monErr != nil {
+			printf("monitoring server error: %v", monErr)
+		}
+	}()
 
 	// get everything wired up
 	gs := grpc.NewServer(grpcOptions...)


### PR DESCRIPTION
This PR establishes a server within Mixer for providing some basic
monitoring and version information for debugging. This solution is
meant ONLY to be a short term patch while we iterate on a more
thorough and complete design for health and status reporting for Mixer
as well as for self-monitoring of Istio components.

It provides two basic endpoints:
- `/metrics` which exposes data from the default collector for
prometheus. This should include stats on number of goroutines and cpu
usage, etc.
- `version` which provides a quick way to get a snapshot of the version
info for Mixer.

Example snippet from `/metrics`:

```
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 9.9604e-05
go_gc_duration_seconds{quantile="0.25"} 0.00012713
go_gc_duration_seconds{quantile="0.5"} 0.000288486
go_gc_duration_seconds{quantile="0.75"} 0.00030185
go_gc_duration_seconds{quantile="1"} 0.000349945
go_gc_duration_seconds_sum 0.001295973
go_gc_duration_seconds_count 6
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 2061
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 4.922944e+06
...
```

Example output from `/version`:

```
version: 0.1.1-2-gb35ce11 (build: 2017-05-12-b35ce11, status: Clean)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/708)
<!-- Reviewable:end -->
