### PR TITLE
Resurrect the attribute based trace context carrier.

### DIFF
--- a/pkg/tracing/BUILD
+++ b/pkg/tracing/BUILD
@@ -5,9 +5,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "attributes.go",
         "basictracing.go",
     ],
     deps = [
+        "//pkg/attribute:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_opentracing_basictracer//:go_default_library",
     ],
@@ -17,6 +19,7 @@ go_test(
     name = "small_tests",
     size = "small",
     srcs = [
+        "attributes_test.go",
         "basictracing_test.go",
     ],
     library = ":go_default_library",

--- a/pkg/tracing/attributes.go
+++ b/pkg/tracing/attributes.go
@@ -1,0 +1,109 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains an implementation of an opentracing carrier built on top of Mixer's attribute bag. This allows
+// clients to inject their span metadata into the set of attributes its reporting to Mixer, and lets Mixer extract
+// span information propagated as attributes in a standard call to Mixer.
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"istio.io/mixer/pkg/attribute"
+)
+
+const (
+	headerAttributeName = "request.headers"
+)
+
+// AttributeFormat is the format marker to use when Injecting/Extracting attribute based metadata.
+type AttributeFormat struct{}
+
+// AttributeCarrier implements opentracing's TextMapWriter and TextMapReader interfaces using Istio's attributes.
+// Today we read only the HTTP headers (as attributes); in the future we can support full attribute based trace propagation.
+type AttributeCarrier struct {
+	req  attribute.Bag
+	resp *attribute.MutableBag
+	keys map[string]bool // the header names we'll look for.
+}
+
+// NewCarrier initializes a carrier that can be used to modify the attributes in the current request context.
+func NewCarrier(req attribute.Bag, resp *attribute.MutableBag, headerNames []string) *AttributeCarrier {
+	keys := make(map[string]bool, len(headerNames))
+	for _, header := range headerNames {
+		keys[header] = true
+	}
+	return &AttributeCarrier{req: req, resp: resp, keys: keys}
+}
+
+type carrierKey struct{}
+
+// NewContext annotates the provided context with the provided carrier and returns the updated context.
+func NewContext(ctx context.Context, carrier *AttributeCarrier) context.Context {
+	return context.WithValue(ctx, carrierKey{}, carrier)
+}
+
+// FromContext extracts the AttributeCarrier from the provided context, or returns nil if one is not found.
+func FromContext(ctx context.Context) *AttributeCarrier {
+	mc := ctx.Value(carrierKey{})
+	if c, ok := mc.(*AttributeCarrier); ok {
+		return c
+	}
+	return nil
+}
+
+// ForeachKey iterates over the request's headers (tucked into the request.headers attribute) looking for the keys
+// that the carrier was constructed with. This uses the headers from the _request_ bag.
+func (c *AttributeCarrier) ForeachKey(handler func(key, val string) error) error {
+	headers, err := getHeaders(c.req)
+	if err != nil {
+		return err
+	}
+	for header, val := range headers {
+		if c.keys[header] {
+			if err := handler(header, val); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Set adds (key, val) to the request.headers attribute of the _response_ bag.
+func (c *AttributeCarrier) Set(key, val string) {
+	headers, err := getHeaders(c.resp)
+	if err != nil {
+		glog.Warningf("Tried to set key in attribute trace metadata carrier, but no request.headers attribute found: %v", err)
+		return
+	}
+	headers[key] = val
+	c.resp.Set(headerAttributeName, headers)
+}
+
+func getHeaders(b attribute.Bag) (map[string]string, error) {
+	// TODO: is this func really even necessary? request.headers is a canonical attribute, so should we be paranoid about it?
+	attrVal, found := b.Get(headerAttributeName)
+	if !found {
+		return nil, fmt.Errorf("no header attribute named '%s'", headerAttributeName)
+	}
+	headers, ok := attrVal.(map[string]string)
+	if !ok {
+		return nil, fmt.Errorf("expected headers to be a map[string]string, got something else: %#v", attrVal)
+	}
+	return headers, nil
+}

--- a/pkg/tracing/attributes_test.go
+++ b/pkg/tracing/attributes_test.go
@@ -1,0 +1,171 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/golang/glog"
+
+	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/mixer/pkg/attribute"
+)
+
+var (
+	wordList = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", headerAttributeName}
+
+	attrs = &mixerpb.Attributes{
+		Words:   []string{"1", "2"},
+		Strings: map[int32]int32{1: -1, 2: -2},
+		Int64S:  map[int32]int64{3: 3, 4: 4},
+		Doubles: map[int32]float64{5: 5.0, 6: 6.0},
+		Bools:   map[int32]bool{7: true, 8: false},
+		Bytes:   map[int32][]uint8{9: {9}, 10: {10}},
+		StringMaps: map[int32]mixerpb.StringMap{
+			11: {}, // make sure request.headers is present/an empty map.
+		},
+	}
+)
+
+func TestContext(t *testing.T) {
+	bag := attribute.GetMutableBag(nil)
+	if err := bag.UpdateBagFromProto(attrs, wordList); err != nil {
+		t.Errorf("Failed to construct bag: %v", err)
+	}
+
+	if c := FromContext(context.Background()); c != nil {
+		t.Errorf("FromContext(context.Background()) = %v; wanted nil", c)
+	}
+
+	c := NewCarrier(bag, bag, wordList)
+
+	ctx := context.Background()
+	ctx = NewContext(ctx, c)
+	if cc := FromContext(ctx); cc != c {
+		t.Errorf("FromContext(ctx) = %v; wanted %v; context: %v", cc, c, ctx)
+	}
+}
+
+func TestSet(t *testing.T) {
+	bag := attribute.GetMutableBag(nil)
+	if err := bag.UpdateBagFromProto(attrs, wordList); err != nil {
+		t.Errorf("Failed to construct bag: %v", err)
+	}
+
+	cases := []struct {
+		key string
+		val string
+	}{
+		{"a", "b"},
+		{"foo", "bar"},
+		{"spanID", "1235"},
+	}
+	for _, c := range cases {
+		cr := NewCarrier(nil, bag, nil)
+		cr.Set(c.key, c.val)
+		val, _ := cr.resp.Get(headerAttributeName)
+		headers := val.(map[string]string)
+		if v, ok := headers[c.key]; !ok || v != c.val {
+			t.Errorf("carrier.Set(%s, %s); bag.String(%s) = %s; wanted %s", c.key, c.val, c.key, val, c.val)
+		}
+	}
+}
+
+func TestForeachKey(t *testing.T) {
+	bag := attribute.GetMutableBag(nil)
+	if err := bag.UpdateBagFromProto(attrs, wordList); err != nil {
+		t.Errorf("Failed to construct bag: %v", err)
+	}
+
+	cases := []struct {
+		data map[string]string
+	}{
+		{map[string]string{"a": "b", "c": "d"}},
+	}
+	for _, c := range cases {
+		b := bag.Child()
+		for k, v := range c.data {
+			b.Set(k, v)
+		}
+
+		err := NewCarrier(b, nil, wordList).ForeachKey(func(key, val string) error {
+			if dval, found := c.data[key]; !found || dval != val {
+				t.Errorf("ForeachKey(func(%s, %s)); wanted func(%s, %s)", key, val, key, dval)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Errorf("ForeachKey failed with unexpected err: %v", err)
+		}
+	}
+}
+
+func TestForeachKey_PropagatesErr(t *testing.T) {
+	bag := attribute.GetMutableBag(nil)
+	if err := bag.UpdateBagFromProto(attrs, wordList); err != nil {
+		t.Errorf("Failed to construct bag: %v", err)
+	}
+
+	c := NewCarrier(bag, bag, []string{"k"})
+	bag.Set(headerAttributeName, map[string]string{"k": "v"})
+
+	err := errors.New("expected")
+	propErr := c.ForeachKey(func(key, val string) error {
+		return err
+	})
+
+	if propErr != err {
+		t.Errorf("ForeachKey(...) = %v; wanted err %v", propErr, err)
+	}
+}
+
+func TestForeachKey_MissingHeaders(t *testing.T) {
+	bag := attribute.GetMutableBag(nil)
+	if err := bag.UpdateBagFromProto(attrs, wordList); err != nil {
+		t.Errorf("Failed to construct bag: %v", err)
+	}
+
+	c := NewCarrier(bag, bag, []string{"k"})
+	bag.Reset()
+
+	err := c.ForeachKey(func(key, val string) error {
+		panic("Should never be called because we failed earlier getting the headers.")
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "no header attribute named") {
+		t.Errorf("ForeachKey(...) = %v; wanted err containing 'No header attribute named'", err)
+	}
+}
+
+func TestSet_BadHeaders(t *testing.T) {
+	bag := attribute.GetMutableBag(nil)
+	if err := bag.UpdateBagFromProto(attrs, wordList); err != nil {
+		t.Errorf("Failed to construct bag: %v", err)
+	}
+
+	c := NewCarrier(bag, bag, []string{"k"})
+	bag.Reset()
+
+	initial := glog.Stats.Warning.Lines()
+	c.Set("foo", "bar")
+	glog.Flush()
+	final := glog.Stats.Warning.Lines()
+	if initial == final {
+		t.Fatalf("Should've logged failure to extract header attribute.")
+	}
+}


### PR DESCRIPTION
Getting Envoy to propagate trace metadata in the gRPC metadata sidechannel will likely take a bit of work. Envoy already propagates the trace metadata to us, in the `request.headers` attribute. This PR implements an opentracing `Carrier`, which is opentracing's abstraction over the trace propagation mechanism. Using this, we'll be able to make use of the Zipkin trace headers Envoy propagates to us via attributes.

This is adding back, with slight modification, code that was in Mixer before the shift to our unary API (we thought we'd get away with just using the existing opentracing interceptors, unfortunately not).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/891)
<!-- Reviewable:end -->
