### PR TITLE
Fix handling of target.service derivation logic.

### DIFF
--- a/adapter/kubernetes/kubernetes.go
+++ b/adapter/kubernetes/kubernetes.go
@@ -268,13 +268,14 @@ func (k *kubegen) Generate(inputs map[string]interface{}) (map[string]interface{
 		}
 	}
 	if targetSvc, found := inputs[k.params.TargetServiceInputName]; found {
-		svc := targetSvc.(string)
-		if len(svc) > 0 {
+		svc, ok := targetSvc.(string)
+		if ok && len(svc) > 0 {
 			n, err := canonicalName(svc, defaultNamespace, k.params.ClusterDomainName)
+			key := valueName(k.params.TargetPrefix, k.params.ServiceValueName)
 			if err != nil {
 				k.log.Warningf("could not canonicalize target service: %v", err)
-			} else {
-				values[valueName(k.params.TargetPrefix, k.params.ServiceValueName)] = n
+			} else if _, ok := values[key]; !ok {
+				values[key] = n
 			}
 		}
 	}

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -12,7 +12,7 @@ rules:
         sourceUID: source.uid | ""
         targetUID: target.uid | ""
         originUID: origin.uid | ""
-        targetService: request.headers["authority"] | request.host | ""
+        targetService: target.service | request.headers["authority"] | request.host | ""
       attribute_bindings:
         source.ip: sourcePodIp
         source.labels: sourceLabels


### PR DESCRIPTION
This PR alters the logic for deriving the `target.service` attribute within the k8s adapter. With this change, the binding of the value defers to existing values (derived from `target.uid`) and, in config, sends in the existing `target.service` attribute as the first choice for `target.service` attribute values.

## Problem description

Incoming attributes include:

```
...
    target.uid -> 'kubernetes://ratings-v1-3560259574-f67qv.mixer-test-9596fea2830045f09a23d6179c'
    target.service -> 'ratings.mixer-test-9596fea2830045f09a23d6179c.svc.cluster.local'
    request.host -> 'ratings:9080'
...
```

**After** preprocessing with `kubernetes` adapter, the attributes include:
```
...
target.service: ratings.default.svc.cluster.local
source.name: reviews-v3-3738910753-m49nc
target.labels: map[version:v1 app:ratings pod-template-hash:3560259574]
...
```

Notice that the namespace for the `target.service` has shifted from `mixer-test...` to `default`. This, in part, is because the config is pulling the source for the derivation from the `request.host` attribute. In this example, that attribute does not include namespace information (and the code falls back to `default`).

This will negatively impact policy enforcement, as it affects the scopes checked for rules.

Example failed resolution (deny rule in `global/ratings.mixer-test-9596fea2830045f09a23d6179c.svc.cluster.local`):
```
...
no rules for global/default.svc.cluster.local
no rules for global/ratings.default.svc.cluster.local
no rules for default.svc.cluster.local/default.svc.cluster.local
no rules for default.svc.cluster.local/ratings.default.svc.cluster.local
no rules for ratings.default.svc.cluster.local/ratings.default.svc.cluster.local
Resolved 0 configs: []
...
```

## Possible alternatives
- abandon `target.service` attribute derivation in the `kubernetes` adapter
- enforce that `attributes` adapters cannot override existing attribute values
- have the `request.host` and `:authority` header include namespace information

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/931)
<!-- Reviewable:end -->
