### PR TITLE
Add KUBECONFIG environment variable handling to kubernetes adapter.

### DIFF
--- a/adapter/kubernetes/config/config.proto
+++ b/adapter/kubernetes/config/config.proto
@@ -47,6 +47,10 @@ message Params {
     // be set to the path of a kubeconfig file that can be used to
     // reach a kubernetes API server.
     //
+    // NOTE: The kubernetes adapter will use the value of the env var
+    // KUBECONFIG in the case where it is set (overriding any value configured
+    // through this proto).
+    //
     // Default: "" (unset)
     string kubeconfig_path = 1;
 

--- a/adapter/kubernetes/kubernetes_test.go
+++ b/adapter/kubernetes/kubernetes_test.go
@@ -148,13 +148,17 @@ func TestBuilder_BuildAttributesGenerator(t *testing.T) {
 }
 
 func TestBuilder_BuildAttributesGeneratorWithEnvVar(t *testing.T) {
+
+	testConf := conf
+	testConf.KubeconfigPath = "please/override"
+
 	tests := []struct {
 		name    string
 		testFn  controllerFactoryFn
 		conf    adapter.Config
 		wantErr bool
 	}{
-		{"success", fakePodCache, conf, false},
+		{"success", fakePodCache, testConf, false},
 	}
 
 	wantPath := "/want/kubeconfig"

--- a/adapter/kubernetes/kubernetes_test.go
+++ b/adapter/kubernetes/kubernetes_test.go
@@ -16,6 +16,7 @@ package kubernetes
 
 import (
 	"errors"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -32,6 +33,7 @@ type fakeCache struct {
 
 	getPodErr bool
 	pods      map[string]*v1.Pod
+	path      string
 }
 
 func (fakeCache) HasSynced() bool {
@@ -57,8 +59,8 @@ func errorStartingPodCache(ignored string, empty time.Duration, e adapter.Env) (
 	return nil, errors.New("cache build error")
 }
 
-func fakePodCache(ignored string, empty time.Duration, e adapter.Env) (cacheController, error) {
-	return &fakeCache{}, nil
+func fakePodCache(path string, empty time.Duration, e adapter.Env) (cacheController, error) {
+	return &fakeCache{path: path}, nil
 }
 
 // note: not using TestAdapterInvariants here because of kubernetes dependency.
@@ -140,6 +142,39 @@ func TestBuilder_BuildAttributesGenerator(t *testing.T) {
 			}
 			if err != nil && !v.wantErr {
 				t.Fatalf("Got error, wanted none: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuilder_BuildAttributesGeneratorWithEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		testFn  controllerFactoryFn
+		conf    adapter.Config
+		wantErr bool
+	}{
+		{"success", fakePodCache, conf, false},
+	}
+
+	wantPath := "/want/kubeconfig"
+	if err := os.Setenv("KUBECONFIG", wantPath); err != nil {
+		t.Fatalf("Could not set KUBECONFIG environment var")
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			b := newBuilder(v.testFn)
+			_, err := b.BuildAttributesGenerator(test.NewEnv(t), v.conf)
+			if err == nil && v.wantErr {
+				t.Fatal("Expected error building adapter")
+			}
+			if err != nil && !v.wantErr {
+				t.Fatalf("Got error, wanted none: %v", err)
+			}
+			got := b.pods.(*fakeCache).path
+			if got != wantPath {
+				t.Errorf("Bad kubeconfig path; got %s, want %s", got, wantPath)
 			}
 		})
 	}


### PR DESCRIPTION
This PR primarily adds handling to kubernetes adapter to take the
value for kubeconfigPath from mixer config as well as from environmental
config (via the KUBECONFIG env var).

NOTE: this configuration was previously available with via
KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT env vars. This PR
consolidates that into the Istio standard KUBECONFIG env var to
harmonize deployment across componenets.

Tested with out-of-the-box config via:

```bash
$ KUBECONFIG=~/.kube/config bazel-bin/cmd/server/mixs server --configStoreURL=fs://$(pwd)/testdata/configroot --logtostderr -v=5
```

and several client calls, as follows:

```bash
$ bazel-bin/cmd/client/mixc report -v=45 -a target.service=foo.default.svc.cluster.local --string_attributes source.uid=kubernetes://productpage-v1-2087264475-bl9f2.default -m localhost:9091 --trace
Report RPC returned OK
Attribute              Type               Value
source.labels          map[string]string  map[version:v1 app:productpage pod-template-hash:2087264475]
source.name            string             productpage-v1-2087264475-bl9f2
source.namespace       string             default
source.service         string             productpage.default.svc.cluster.local
source.serviceAccount  string             default
```

This PR also fixes the previously observed issue with sync.Once and initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/729)
<!-- Reviewable:end -->
