### PR TITLE
Fix useless logging by using the correct variable

### DIFF
--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -322,42 +322,42 @@ func GetBagFromProto(attrs *mixerpb.Attributes, globalDict []string) (*MutableBa
 	log(buf, "  updating int64 attributes:\n")
 	for k, v := range attrs.Int64S {
 		name, e = lookup(k, e, globalDict, messageDict)
-		log(buf, "    %s -> '%d'\n", name, value)
+		log(buf, "    %s -> '%d'\n", name, v)
 		mb.values[name] = v
 	}
 
 	log(buf, "  updating double attributes:\n")
 	for k, v := range attrs.Doubles {
 		name, e = lookup(k, e, globalDict, messageDict)
-		log(buf, "    %s -> '%f'\n", name, value)
+		log(buf, "    %s -> '%f'\n", name, v)
 		mb.values[name] = v
 	}
 
 	log(buf, "  updating bool attributes:\n")
 	for k, v := range attrs.Bools {
 		name, e = lookup(k, e, globalDict, messageDict)
-		log(buf, "    %s -> '%t'\n", name, value)
+		log(buf, "    %s -> '%t'\n", name, v)
 		mb.values[name] = v
 	}
 
 	log(buf, "  updating timestamp attributes:\n")
 	for k, v := range attrs.Timestamps {
 		name, e = lookup(k, e, globalDict, messageDict)
-		log(buf, "    %s -> '%v'\n", name, value)
+		log(buf, "    %s -> '%v'\n", name, v)
 		mb.values[name] = v
 	}
 
 	log(buf, "  updating duration attributes:\n")
 	for k, v := range attrs.Durations {
 		name, e = lookup(k, e, globalDict, messageDict)
-		log(buf, "    %s -> '%v'\n", name, value)
+		log(buf, "    %s -> '%v'\n", name, v)
 		mb.values[name] = v
 	}
 
 	log(buf, "  updating bytes attributes:\n")
 	for k, v := range attrs.Bytes {
 		name, e = lookup(k, e, globalDict, messageDict)
-		log(buf, "    %s -> '%v'\n", name, value)
+		log(buf, "    %s -> '%s'\n", name, v)
 		mb.values[name] = v
 	}
 
@@ -370,7 +370,7 @@ func GetBagFromProto(attrs *mixerpb.Attributes, globalDict []string) (*MutableBa
 			var value2 string
 			name2, e = lookup(k2, e, globalDict, messageDict)
 			value2, e = lookup(v2, e, globalDict, messageDict)
-			log(buf, "    %s -> '%v'\n", name, value)
+			log(buf, "    %s -> '%v'\n", name2, value2)
 			sm[name2] = value2
 		}
 		mb.values[name] = sm


### PR DESCRIPTION
```sh
./bazel-bin/cmd/client/mixc check -b bool=true -d double=1.0 -i int=64 -s target.service=ratings.svc.cluster.local -t time=2006-01-02T15:04:05Z --trace --stringmap_attributes "strmap=k1:'v1';k2:'v2'" --bytes_attributes bytes=61:61:61 --duration_attributes duration=1s
```
```
I0531 17:12:24.174081    7124 mutableBag.go:380] Creating bag from wire attributes:
  updating string attributes:
    target.service -> 'ratings.svc.cluster.local'
  updating int64 attributes:
    int -> '64'
  updating double attributes:
    double -> '1.000000'
  updating bool attributes:
    bool -> 'true'
  updating timestamp attributes:
    time -> '2006-01-02 15:04:05 +0000 UTC'
  updating duration attributes:
    duration -> '1s'
  updating bytes attributes:
    bytes -> 'aaa'
  updating stringmap attribute strmap:
    k2 -> ''v2''
    k1 -> ''v1''
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/779)
<!-- Reviewable:end -->
