### PR TITLE
Add line number support for error msg in codegen.

### DIFF
--- a/tools/codegen/pkg/interfacegen/generator_test.go
+++ b/tools/codegen/pkg/interfacegen/generator_test.go
@@ -113,6 +113,7 @@ func generteFDSFileHacky(protoFile string, outputFDSFile string) error {
 		"-I=.",
 		"-I=api",
 		"--include_imports",
+		"--include_source_info",
 	}
 	cmd := exec.Command("protoc", protocCmd...)
 	dir := path.Join(os.Getenv("GOPATH"), "src/istio.io")

--- a/tools/codegen/pkg/modelgen/model_test.go
+++ b/tools/codegen/pkg/modelgen/model_test.go
@@ -40,7 +40,8 @@ func TestErrorInTemplate(t *testing.T) {
 		{"testdata/MissingBothRequiredExt.proto", "one proto file that has both extensions"},
 		{"testdata/MissingTypeMessage.proto", "message 'Type' not defined"},
 		{"testdata/MissingConstructorMessage.proto", "message 'Constructor' not defined"},
-		{"testdata/ReservedFieldInConstructor.proto", "Constructor message must not contain the reserved filed name 'Name'"},
+		{"testdata/ReservedFieldInConstructor.proto", "proto:15: Constructor message must not contain the reserved filed name 'Name'"},
+		{"testdata/Proto2BadSyntax.proto", "Proto2BadSyntax.proto:3: Only proto3 template files are allowed."},
 	}
 
 	for idx, tt := range tests {
@@ -159,6 +160,7 @@ func generteFDSFileHacky(protoFile string, outputFDSFile string) error {
 		"-I=.",
 		"-I=api",
 		"--include_imports",
+		"--include_source_info",
 	}
 	cmd := exec.Command("protoc", protocCmd...)
 	dir := path.Join(os.Getenv("GOPATH"), "src/istio.io")

--- a/tools/codegen/pkg/modelgen/testdata/Proto2BadSyntax.proto
+++ b/tools/codegen/pkg/modelgen/testdata/Proto2BadSyntax.proto
@@ -1,0 +1,13 @@
+
+
+syntax = "proto2";
+
+package foo.bar;
+
+import "mixer/tools/codegen/pkg/template_extension/TemplateExtensions.proto";
+
+option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.config.template.template_name) = "List";
+
+message Type {}
+message Constructor {}


### PR DESCRIPTION
- We are saving all the locations upfront in a map of path string and line number. path string is a comma separated string for FileDescriptorProto.SourceCodeInfo.Location.Path (which is an []int)
- Then during parsing in the parser.go, we are now keeping track of index as we iterate over the descriptors. Using the index we are creating the path string and storing it inside the wrapper objects itself (Descriptor and Enums). This path string is then used to retrieve the location from the pathToLocation map.

example on how to get the line number is in model.go. All the code to build the paths is in parser.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/827)
<!-- Reviewable:end -->
