### PR TITLE
Treat empty strings as nil in expr

### DIFF
--- a/pkg/expr/eval_test.go
+++ b/pkg/expr/eval_test.go
@@ -164,6 +164,19 @@ func TestGoodEval(tt *testing.T) {
 			true, "",
 		},
 		{
+			`origin.name | "users"`,
+			map[string]interface{}{
+				"origin.name": "",
+			},
+			"users", "",
+		},
+		{
+			`origin.name | "users"`,
+			map[string]interface{}{
+			},
+			"users", "",
+		},
+		{
 			`(x/y) == 30`,
 			map[string]interface{}{
 				"x": int64(20),
@@ -223,12 +236,12 @@ func TestGoodEval(tt *testing.T) {
 				if tst.err == "" {
 					t.Errorf("[%d] unexpected error: %v", idx, err)
 				} else if !strings.Contains(err.Error(), tst.err) {
-					t.Errorf("[%d] got %s\nwant %s", idx, err, tst.err)
+					t.Errorf("[%d] got <%s>\nwant <%s>", idx, err, tst.err)
 				}
 				return
 			}
 			if res != tst.result {
-				t.Errorf("[%d] %s got %s\nwant %s", idx, exp.String(), res, tst.result)
+				t.Errorf("[%d] %s got <%s>\nwant <%s>", idx, exp.String(), res, tst.result)
 			}
 		})
 	}

--- a/pkg/expr/eval_test.go
+++ b/pkg/expr/eval_test.go
@@ -164,6 +164,15 @@ func TestGoodEval(tt *testing.T) {
 			true, "",
 		},
 		{
+			`request.header["user"] | "unknown"`,
+			map[string]interface{}{
+				"request.header": map[string]string{
+					"myheader": "bbb",
+				},
+			},
+			"unknown", "",
+		},
+		{
 			`origin.name | "users"`,
 			map[string]interface{}{
 				"origin.name": "",
@@ -172,8 +181,7 @@ func TestGoodEval(tt *testing.T) {
 		},
 		{
 			`origin.name | "users"`,
-			map[string]interface{}{
-			},
+			map[string]interface{}{},
 			"users", "",
 		},
 		{

--- a/pkg/expr/eval_test.go
+++ b/pkg/expr/eval_test.go
@@ -244,12 +244,12 @@ func TestGoodEval(tt *testing.T) {
 				if tst.err == "" {
 					t.Errorf("[%d] unexpected error: %v", idx, err)
 				} else if !strings.Contains(err.Error(), tst.err) {
-					t.Errorf("[%d] got <%s>\nwant <%s>", idx, err, tst.err)
+					t.Errorf("[%d] got <%q>\nwant <%q>", idx, err, tst.err)
 				}
 				return
 			}
 			if res != tst.result {
-				t.Errorf("[%d] %s got <%s>\nwant <%s>", idx, exp.String(), res, tst.result)
+				t.Errorf("[%d] %s got <%q>\nwant <%q>", idx, exp.String(), res, tst.result)
 			}
 		})
 	}

--- a/pkg/expr/func.go
+++ b/pkg/expr/func.go
@@ -213,7 +213,9 @@ func newOR() Func {
 func (f *orFunc) Call(attrs attribute.Bag, args []*Expression, fMap map[string]FuncBase) (interface{}, error) {
 	for _, arg := range args {
 		ret, _ := arg.Eval(attrs, fMap)
-		if ret != nil {
+		// treating empty strings as nil, since
+		// go strings cannot be nil
+		if ret != nil && ret != "" {
 			return ret, nil
 		}
 	}


### PR DESCRIPTION
If "user" header was not specified, previously the expression below used to evaluate to
```
request.header["user"] | "unknown"   ---> ""
```
Now we treat empty strings as nil so 
```
request.header["user"] | "unknown"   ---> "unknown"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/825)
<!-- Reviewable:end -->
