### PR TITLE
Update to rules_docker repo for docker builds

### DIFF
--- a/BUILD.ubuntu
+++ b/BUILD.ubuntu
@@ -1,6 +1,6 @@
 # build base docker ubuntu image
 
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 docker_build(
     name = "xenial",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
 go_repositories()
 
 git_repository(
+    name = "io_bazel_rules_docker",
+    commit = "e770f81cef4165828df955f37b827874a884a1de",  # June 21, 2017 (v0.0.2)
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+)
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories")
+
+docker_repositories()
+
+git_repository(
     name = "org_pubref_rules_protobuf",
     commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31, 2017 (gogo* support)
     remote = "https://github.com/pubref/rules_protobuf",

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("//docker:mixer_docker.bzl", "mixer_docker_build")
 
 # Use "manual" target tag to skip rules in the wildcard expansion
@@ -36,6 +37,7 @@ mixer_docker_build(
     ],
     ports = [
         "9091",
+        "9093",
         "9094",
         "42422",
     ],

--- a/docker/gcloud_build.sh
+++ b/docker/gcloud_build.sh
@@ -11,11 +11,12 @@ fi
 
 if [ -z $BAZEL_OUTBASE ]
 then
-    bazel run //docker:mixer gcr.io/$PROJECT/mixer:$DOCKER_TAG
+    bazel run //docker:mixer
 else
-    bazel --output_base=$BAZEL_OUTBASE run //docker:mixer gcr.io/$PROJECT/mixer:$DOCKER_TAG
+    bazel --output_base=$BAZEL_OUTBASE run //docker:mixer
 fi
 
+docker tag //docker:mixer gcr.io/$PROJECT/mixer:$DOCKER_TAG
 docker tag gcr.io/$PROJECT/mixer:$DOCKER_TAG gcr.io/$PROJECT/mixer:latest
 
 gcloud docker -- push gcr.io/$PROJECT/mixer:$DOCKER_TAG

--- a/docker/mixer_docker.bzl
+++ b/docker/mixer_docker.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 def mixer_docker_build(images, **kwargs):
     for image in images:


### PR DESCRIPTION
Bazel has broken out the docker tools into their own repo. This switches Mixer over to the new rules_docker repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/851)
<!-- Reviewable:end -->
