### PR TITLE
Switch stdioLogger adapter to use zap

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -496,12 +496,6 @@ new_go_repository(
     importpath = "go.uber.org/atomic",
 )
 
-new_go_repository(
-    name = "org_uber_go_multierr",
-    commit = "3c4937480c32f4c13a875a1829af76c98ca3d40a",  # Jun 30, 2017 (v1.1.0)
-    importpath = "go.uber.org/multierr",
-)
-
 ##
 ## Testing
 ##

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -484,6 +484,24 @@ new_go_repository(
     importpath = "golang.org/x/tools",
 )
 
+new_go_repository(
+    name = "org_uber_go_zap",
+    commit = "9cabc84638b70e564c3dab2766efcb1ded2aac9f",  # Jun 8, 2017 (v1.4.1)
+    importpath = "go.uber.org/zap",
+)
+
+new_go_repository(
+    name = "org_uber_go_atomic",
+    commit = "4e336646b2ef9fc6e47be8e21594178f98e5ebcf",  # Apr 12, 2017 (v1.2.0)
+    importpath = "go.uber.org/atomic",
+)
+
+new_go_repository(
+    name = "org_uber_go_multierr",
+    commit = "3c4937480c32f4c13a875a1829af76c98ca3d40a",  # Jun 30, 2017 (v1.1.0)
+    importpath = "go.uber.org/multierr",
+)
+
 ##
 ## Testing
 ##

--- a/adapter/stdioLogger/BUILD
+++ b/adapter/stdioLogger/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//pkg/adapter:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 

--- a/adapter/stdioLogger/BUILD
+++ b/adapter/stdioLogger/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//adapter/stdioLogger/config:go_default_library",
         "//pkg/adapter:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
     ],
 )
 

--- a/adapter/stdioLogger/config/config.proto
+++ b/adapter/stdioLogger/config/config.proto
@@ -36,4 +36,8 @@ message Params {
     // Selects which standard stream to write to for log entries.
     // STDERR is the default Stream.
     Stream log_stream = 1;
+
+    // If true, empty fields from a log entry will NOT be included
+    // in the generated JSON output.
+    bool omit_empty_fields = 2;
 }

--- a/adapter/stdioLogger/stdioLogger_test.go
+++ b/adapter/stdioLogger/stdioLogger_test.go
@@ -99,7 +99,7 @@ func TestLogger_Log(t *testing.T) {
 		input []adapter.LogEntry
 		want  []string
 	}{
-		{"empty_arrary", []adapter.LogEntry{}, nil},
+		{"empty_array", []adapter.LogEntry{}, nil},
 		{"no_payload", []adapter.LogEntry{noPayloadEntry}, []string{baseLog}},
 		{"text_payload", []adapter.LogEntry{textPayloadEntry}, []string{textPayloadLog}},
 		{"json_payload", []adapter.LogEntry{jsonPayloadEntry}, []string{jsonPayloadLog}},
@@ -170,7 +170,7 @@ func TestLogger_LogAccess(t *testing.T) {
 			t.Errorf("LogAccess(%v) => unexpected error: %v", v.input, err)
 		}
 		if !reflect.DeepEqual(tc.(*testCore).lines, v.want) {
-			t.Errorf("LogAccess(%v) => %#v, want %#s", v.input, tc.(*testCore).lines, v.want)
+			t.Errorf("LogAccess(%v) => %#v, want %#v", v.input, tc.(*testCore).lines, v.want)
 		}
 	}
 }
@@ -213,7 +213,9 @@ func BenchmarkLogger_Log(b *testing.B) {
 	l := &logger{impl: zap.NewNop()}
 
 	for i := 0; i < b.N; i++ {
-		l.log([]adapter.LogEntry{entry1, entry2})
+		if err := l.log([]adapter.LogEntry{entry1, entry2}); err != nil {
+			b.Logf("error in log: %v", err)
+		}
 	}
 }
 

