### PR TITLE
Add pprof support to mixer.

### DIFF
--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	_ "net/http/pprof" // For profiling / performance investigations
 	"os"
 	"strings"
 	"time"


### PR DESCRIPTION
With this PR, we can use commands like the following to improve our understanding of Mixer's runtime:
- `go tool pprof http://localhost:9093/debug/pprof/heap`
- `go tool pprof http://localhost:9093/debug/pprof/profile`
- `wget http://localhost:6060/debug/pprof/trace?seconds=5`

More info available here: https://blog.golang.org/profiling-go-programs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/875)
<!-- Reviewable:end -->
