### PR TITLE
Use proto.Marshal instead of gob.Encode to compute executor cache keys

### DIFF
--- a/pkg/adapterManager/BUILD
+++ b/pkg/adapterManager/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",
         "//pkg/status:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
     ],

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -18,12 +18,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
-	"encoding/gob"
 	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/glog"
 	rpc "github.com/googleapis/googleapis/google/rpc"
 
@@ -383,29 +383,30 @@ func newCacheKey(kind config.Kind, cfg *cpb.Combined) (*cacheKey, error) {
 		impl: cfg.Builder.GetImpl(),
 	}
 
-	//TODO pre-compute shas and store with params
-	b := pool.GetBuffer()
-	// use gob encoding so that we don't rely on proto marshal
-	enc := gob.NewEncoder(b)
-
+	// TODO: investigate requesting a change to the proto.Marshal API so that we can provide the buffer to marshal
+	// in to; right now proto.Marshal chooses to alloc a new buffer every time. We could avoid this by pooling & an API change.
 	if cfg.Builder.Params != nil {
-		if err := enc.Encode(cfg.Builder.Params); err != nil {
-			pool.PutBuffer(b)
+		ppb, ok := cfg.Builder.Params.(proto.Message)
+		if !ok {
+			return nil, fmt.Errorf("non-proto cfg.Builder.Params: %v", cfg.Builder.Params)
+		}
+		b, err := proto.Marshal(ppb)
+		if err != nil {
 			return nil, err
 		}
-		ret.builderParamsSHA = sha1.Sum(b.Bytes())
+		ret.builderParamsSHA = sha1.Sum(b)
 	}
-	b.Reset()
 	if cfg.Aspect.Params != nil {
-		if err := enc.Encode(cfg.Aspect.Params); err != nil {
-			pool.PutBuffer(b)
+		ppb, ok := cfg.Aspect.Params.(proto.Message)
+		if !ok {
+			return nil, fmt.Errorf("non-proto cfg.Aspect.Params: %v", cfg.Aspect.Params)
+		}
+		b, err := proto.Marshal(ppb)
+		if err != nil {
 			return nil, err
 		}
-
-		ret.aspectParamsSHA = sha1.Sum(b.Bytes())
+		ret.aspectParamsSHA = sha1.Sum(b)
 	}
-	pool.PutBuffer(b)
-
 	return &ret, nil
 }
 

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -382,7 +382,7 @@ func newCacheKey(kind config.Kind, cfg *cpb.Combined) (*cacheKey, error) {
 		kind: kind,
 		impl: cfg.Builder.GetImpl(),
 	}
-
+	// TODO: pre-compute shas and store with params
 	b := pool.GetBuffer()
 	pbuf := proto.NewBuffer(b.Bytes())
 	if cfg.Builder.Params != nil {

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -305,8 +305,8 @@ func TestManager(t *testing.T) {
 		{true, false, "could not find registered adapter", nil, []*cpb.Combined{goodcfg}},
 		{true, true, "", &fakeCheckExecutor{}, []*cpb.Combined{goodcfg, goodcfg2}},
 		{true, true, "", nil, []*cpb.Combined{goodcfg}},
-		{true, true, "can't handle type", nil, []*cpb.Combined{badcfg1}},
-		{true, true, "can't handle type", nil, []*cpb.Combined{badcfg2}},
+		{true, true, "non-proto cfg.Builder.Params", nil, []*cpb.Combined{badcfg1}},
+		{true, true, "non-proto cfg.Aspect.Params", nil, []*cpb.Combined{badcfg2}},
 	}
 
 	for idx, tt := range ttt {
@@ -488,8 +488,8 @@ func TestManager_BulkExecute(t *testing.T) {
 		{"", []*cpb.Combined{}},
 		{"", []*cpb.Combined{goodcfg}},
 		{"", []*cpb.Combined{goodcfg, goodcfg}},
-		{"can't handle type", []*cpb.Combined{badcfg1, goodcfg}},
-		{"can't handle type", []*cpb.Combined{goodcfg, badcfg2}},
+		{"non-proto cfg.Builder.Params", []*cpb.Combined{badcfg1, goodcfg}},
+		{"non-proto cfg.Aspect.Params", []*cpb.Combined{goodcfg, badcfg2}},
 	}
 
 	requestBag := attribute.GetMutableBag(nil)


### PR DESCRIPTION
Use proto.Marshal instead of gob.Encode to produce a byte array of the input params. This is because gob requires reflection to determine a type for the value it's encoding; for some reason subfields on a proto oneof don't play well with this. Our config ingestion code already requires that the params fields be protos, so this change is safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/814)
<!-- Reviewable:end -->