--- a/adapter/stdioLogger/stdioLogger_test.go
+++ b/adapter/stdioLogger/stdioLogger_test.go
@@ -16,11 +16,12 @@ package stdioLogger
 
 import (
 	"errors"
-	"io"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"istio.io/mixer/adapter/stdioLogger/config"
 	"istio.io/mixer/pkg/adapter"
@@ -33,9 +34,9 @@ func TestAdapterInvariants(t *testing.T) {
 
 func TestBuilder_NewLogger(t *testing.T) {
 	tests := []newAspectTests{
-		{&config.Params{}, defaultAspectImpl},
-		{defaultParams, defaultAspectImpl},
-		{overridesParams, overridesAspectImpl},
+		{&config.Params{}, []string{"stderr"}},
+		{defaultParams, []string{"stderr"}},
+		{overridesParams, []string{"stdout"}},
 	}
 
 	e := testEnv{}
@@ -43,20 +44,20 @@ func TestBuilder_NewLogger(t *testing.T) {
 	for _, v := range tests {
 		asp, err := a.NewApplicationLogsAspect(e, v.config)
 		if err != nil {
-			t.Errorf("NewApplicationLogsAspect(env, %s) => unexpected error: %v", v.config, err)
+			t.Errorf("NewAccessLogsAspect(env, %s) => unexpected error: %v", v.config, err)
 		}
 		got := asp.(*logger)
-		if !reflect.DeepEqual(got, v.want) {
-			t.Errorf("NewApplicationLogsAspect(env, %s) => %v, want %v", v.config, got, v.want)
+		if !reflect.DeepEqual(got.outputPaths, v.outputPaths) {
+			t.Errorf("Bad output path configuration: got %v, want %v", got.outputPaths, v.outputPaths)
 		}
 	}
 }
 
 func TestBuilder_NewAccessLogger(t *testing.T) {
 	tests := []newAspectTests{
-		{&config.Params{}, defaultAspectImpl},
-		{defaultParams, defaultAspectImpl},
-		{overridesParams, overridesAspectImpl},
+		{&config.Params{}, []string{"stderr"}},
+		{defaultParams, []string{"stderr"}},
+		{overridesParams, []string{"stdout"}},
 	}
 
 	e := testEnv{}
@@ -67,8 +68,8 @@ func TestBuilder_NewAccessLogger(t *testing.T) {
 			t.Errorf("NewAccessLogsAspect(env, %s) => unexpected error: %v", v.config, err)
 		}
 		got := asp.(*logger)
-		if !reflect.DeepEqual(got, v.want) {
-			t.Errorf("NewAccessLogsAspect(env, %s) => %v, want %v", v.config, got, v.want)
+		if !reflect.DeepEqual(got.outputPaths, v.outputPaths) {
+			t.Errorf("Bad output path configuration: got %v, want %v", got.outputPaths, v.outputPaths)
 		}
 	}
 }
@@ -81,9 +82,6 @@ func TestLogger_Close(t *testing.T) {
 }
 
 func TestLogger_Log(t *testing.T) {
-
-	tw := &testWriter{lines: make([]string, 0)}
-
 	structPayload := map[string]interface{}{"val": 42, "obj": map[string]interface{}{"val": false}}
 
 	noPayloadEntry := adapter.LogEntry{LogName: "istio_log", Labels: map[string]interface{}{}, Timestamp: "2017-Jan-09", Severity: adapter.Info}
@@ -94,46 +92,55 @@ func TestLogger_Log(t *testing.T) {
 	baseLog := `{"logName":"istio_log","timestamp":"2017-Jan-09","severity":"INFO"}`
 	textPayloadLog := `{"logName":"istio_log","timestamp":"2017-Jan-09","severity":"INFO","textPayload":"text payload"}`
 	jsonPayloadLog := `{"logName":"istio_log","timestamp":"2017-Jan-09","severity":"INFO","structPayload":{"obj":{"val":false},"val":42}}`
-	labelLog := `{"logName":"istio_log","labels":{"label":42},"timestamp":"2017-Jan-09","severity":"INFO"}`
-
-	baseAspectImpl := &logger{tw}
+	labelLog := `{"logName":"istio_log","timestamp":"2017-Jan-09","severity":"INFO","labels":{"label":42}}`
 
 	tests := []struct {
-		asp   *logger
+		name  string
 		input []adapter.LogEntry
 		want  []string
 	}{
-		{baseAspectImpl, []adapter.LogEntry{}, []string{}},
-		{baseAspectImpl, []adapter.LogEntry{noPayloadEntry}, []string{baseLog}},
-		{baseAspectImpl, []adapter.LogEntry{textPayloadEntry}, []string{textPayloadLog}},
-		{baseAspectImpl, []adapter.LogEntry{jsonPayloadEntry}, []string{jsonPayloadLog}},
-		{baseAspectImpl, []adapter.LogEntry{labelEntry}, []string{labelLog}},
+		{"empty_arrary", []adapter.LogEntry{}, nil},
+		{"no_payload", []adapter.LogEntry{noPayloadEntry}, []string{baseLog}},
+		{"text_payload", []adapter.LogEntry{textPayloadEntry}, []string{textPayloadLog}},
+		{"json_payload", []adapter.LogEntry{jsonPayloadEntry}, []string{jsonPayloadLog}},
+		{"labels", []adapter.LogEntry{labelEntry}, []string{labelLog}},
 	}
 
 	for _, v := range tests {
-		if err := v.asp.Log(v.input); err != nil {
-			t.Errorf("Log(%v) => unexpected error: %v", v.input, err)
-		}
-		if !reflect.DeepEqual(tw.lines, v.want) {
-			t.Errorf("Log(%v) => %v, want %s", v.input, tw.lines, v.want)
-		}
-		tw.lines = make([]string, 0)
+		t.Run(v.name, func(t *testing.T) {
+			tc := newTestCore(false, false)
+			l := &logger{impl: newTestLogger(tc)}
+			if err := l.Log(v.input); err != nil {
+				t.Errorf("Log(%v) => unexpected error: %v", v.input, err)
+			}
+			if !reflect.DeepEqual(tc.(*testCore).lines, v.want) {
+				t.Errorf("Log(%v) => %v, want %s", v.input, tc.(*testCore).lines, v.want)
+			}
+		})
 	}
 }
 
 func TestLogger_LogFailure(t *testing.T) {
-	tw := &testWriter{errorOnWrite: true}
 	textPayloadEntry := adapter.LogEntry{LogName: "istio_log", TextPayload: "text payload", Timestamp: "2017-Jan-09", Severity: adapter.Info}
-	baseAspectImpl := &logger{tw}
+	cases := []struct {
+		name string
+		core zapcore.Core
+	}{
+		{"write_error", newTestCore(true, false)},
+		{"sync_error", newTestCore(false, true)},
+	}
 
-	if err := baseAspectImpl.Log([]adapter.LogEntry{textPayloadEntry}); err == nil {
-		t.Error("Log() should have produced error")
+	for _, v := range cases {
+		t.Run(v.name, func(t *testing.T) {
+			l := &logger{impl: zap.New(v.core)}
+			if err := l.Log([]adapter.LogEntry{textPayloadEntry}); err == nil {
+				t.Fatal("Log() should have produced error")
+			}
+		})
 	}
 }
 
 func TestLogger_LogAccess(t *testing.T) {
-	tw := &testWriter{lines: make([]string, 0)}
-
 	noLabelsEntry := adapter.LogEntry{LogName: "access_log"}
 	labelsEntry := adapter.LogEntry{LogName: "access_log", Labels: map[string]interface{}{"test": false, "val": 42}}
 	labelsWithTextEntry := adapter.LogEntry{
@@ -150,31 +157,63 @@ func TestLogger_LogAccess(t *testing.T) {
 		input []adapter.LogEntry
 		want  []string
 	}{
-		{[]adapter.LogEntry{}, []string{}},
+		{[]adapter.LogEntry{}, []string(nil)},
 		{[]adapter.LogEntry{noLabelsEntry}, []string{baseLog}},
 		{[]adapter.LogEntry{labelsEntry}, []string{labelsLog}},
 		{[]adapter.LogEntry{labelsWithTextEntry}, []string{labelsWithTextLog}},
 	}
 
 	for _, v := range tests {
-		log := &logger{tw}
+		tc := newTestCore(false, false)
+		log := &logger{impl: newTestLogger(tc)}
 		if err := log.LogAccess(v.input); err != nil {
 			t.Errorf("LogAccess(%v) => unexpected error: %v", v.input, err)
 		}
-		if !reflect.DeepEqual(tw.lines, v.want) {
-			t.Errorf("LogAccess(%v) => %v, want %s", v.input, tw.lines, v.want)
+		if !reflect.DeepEqual(tc.(*testCore).lines, v.want) {
+			t.Errorf("LogAccess(%v) => %#v, want %#s", v.input, tc.(*testCore).lines, v.want)
 		}
-		tw.lines = make([]string, 0)
 	}
 }
 
 func TestLogger_LogAccessFailure(t *testing.T) {
-	tw := &testWriter{errorOnWrite: true}
 	entry := adapter.LogEntry{LogName: "access_log"}
-	l := &logger{tw}
 
-	if err := l.LogAccess([]adapter.LogEntry{entry}); err == nil {
-		t.Error("LogAccess() should have produced error")
+	cases := []struct {
+		name string
+		core zapcore.Core
+	}{
+		{"write_error", newTestCore(true, false)},
+		{"sync_error", newTestCore(false, true)},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(t *testing.T) {
+			l := &logger{impl: zap.New(v.core)}
+			if err := l.LogAccess([]adapter.LogEntry{entry}); err == nil {
+				t.Fatal("LogAccess() should have produced error")
+			}
+		})
+	}
+}
+
+func BenchmarkLogger_Log(b *testing.B) {
+	entry1 := adapter.LogEntry{
+		LogName:       "access_log",
+		Labels:        map[string]interface{}{"test": false, "val": 42},
+		TextPayload:   "this is a log line",
+		StructPayload: map[string]interface{}{"bool": true, "number": 242, "map": map[string]string{"test": "test"}, "array": []string{"t", "v", "x"}},
+	}
+
+	entry2 := adapter.LogEntry{
+		Labels:        map[string]interface{}{"test": true, "val": 55},
+		TextPayload:   "this is a log line",
+		StructPayload: map[string]interface{}{"bool": true, "number": 242, "map": map[string]string{"test": "test"}, "array": []string{"t", "v", "x"}},
+	}
+
+	l := &logger{impl: zap.NewNop()}
+
+	for i := 0; i < b.N; i++ {
+		l.log([]adapter.LogEntry{entry1, entry2})
 	}
 }
 
@@ -183,31 +222,55 @@ type (
 		adapter.Env
 	}
 	newAspectTests struct {
-		config *config.Params
-		want   *logger
+		config      *config.Params
+		outputPaths []string
 	}
-	testWriter struct {
-		io.Writer
+	testCore struct {
+		zapcore.Core
 
+		enc          zapcore.Encoder
 		count        int
 		lines        []string
 		errorOnWrite bool
+		errorOnSync  bool
 	}
 )
 
 var (
-	defaultParams     = &config.Params{LogStream: config.STDERR}
-	defaultAspectImpl = &logger{os.Stderr}
-
-	overridesParams     = &config.Params{LogStream: config.STDOUT}
-	overridesAspectImpl = &logger{os.Stdout}
+	defaultParams   = &config.Params{LogStream: config.STDERR}
+	overridesParams = &config.Params{LogStream: config.STDOUT}
 )
 
-func (t *testWriter) Write(p []byte) (n int, err error) {
-	if t.errorOnWrite {
-		return 0, errors.New("write error")
+func newTestLogger(t zapcore.Core) *zap.Logger {
+	return zap.New(t)
+}
+
+func newTestCore(errOnWrite, errOnSync bool) zapcore.Core {
+	return &testCore{
+		errorOnWrite: errOnWrite,
+		errorOnSync:  errOnSync,
+		enc:          zapcore.NewJSONEncoder(zapConfig),
 	}
+}
+
+func (t *testCore) Write(e zapcore.Entry, f []zapcore.Field) error {
+	if t.errorOnWrite {
+		return errors.New("write error")
+	}
+
+	buf, err := t.enc.EncodeEntry(e, fields)
+	if err != nil {
+		return err
+	}
+
 	t.count++
-	t.lines = append(t.lines, strings.Trim(string(p), "\n"))
-	return len(p), nil
+	t.lines = append(t.lines, strings.Trim(buf.String(), "\n"))
+	return nil
+}
+
+func (t *testCore) Sync() error {
+	if t.errorOnSync {
+		return errors.New("sync error")
+	}
+	return nil
 }

--- a/testdata/configroot/scopes/global/adapters.yml
+++ b/testdata/configroot/scopes/global/adapters.yml
@@ -8,6 +8,7 @@ adapters:
     impl: stdioLogger
     params:
       logStream: STDERR
+      omitEmptyFields: true
   - name: prometheus
     kind: metrics
     impl: prometheus


### PR DESCRIPTION
This PR transitions the stdioLogger adapter implementation from using the standard json encoder to serialize logs to [zap](https://github.com/uber-go/zap).

About zap:
> It includes a reflection-free, zero-allocation JSON encoder, and the base Logger strives to avoid serialization overhead and allocations wherever possible.

For comparision, using the newly added (extremely raw) benchmark, I saw the following on my laptop:

#### Original implementation, using a `logStream` of `ioutil.Discard`:
```
BenchmarkLogger_Log-8             200000             10930 ns/op            2801 B/op         76 allocs/op
PASS
ok      istio.io/mixer/adapter/stdioLogger      2.337s
```
#### With zap:
```
BenchmarkLogger_Log-8            3000000               461 ns/op             384 B/op          1 allocs/op
PASS
ok      istio.io/mixer/adapter/stdioLogger      1.899s
```

The reduction in `allocs/op` from 76 to 1 convinced me that this may be worth pursuing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/880)
<!-- Reviewable:end -->
