### PR TITLE
Support dispatching to new adapter model Handlers

### DIFF
--- a/adapter/memQuota/memQuota.go
+++ b/adapter/memQuota/memQuota.go
@@ -73,7 +73,7 @@ func (builder) ValidateConfig(cfg adapter.Config) (ce *adapter.ConfigErrors) {
 	return
 }
 
-func (builder) NewQuotasAspect(env adapter.Env, c adapter.Config, quotas map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+func (builder) NewQuotasAspect(env adapter.Env, c adapter.Config, d map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
 	return newAspect(env, c.(*config.Params))
 }
 

--- a/adapter/memQuota/memQuota.go
+++ b/adapter/memQuota/memQuota.go
@@ -73,7 +73,7 @@ func (builder) ValidateConfig(cfg adapter.Config) (ce *adapter.ConfigErrors) {
 	return
 }
 
-func (builder) NewQuotasAspect(env adapter.Env, c adapter.Config, d map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+func (builder) NewQuotasAspect(env adapter.Env, c adapter.Config, quotas map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
 	return newAspect(env, c.(*config.Params))
 }
 

--- a/adapter/noop/noop.go
+++ b/adapter/noop/noop.go
@@ -24,94 +24,70 @@ import (
 )
 
 type (
-	// AccessLogsBuilder implements adapter.AccessLogBuilder
-	AccessLogsBuilder struct{ adapter.DefaultBuilder }
-	// AppLogsBuilder implements adapter.ApplicationLogsBuilder
-	AppLogsBuilder struct{ adapter.DefaultBuilder }
-	// AttrBuilder implements adapter.AttributeGeneratorBuilder
-	AttrBuilder struct{ adapter.DefaultBuilder }
-	// DenialsBuilder implements adapter.DenialsBuilder
-	DenialsBuilder struct{ adapter.DefaultBuilder }
-	// ListBuilder implements adapter.ListsBuilder
-	ListBuilder struct{ adapter.DefaultBuilder }
-	// MetricBuilder implements adapter.MetricsBuilder
-	MetricBuilder struct{ adapter.DefaultBuilder }
-	// QuotaBuilder implements adapter.QuotasBuilder
-	QuotaBuilder struct{ adapter.DefaultBuilder }
-
-	accessLogsAspect struct{}
-	appLogsAspect    struct{}
-	attrAspect       struct{}
-	denialsAspect    struct{}
-	listAspect       struct{}
-	metricAspect     struct{}
-	quotaAspect      struct{}
+	// Builder implements all adapter.*Builder interfaces
+	Builder struct{ adapter.DefaultBuilder }
+	aspect  struct{}
 )
 
 // Register registers the no-op adapter as every aspect.
 func Register(r adapter.Registrar) {
-	r.RegisterAccessLogsBuilder(AccessLogsBuilder{adapter.NewDefaultBuilder("noop access", "", nil)})
-	r.RegisterApplicationLogsBuilder(AppLogsBuilder{adapter.NewDefaultBuilder("noop application", "", nil)})
-	r.RegisterAttributesGeneratorBuilder(AttrBuilder{adapter.NewDefaultBuilder("noop attr gen", "", nil)})
-	r.RegisterDenialsBuilder(DenialsBuilder{adapter.NewDefaultBuilder("noop denials", "", nil)})
-	r.RegisterListsBuilder(ListBuilder{adapter.NewDefaultBuilder("noop lists", "", nil)})
-	r.RegisterMetricsBuilder(MetricBuilder{adapter.NewDefaultBuilder("noop metrics", "", nil)})
-	r.RegisterQuotasBuilder(QuotaBuilder{adapter.NewDefaultBuilder("noop quotas", "", nil)})
+	b := Builder{adapter.NewDefaultBuilder("noop builder", "", nil)}
+	r.RegisterAccessLogsBuilder(b)
+	r.RegisterApplicationLogsBuilder(b)
+	r.RegisterAttributesGeneratorBuilder(b)
+	r.RegisterDenialsBuilder(b)
+	r.RegisterListsBuilder(b)
+	r.RegisterMetricsBuilder(b)
+	r.RegisterQuotasBuilder(b)
 }
 
 // BuildAttributesGenerator creates an adapter.AttributesGenerator instance
-func (AttrBuilder) BuildAttributesGenerator(adapter.Env, adapter.Config) (adapter.AttributesGenerator, error) {
-	return &attrAspect{}, nil
+func (Builder) BuildAttributesGenerator(adapter.Env, adapter.Config) (adapter.AttributesGenerator, error) {
+	return &aspect{}, nil
 }
-func (attrAspect) Generate(map[string]interface{}) (map[string]interface{}, error) {
+func (aspect) Generate(map[string]interface{}) (map[string]interface{}, error) {
 	return map[string]interface{}{}, nil
 }
-func (attrAspect) Close() error { return nil }
+func (aspect) Close() error { return nil }
 
 // NewAccessLogsAspect creates an adapter.AccessLogsAspect instance
-func (AccessLogsBuilder) NewAccessLogsAspect(adapter.Env, adapter.Config) (adapter.AccessLogsAspect, error) {
-	return &accessLogsAspect{}, nil
+func (Builder) NewAccessLogsAspect(adapter.Env, adapter.Config) (adapter.AccessLogsAspect, error) {
+	return &aspect{}, nil
 }
-func (accessLogsAspect) LogAccess([]adapter.LogEntry) error { return nil }
-func (accessLogsAspect) Close() error                       { return nil }
+func (aspect) LogAccess([]adapter.LogEntry) error { return nil }
 
 // NewApplicationLogsAspect creates an adapter.ApplicationLogsAspect instance
-func (AppLogsBuilder) NewApplicationLogsAspect(adapter.Env, adapter.Config) (adapter.ApplicationLogsAspect, error) {
-	return &appLogsAspect{}, nil
+func (Builder) NewApplicationLogsAspect(adapter.Env, adapter.Config) (adapter.ApplicationLogsAspect, error) {
+	return &aspect{}, nil
 }
-func (appLogsAspect) Log([]adapter.LogEntry) error { return nil }
-func (appLogsAspect) Close() error                 { return nil }
+func (aspect) Log([]adapter.LogEntry) error { return nil }
 
 // NewDenialsAspect creates an adapter.DenialsAspect instance
-func (DenialsBuilder) NewDenialsAspect(adapter.Env, adapter.Config) (adapter.DenialsAspect, error) {
-	return &denialsAspect{}, nil
+func (Builder) NewDenialsAspect(adapter.Env, adapter.Config) (adapter.DenialsAspect, error) {
+	return &aspect{}, nil
 }
-func (denialsAspect) Deny() rpc.Status { return status.New(rpc.FAILED_PRECONDITION) }
-func (denialsAspect) Close() error     { return nil }
+func (aspect) Deny() rpc.Status { return status.New(rpc.FAILED_PRECONDITION) }
 
 // NewListsAspect creates an adapter.ListsAspect instance
-func (ListBuilder) NewListsAspect(adapter.Env, adapter.Config) (adapter.ListsAspect, error) {
-	return &listAspect{}, nil
+func (Builder) NewListsAspect(adapter.Env, adapter.Config) (adapter.ListsAspect, error) {
+	return &aspect{}, nil
 }
-func (listAspect) CheckList(symbol string) (bool, error) { return false, nil }
-func (listAspect) Close() error                          { return nil }
+func (aspect) CheckList(symbol string) (bool, error) { return false, nil }
 
 // NewMetricsAspect creates an adapter.MetricsAspect instance
-func (MetricBuilder) NewMetricsAspect(adapter.Env, adapter.Config, map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
-	return &metricAspect{}, nil
+func (Builder) NewMetricsAspect(adapter.Env, adapter.Config, map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+	return &aspect{}, nil
 }
-func (metricAspect) Record([]adapter.Value) error { return nil }
-func (metricAspect) Close() error                 { return nil }
+func (aspect) Record([]adapter.Value) error { return nil }
 
 // NewQuotasAspect creates an adapter.QuotasAspect instance
-func (QuotaBuilder) NewQuotasAspect(env adapter.Env, c adapter.Config, quotas map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
-	return &quotaAspect{}, nil
+func (Builder) NewQuotasAspect(env adapter.Env, c adapter.Config, quotas map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+	return &aspect{}, nil
 }
-func (quotaAspect) Alloc(adapter.QuotaArgs) (adapter.QuotaResult, error) {
+func (aspect) Alloc(adapter.QuotaArgs) (adapter.QuotaResult, error) {
 	return adapter.QuotaResult{}, nil
 }
-func (quotaAspect) AllocBestEffort(adapter.QuotaArgs) (adapter.QuotaResult, error) {
+func (aspect) AllocBestEffort(adapter.QuotaArgs) (adapter.QuotaResult, error) {
 	return adapter.QuotaResult{}, nil
 }
-func (quotaAspect) ReleaseBestEffort(adapter.QuotaArgs) (int64, error) { return 0, nil }
-func (quotaAspect) Close() error                                       { return nil }
+func (aspect) ReleaseBestEffort(adapter.QuotaArgs) (int64, error) { return 0, nil }

--- a/adapter/noop/noop.go
+++ b/adapter/noop/noop.go
@@ -24,13 +24,20 @@ import (
 )
 
 type (
-	AccessLogsBuilder struct{ adapter.Builder }
-	AppLogsBuilder    struct{ adapter.Builder }
-	AttrBuilder       struct{ adapter.Builder }
-	DenialsBuilder    struct{ adapter.Builder }
-	ListBuilder       struct{ adapter.Builder }
-	MetricBuilder     struct{ adapter.Builder }
-	QuotaBuilder      struct{ adapter.Builder }
+	// AccessLogsBuilder implements adapter.AccessLogBuilder
+	AccessLogsBuilder struct{ adapter.DefaultBuilder }
+	// AppLogsBuilder implements adapter.ApplicationLogsBuilder
+	AppLogsBuilder struct{ adapter.DefaultBuilder }
+	// AttrBuilder implements adapter.AttributeGeneratorBuilder
+	AttrBuilder struct{ adapter.DefaultBuilder }
+	// DenialsBuilder implements adapter.DenialsBuilder
+	DenialsBuilder struct{ adapter.DefaultBuilder }
+	// ListBuilder implements adapter.ListsBuilder
+	ListBuilder struct{ adapter.DefaultBuilder }
+	// MetricBuilder implements adapter.MetricsBuilder
+	MetricBuilder struct{ adapter.DefaultBuilder }
+	// QuotaBuilder implements adapter.QuotasBuilder
+	QuotaBuilder struct{ adapter.DefaultBuilder }
 
 	accessLogsAspect struct{}
 	appLogsAspect    struct{}
@@ -43,15 +50,16 @@ type (
 
 // Register registers the no-op adapter as every aspect.
 func Register(r adapter.Registrar) {
-	r.RegisterAccessLogsBuilder(AccessLogsBuilder{})
-	r.RegisterApplicationLogsBuilder(AppLogsBuilder{})
-	r.RegisterAttributesGeneratorBuilder(AttrBuilder{})
-	r.RegisterDenialsBuilder(DenialsBuilder{})
-	r.RegisterListsBuilder(ListBuilder{})
-	r.RegisterMetricsBuilder(MetricBuilder{})
-	r.RegisterQuotasBuilder(QuotaBuilder{})
+	r.RegisterAccessLogsBuilder(AccessLogsBuilder{adapter.NewDefaultBuilder("noop access", "", nil)})
+	r.RegisterApplicationLogsBuilder(AppLogsBuilder{adapter.NewDefaultBuilder("noop application", "", nil)})
+	r.RegisterAttributesGeneratorBuilder(AttrBuilder{adapter.NewDefaultBuilder("noop attr gen", "", nil)})
+	r.RegisterDenialsBuilder(DenialsBuilder{adapter.NewDefaultBuilder("noop denials", "", nil)})
+	r.RegisterListsBuilder(ListBuilder{adapter.NewDefaultBuilder("noop lists", "", nil)})
+	r.RegisterMetricsBuilder(MetricBuilder{adapter.NewDefaultBuilder("noop metrics", "", nil)})
+	r.RegisterQuotasBuilder(QuotaBuilder{adapter.NewDefaultBuilder("noop quotas", "", nil)})
 }
 
+// BuildAttributesGenerator creates an adapter.AttributesGenerator instance
 func (AttrBuilder) BuildAttributesGenerator(adapter.Env, adapter.Config) (adapter.AttributesGenerator, error) {
 	return &attrAspect{}, nil
 }
@@ -60,36 +68,42 @@ func (attrAspect) Generate(map[string]interface{}) (map[string]interface{}, erro
 }
 func (attrAspect) Close() error { return nil }
 
+// NewAccessLogsAspect creates an adapter.AccessLogsAspect instance
 func (AccessLogsBuilder) NewAccessLogsAspect(adapter.Env, adapter.Config) (adapter.AccessLogsAspect, error) {
 	return &accessLogsAspect{}, nil
 }
 func (accessLogsAspect) LogAccess([]adapter.LogEntry) error { return nil }
 func (accessLogsAspect) Close() error                       { return nil }
 
+// NewApplicationLogsAspect creates an adapter.ApplicationLogsAspect instance
 func (AppLogsBuilder) NewApplicationLogsAspect(adapter.Env, adapter.Config) (adapter.ApplicationLogsAspect, error) {
 	return &appLogsAspect{}, nil
 }
 func (appLogsAspect) Log([]adapter.LogEntry) error { return nil }
 func (appLogsAspect) Close() error                 { return nil }
 
+// NewDenialsAspect creates an adapter.DenialsAspect instance
 func (DenialsBuilder) NewDenialsAspect(adapter.Env, adapter.Config) (adapter.DenialsAspect, error) {
 	return &denialsAspect{}, nil
 }
 func (denialsAspect) Deny() rpc.Status { return status.New(rpc.FAILED_PRECONDITION) }
 func (denialsAspect) Close() error     { return nil }
 
+// NewListsAspect creates an adapter.ListsAspect instance
 func (ListBuilder) NewListsAspect(adapter.Env, adapter.Config) (adapter.ListsAspect, error) {
 	return &listAspect{}, nil
 }
 func (listAspect) CheckList(symbol string) (bool, error) { return false, nil }
 func (listAspect) Close() error                          { return nil }
 
+// NewMetricsAspect creates an adapter.MetricsAspect instance
 func (MetricBuilder) NewMetricsAspect(adapter.Env, adapter.Config, map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	return &metricAspect{}, nil
 }
 func (metricAspect) Record([]adapter.Value) error { return nil }
 func (metricAspect) Close() error                 { return nil }
 
+// NewQuotasAspect creates an adapter.QuotasAspect instance
 func (QuotaBuilder) NewQuotasAspect(env adapter.Env, c adapter.Config, quotas map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
 	return &quotaAspect{}, nil
 }

--- a/adapter/noop/noop_test.go
+++ b/adapter/noop/noop_test.go
@@ -25,14 +25,15 @@ import (
 func TestRegisteredForAllAspects(t *testing.T) {
 	builders := adapterManager.BuilderMap([]adapter.RegisterFn{Register})
 
-	name := builder{}.Name()
-	noop := builders[name]
-
 	var i uint
 	for i = 0; i < uint(config.NumKinds); i++ {
 		k := config.Kind(i)
-		if !noop.Kinds.IsSet(k) {
-			t.Errorf("%s is not registered for kind %s", name, k)
+		found := false
+		for _, noop := range builders {
+			found = found || noop.Kinds.IsSet(k)
+		}
+		if !found {
+			t.Errorf("Noop is not registered for kind %s", k)
 		}
 	}
 }

--- a/adapter/statsd/statsd.go
+++ b/adapter/statsd/statsd.go
@@ -85,7 +85,7 @@ func (b *builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	return
 }
 
-func (*builder) NewMetricsAspect(env adapter.Env, cfg adapter.Config, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
+func (b *builder) NewMetricsAspect(env adapter.Env, cfg adapter.Config, metrics map[string]*adapter.MetricDefinition) (adapter.MetricsAspect, error) {
 	params := cfg.(*config.Params)
 
 	flushBytes := int(params.FlushBytes)

--- a/adapter/statsd/statsd.go
+++ b/adapter/statsd/statsd.go
@@ -66,7 +66,7 @@ func newBuilder() *builder {
 	return &builder{adapter.NewDefaultBuilder(name, desc, defaultConf)}
 }
 
-func (b *builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
+func (*builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	params := c.(*config.Params)
 	if params.FlushDuration < 0 {
 		ce = ce.Appendf("flushDuration", "flush duration must be >= 0")

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -492,7 +492,8 @@ func newCacheKey(kind config.Kind, cfg *cpb.Combined) (*cacheKey, error) {
 }
 
 // cacheGet gets an aspect executor from the cache, use adapter.Manager to construct an object in case of a cache miss
-func (m *Manager) cacheGet(cfg *cpb.Combined, mgr aspect.Manager, createAspect aspect.CreateAspectFunc, df descriptor.Finder) (executor aspect.Executor, err error) {
+func (m *Manager) cacheGet(
+	cfg *cpb.Combined, mgr aspect.Manager, createAspect aspect.CreateAspectFunc, df descriptor.Finder) (executor aspect.Executor, err error) {
 	var key *cacheKey
 	if key, err = newCacheKey(mgr.Kind(), cfg); err != nil {
 		return nil, err

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -416,10 +416,10 @@ func (m *Manager) execute(ctx context.Context, cfg *cpb.Combined, requestBag att
 
 	var createAspect aspect.CreateAspectFunc
 	if builder, found := m.builders.FindBuilder(cfg.Builder.Impl); found {
-		var e error
-		createAspect, e = aspect.FromBuilder(builder, kind)
-		if e != nil {
-			return status.WithError(e)
+		var err error
+		createAspect, err = aspect.FromBuilder(builder, kind)
+		if err != nil {
+			return status.WithError(err)
 		}
 	} else if handler, found := m.getHandlers()[cfg.Builder.Impl]; found {
 		createAspect = aspect.FromHandler(handler.Instance)

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -432,7 +432,7 @@ func (m *Manager) execute(ctx context.Context, cfg *cpb.Combined, requestBag att
 
 	executor, err := m.cacheGet(cfg, mgr, createAspect, df)
 	if err != nil {
-		return status.WithError(fmt.Errorf("Failed to construct executor for adapter '%s': %v", cfg.Builder.Impl, err))
+		return status.WithError(fmt.Errorf("failed to construct executor for adapter '%s': %v", cfg.Builder.Impl, err))
 	}
 
 	// TODO: plumb ctx through asp.Execute

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -108,8 +108,9 @@ type Manager struct {
 	adapterGP         *pool.GoroutinePool
 
 	// Configs for the aspects that'll be used to serve each API method.
-	cfg atomic.Value
-	df  atomic.Value
+	resolver atomic.Value // config.Resolver
+	df       atomic.Value // descriptor.Finder
+	handlers atomic.Value // map[string]*HandlerInfo
 
 	// protects cache
 	lock          sync.RWMutex
@@ -225,7 +226,7 @@ func (m *Manager) Quota(ctx context.Context, requestBag attribute.Bag,
 }
 
 func (m *Manager) loadConfigs(attrs attribute.Bag, ks config.KindSet, isPreprocess bool, strict bool) ([]*cpb.Combined, error) {
-	cfg, _ := m.cfg.Load().(config.Resolver)
+	cfg, _ := m.resolver.Load().(config.Resolver)
 	if cfg == nil {
 		return nil, errors.New("configuration is not yet available")
 	}
@@ -413,21 +414,25 @@ func (m *Manager) execute(ctx context.Context, cfg *cpb.Combined, requestBag att
 		return status.WithError(fmt.Errorf("could not find aspect manager %#v", cfg.Aspect.Kind))
 	}
 
-	var builder adapter.Builder
-	if builder, found = m.builders.FindBuilder(cfg.Builder.Impl); !found {
+	var createAspect aspect.CreateAspectFunc
+	if builder, found := m.builders.FindBuilder(cfg.Builder.Impl); found {
+		createAspect = aspect.FromBuilder(builder)
+	} else if handler, found := m.getHandlers()[cfg.Builder.Impl]; found {
+		createAspect = aspect.FromHandler(handler.Instance)
+	} else {
 		return status.WithError(fmt.Errorf("could not find registered adapter %#v", cfg.Builder.Impl))
 	}
 
 	// Both cacheGet and invokeFunc call adapter-supplied code, so we need to guard against both panicking.
 	defer func() {
 		if r := recover(); r != nil {
-			out = status.WithError(fmt.Errorf("adapter '%s' panicked with '%v'", builder.Name(), r))
+			out = status.WithError(fmt.Errorf("adapter '%s' panicked with '%v'", cfg.Builder.Impl, r))
 		}
 	}()
 
-	executor, err := m.cacheGet(cfg, mgr, builder, df)
+	executor, err := m.cacheGet(cfg, mgr, createAspect, df)
 	if err != nil {
-		return status.WithError(err)
+		return status.WithError(fmt.Errorf("Failed to construct executor for adapter '%s': %v", cfg.Builder.Impl, err))
 	}
 
 	// TODO: plumb ctx through asp.Execute
@@ -483,7 +488,7 @@ func newCacheKey(kind config.Kind, cfg *cpb.Combined) (*cacheKey, error) {
 }
 
 // cacheGet gets an aspect executor from the cache, use adapter.Manager to construct an object in case of a cache miss
-func (m *Manager) cacheGet(cfg *cpb.Combined, mgr aspect.Manager, builder adapter.Builder, df descriptor.Finder) (executor aspect.Executor, err error) {
+func (m *Manager) cacheGet(cfg *cpb.Combined, mgr aspect.Manager, createAspect aspect.CreateAspectFunc, df descriptor.Finder) (executor aspect.Executor, err error) {
 	var key *cacheKey
 	if key, err = newCacheKey(mgr.Kind(), cfg); err != nil {
 		return nil, err
@@ -499,17 +504,17 @@ func (m *Manager) cacheGet(cfg *cpb.Combined, mgr aspect.Manager, builder adapte
 	}
 
 	// create an aspect
-	env := newEnv(builder.Name(), m.adapterGP)
+	env := newEnv(cfg.Builder.Name, m.adapterGP)
 
 	switch m := mgr.(type) {
 	case aspect.PreprocessManager:
-		executor, err = m.NewPreprocessExecutor(cfg, builder, env, df)
+		executor, err = m.NewPreprocessExecutor(cfg, createAspect, env, df)
 	case aspect.CheckManager:
-		executor, err = m.NewCheckExecutor(cfg, builder, env, df)
+		executor, err = m.NewCheckExecutor(cfg, createAspect, env, df)
 	case aspect.ReportManager:
-		executor, err = m.NewReportExecutor(cfg, builder, env, df)
+		executor, err = m.NewReportExecutor(cfg, createAspect, env, df)
 	case aspect.QuotaManager:
-		executor, err = m.NewQuotaExecutor(cfg, builder, env, df)
+		executor, err = m.NewQuotaExecutor(cfg, createAspect, env, df)
 	}
 
 	if err != nil {
@@ -555,6 +560,10 @@ func (m *Manager) SupportedKinds(builder string) config.KindSet {
 	return m.builders.SupportedKinds(builder)
 }
 
+func (m *Manager) getHandlers() map[string]*config.HandlerInfo {
+	return m.handlers.Load().(map[string]*config.HandlerInfo)
+}
+
 // Aspects returns a fully constructed manager table, indexed by config.Kind.
 func Aspects(inventory aspect.ManagerInventory) [config.NumKinds]aspect.Manager {
 	r := [config.NumKinds]aspect.Manager{}
@@ -579,7 +588,8 @@ func Aspects(inventory aspect.ManagerInventory) [config.NumKinds]aspect.Manager 
 }
 
 // ConfigChange listens for config change notifications.
-func (m *Manager) ConfigChange(cfg config.Resolver, df descriptor.Finder) {
-	m.cfg.Store(cfg)
+func (m *Manager) ConfigChange(cfg config.Resolver, df descriptor.Finder, handlers map[string]*config.HandlerInfo) {
+	m.resolver.Store(cfg)
 	m.df.Store(df)
+	m.handlers.Store(handlers)
 }

--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -416,7 +416,11 @@ func (m *Manager) execute(ctx context.Context, cfg *cpb.Combined, requestBag att
 
 	var createAspect aspect.CreateAspectFunc
 	if builder, found := m.builders.FindBuilder(cfg.Builder.Impl); found {
-		createAspect = aspect.FromBuilder(builder)
+		var e error
+		createAspect, e = aspect.FromBuilder(builder, kind)
+		if e != nil {
+			return status.WithError(e)
+		}
 	} else if handler, found := m.getHandlers()[cfg.Builder.Impl]; found {
 		createAspect = aspect.FromHandler(handler.Instance)
 	} else {

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -162,7 +162,8 @@ func (m *fakePreprocessMgr) Kind() config.Kind {
 	return m.kind
 }
 
-func (m *fakePreprocessMgr) NewPreprocessExecutor(c *cpb.Combined, _ aspect.CreateAspectFunc, e adapter.Env, _ descriptor.Finder) (aspect.PreprocessExecutor, error) {
+func (m *fakePreprocessMgr) NewPreprocessExecutor(
+	c *cpb.Combined, _ aspect.CreateAspectFunc, e adapter.Env, _ descriptor.Finder) (aspect.PreprocessExecutor, error) {
 	m.called++
 	if m.pe == nil {
 		return nil, errors.New("unable to create aspect")
@@ -175,7 +176,8 @@ func (m *fakeCheckAspectMgr) Kind() config.Kind {
 	return m.kind
 }
 
-func (m *fakeCheckAspectMgr) NewCheckExecutor(cfg *cpb.Combined, _ aspect.CreateAspectFunc, env adapter.Env, _ descriptor.Finder) (aspect.CheckExecutor, error) {
+func (m *fakeCheckAspectMgr) NewCheckExecutor(
+	cfg *cpb.Combined, _ aspect.CreateAspectFunc, env adapter.Env, _ descriptor.Finder) (aspect.CheckExecutor, error) {
 	m.called++
 	if m.ce == nil {
 		return nil, errors.New("unable to create aspect")
@@ -188,7 +190,8 @@ func (m *fakeReportAspectMgr) Kind() config.Kind {
 	return m.kind
 }
 
-func (m *fakeReportAspectMgr) NewReportExecutor(cfg *cpb.Combined, _ aspect.CreateAspectFunc, env adapter.Env, _ descriptor.Finder) (aspect.ReportExecutor, error) {
+func (m *fakeReportAspectMgr) NewReportExecutor(
+	cfg *cpb.Combined, _ aspect.CreateAspectFunc, env adapter.Env, _ descriptor.Finder) (aspect.ReportExecutor, error) {
 	m.called++
 	if m.re == nil {
 		return nil, errors.New("unable to create aspect")
@@ -201,7 +204,8 @@ func (m *fakeQuotaAspectMgr) Kind() config.Kind {
 	return m.kind
 }
 
-func (m *fakeQuotaAspectMgr) NewQuotaExecutor(cfg *cpb.Combined, _ aspect.CreateAspectFunc, env adapter.Env, _ descriptor.Finder) (aspect.QuotaExecutor, error) {
+func (m *fakeQuotaAspectMgr) NewQuotaExecutor(
+	cfg *cpb.Combined, _ aspect.CreateAspectFunc, env adapter.Env, _ descriptor.Finder) (aspect.QuotaExecutor, error) {
 	m.called++
 	if m.qe == nil {
 		return nil, errors.New("unable to create aspect")

--- a/pkg/adapterManager/manager_test.go
+++ b/pkg/adapterManager/manager_test.go
@@ -121,6 +121,18 @@ func (f *fakeResolver) ResolveUnconditional(attribute.Bag, config.KindSet, bool)
 }
 
 func (f *fakeBuilder) Name() string { return f.name }
+func (fakeBuilder) NewAccessLogsAspect(adapter.Env, adapter.Config) (adapter.AccessLogsAspect, error) {
+	return nil, nil
+}
+func (fakeBuilder) NewDenialsAspect(adapter.Env, adapter.Config) (adapter.DenialsAspect, error) {
+	return nil, nil
+}
+func (fakeBuilder) BuildAttributesGenerator(adapter.Env, adapter.Config) (adapter.AttributesGenerator, error) {
+	return nil, nil
+}
+func (fakeBuilder) NewQuotasAspect(adapter.Env, adapter.Config, map[string]*adapter.QuotaDefinition) (adapter.QuotasAspect, error) {
+	return nil, nil
+}
 
 func (f *fakePreprocessExecutor) Execute(attribute.Bag, expr.Evaluator) (*aspect.PreprocessResult, rpc.Status) {
 	f.called++
@@ -230,6 +242,9 @@ func (testAspect) DefaultConfig() adapter.Config                       { return 
 func (testAspect) ValidateConfig(adapter.Config) *adapter.ConfigErrors { return nil }
 func (testAspect) Name() string                                        { return "" }
 func (testAspect) Description() string                                 { return "" }
+func (testAspect) NewDenialsAspect(adapter.Env, adapter.Config) (adapter.DenialsAspect, error) {
+	return nil, nil
+}
 
 func (m *fakeBuilderReg) FindBuilder(string) (adapter.Builder, bool) {
 	return m.adp, m.found

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -19,6 +19,7 @@ go_library(
     ],
     deps = [
         "//pkg/adapter:go_default_library",
+        "//pkg/adapter/config:go_default_library",
         "//pkg/aspect/config:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/config:go_default_library",

--- a/pkg/aspect/BUILD
+++ b/pkg/aspect/BUILD
@@ -56,6 +56,7 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
+        "//adapter/noop:go_default_library",
         "//pkg/adapter/test:go_default_library",
         "//pkg/aspect/test:go_default_library",
     ],

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -98,7 +98,7 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 				Builder: &cfgpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &cfgpb.Aspect{Params: v.params},
 			}
-			asp, err := m.NewReportExecutor(c, tl, test.Env{}, accesslogsDF)
+			asp, err := m.NewReportExecutor(c, FromBuilder(tl), test.Env{}, accesslogsDF)
 			if err != nil {
 				t.Fatalf("NewExecutor(): should not have received error for %s (%v)", v.name, err)
 			}
@@ -134,7 +134,7 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 	m := newAccessLogsManager()
 	for idx, v := range failureCases {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			if _, err := m.NewReportExecutor(v.cfg, v.adptr, test.Env{}, accesslogsDF); err == nil {
+			if _, err := m.NewReportExecutor(v.cfg, FromBuilder(v.adptr), test.Env{}, accesslogsDF); err == nil {
 				t.Fatalf("NewExecutor()[%s]: expected error for bad adapter (%T)", v.name, v.adptr)
 			}
 		})

--- a/pkg/aspect/accessLogsManager_test.go
+++ b/pkg/aspect/accessLogsManager_test.go
@@ -98,7 +98,8 @@ func TestAccessLoggerManager_NewAspect(t *testing.T) {
 				Builder: &cfgpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &cfgpb.Aspect{Params: v.params},
 			}
-			asp, err := m.NewReportExecutor(c, FromBuilder(tl), test.Env{}, accesslogsDF)
+			f, _ := FromBuilder(tl, config.AccessLogsKind)
+			asp, err := m.NewReportExecutor(c, f, test.Env{}, accesslogsDF)
 			if err != nil {
 				t.Fatalf("NewExecutor(): should not have received error for %s (%v)", v.name, err)
 			}
@@ -134,7 +135,8 @@ func TestAccessLoggerManager_NewAspectFailures(t *testing.T) {
 	m := newAccessLogsManager()
 	for idx, v := range failureCases {
 		t.Run(fmt.Sprintf("[%d] %s", idx, v.name), func(t *testing.T) {
-			if _, err := m.NewReportExecutor(v.cfg, FromBuilder(v.adptr), test.Env{}, accesslogsDF); err == nil {
+			f, _ := FromBuilder(v.adptr, config.AccessLogsKind)
+			if _, err := m.NewReportExecutor(v.cfg, f, test.Env{}, accesslogsDF); err == nil {
 				t.Fatalf("NewExecutor()[%s]: expected error for bad adapter (%T)", v.name, v.adptr)
 			}
 		})

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -131,7 +131,8 @@ func TestLoggerManager_NewLogger(t *testing.T) {
 				Builder: &cfgpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &cfgpb.Aspect{Params: v.params},
 			}
-			asp, err := m.NewReportExecutor(&c, FromBuilder(tl), atest.NewEnv(t), applogsDF)
+			f, _ := FromBuilder(tl, config.ApplicationLogsKind)
+			asp, err := m.NewReportExecutor(&c, f, atest.NewEnv(t), applogsDF)
 			if err != nil {
 				t.Fatalf("NewExecutor(): should not have received error for %s (%v)", v.name, err)
 			}
@@ -179,8 +180,8 @@ func TestLoggerManager_NewLoggerFailures(t *testing.T) {
 					Params: v.cfg,
 				},
 			}
-
-			if _, err := m.NewReportExecutor(cfg, FromBuilder(v.adptr), atest.NewEnv(t), applogsDF); err == nil {
+			f, _ := FromBuilder(v.adptr, config.ApplicationLogsKind)
+			if _, err := m.NewReportExecutor(cfg, f, atest.NewEnv(t), applogsDF); err == nil {
 				t.Fatalf("NewExecutor(): expected error for bad adapter (%T)", v.adptr)
 			}
 		})

--- a/pkg/aspect/applicationLogsManager_test.go
+++ b/pkg/aspect/applicationLogsManager_test.go
@@ -131,7 +131,7 @@ func TestLoggerManager_NewLogger(t *testing.T) {
 				Builder: &cfgpb.Adapter{Params: &ptypes.Empty{}},
 				Aspect:  &cfgpb.Aspect{Params: v.params},
 			}
-			asp, err := m.NewReportExecutor(&c, tl, atest.NewEnv(t), applogsDF)
+			asp, err := m.NewReportExecutor(&c, FromBuilder(tl), atest.NewEnv(t), applogsDF)
 			if err != nil {
 				t.Fatalf("NewExecutor(): should not have received error for %s (%v)", v.name, err)
 			}
@@ -180,7 +180,7 @@ func TestLoggerManager_NewLoggerFailures(t *testing.T) {
 				},
 			}
 
-			if _, err := m.NewReportExecutor(cfg, v.adptr, atest.NewEnv(t), applogsDF); err == nil {
+			if _, err := m.NewReportExecutor(cfg, FromBuilder(v.adptr), atest.NewEnv(t), applogsDF); err == nil {
 				t.Fatalf("NewExecutor(): expected error for bad adapter (%T)", v.adptr)
 			}
 		})

--- a/pkg/aspect/attrgenmgr_test.go
+++ b/pkg/aspect/attrgenmgr_test.go
@@ -144,7 +144,7 @@ func TestAttributeGeneratorManager_NewPreprocessExecutor(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			exec, err := m.NewPreprocessExecutor(c, v.builder, test.NewEnv(t), nil)
+			exec, err := m.NewPreprocessExecutor(c, FromBuilder(v.builder), test.NewEnv(t), nil)
 			if err == nil && v.wantErr {
 				t.Error("Expected to receive error")
 			}

--- a/pkg/aspect/attrgenmgr_test.go
+++ b/pkg/aspect/attrgenmgr_test.go
@@ -144,7 +144,8 @@ func TestAttributeGeneratorManager_NewPreprocessExecutor(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			exec, err := m.NewPreprocessExecutor(c, FromBuilder(v.builder), test.NewEnv(t), nil)
+			f, _ := FromBuilder(v.builder, config.AttributesKind)
+			exec, err := m.NewPreprocessExecutor(c, f, test.NewEnv(t), nil)
 			if err == nil && v.wantErr {
 				t.Error("Expected to receive error")
 			}

--- a/pkg/aspect/common.go
+++ b/pkg/aspect/common.go
@@ -26,44 +26,41 @@ import (
 	"istio.io/mixer/pkg/expr"
 )
 
+// FromHandler creates a CreateAspectFunc from the provided handler instance.
 func FromHandler(handler config.Handler) CreateAspectFunc {
 	return func(adapter.Env, adapter.Config, ...interface{}) (adapter.Aspect, error) {
 		return handler, nil
 	}
 }
 
+// FromBuilder creates a CreateAspectFunc from the provided builder instance, dispatching to New*Aspect methods based
+// on the builder's type.
 func FromBuilder(builder adapter.Builder) CreateAspectFunc {
 	switch b := builder.(type) {
 	case adapter.DenialsBuilder:
-		// yet `return b.NewDenialsAspect` is a compilation error.
 		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
 			return b.NewDenialsAspect(env, c)
 		}
 	case adapter.AccessLogsBuilder:
-		// yet `return b.NewDenialsAspect` is a compilation error.
 		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
 			return b.NewAccessLogsAspect(env, c)
 		}
 	case adapter.ApplicationLogsBuilder:
-		// yet `return b.NewDenialsAspect` is a compilation error.
 		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
 			return b.NewApplicationLogsAspect(env, c)
 		}
 	case adapter.AttributesGeneratorBuilder:
-		// yet `return b.NewDenialsAspect` is a compilation error.
 		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
 			return b.BuildAttributesGenerator(env, c)
 		}
 	case adapter.ListsBuilder:
-		// yet `return b.NewDenialsAspect` is a compilation error.
 		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
 			return b.NewListsAspect(env, c)
 		}
 	case adapter.MetricsBuilder:
-		// yet `return b.NewDenialsAspect` is a compilation error.
 		return func(env adapter.Env, c adapter.Config, cfg ...interface{}) (adapter.Aspect, error) {
 			if len(cfg) < 1 {
-				return nil, fmt.Errorf("metric builders must have configuration args.")
+				return nil, fmt.Errorf("metric builders must have configuration args")
 			}
 			metrics, ok := cfg[0].(map[string]*adapter.MetricDefinition)
 			if !ok {
@@ -72,10 +69,9 @@ func FromBuilder(builder adapter.Builder) CreateAspectFunc {
 			return b.NewMetricsAspect(env, c, metrics)
 		}
 	case adapter.QuotasBuilder:
-		// yet `return b.NewDenialsAspect` is a compilation error.
 		return func(env adapter.Env, c adapter.Config, cfg ...interface{}) (adapter.Aspect, error) {
 			if len(cfg) < 1 {
-				return nil, fmt.Errorf("quota builders must have configuration args.")
+				return nil, fmt.Errorf("quota builders must have configuration args")
 			}
 			quotas, ok := cfg[0].(map[string]*adapter.QuotaDefinition)
 			if !ok {
@@ -86,7 +82,7 @@ func FromBuilder(builder adapter.Builder) CreateAspectFunc {
 	default:
 		// TODO: should we do something stronger here, or maybe change this func to return `(CreateAspectFunc, error)`?
 		return func(adapter.Env, adapter.Config, ...interface{}) (adapter.Aspect, error) {
-			return nil, fmt.Errorf("Invalid builder type: %#v", builder)
+			return nil, fmt.Errorf("invalid builder type: %#v", builder)
 		}
 	}
 }

--- a/pkg/aspect/common.go
+++ b/pkg/aspect/common.go
@@ -21,9 +21,75 @@ import (
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/adapter/config"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 )
+
+func FromHandler(handler config.Handler) CreateAspectFunc {
+	return func(adapter.Env, adapter.Config, ...interface{}) (adapter.Aspect, error) {
+		return handler, nil
+	}
+}
+
+func FromBuilder(builder adapter.Builder) CreateAspectFunc {
+	switch b := builder.(type) {
+	case adapter.DenialsBuilder:
+		// yet `return b.NewDenialsAspect` is a compilation error.
+		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
+			return b.NewDenialsAspect(env, c)
+		}
+	case adapter.AccessLogsBuilder:
+		// yet `return b.NewDenialsAspect` is a compilation error.
+		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
+			return b.NewAccessLogsAspect(env, c)
+		}
+	case adapter.ApplicationLogsBuilder:
+		// yet `return b.NewDenialsAspect` is a compilation error.
+		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
+			return b.NewApplicationLogsAspect(env, c)
+		}
+	case adapter.AttributesGeneratorBuilder:
+		// yet `return b.NewDenialsAspect` is a compilation error.
+		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
+			return b.BuildAttributesGenerator(env, c)
+		}
+	case adapter.ListsBuilder:
+		// yet `return b.NewDenialsAspect` is a compilation error.
+		return func(env adapter.Env, c adapter.Config, _ ...interface{}) (adapter.Aspect, error) {
+			return b.NewListsAspect(env, c)
+		}
+	case adapter.MetricsBuilder:
+		// yet `return b.NewDenialsAspect` is a compilation error.
+		return func(env adapter.Env, c adapter.Config, cfg ...interface{}) (adapter.Aspect, error) {
+			if len(cfg) < 1 {
+				return nil, fmt.Errorf("metric builders must have configuration args.")
+			}
+			metrics, ok := cfg[0].(map[string]*adapter.MetricDefinition)
+			if !ok {
+				return nil, fmt.Errorf("arg to metrics builder must be a map[string]*adapter.MetricDefinition, got: %#v", cfg[0])
+			}
+			return b.NewMetricsAspect(env, c, metrics)
+		}
+	case adapter.QuotasBuilder:
+		// yet `return b.NewDenialsAspect` is a compilation error.
+		return func(env adapter.Env, c adapter.Config, cfg ...interface{}) (adapter.Aspect, error) {
+			if len(cfg) < 1 {
+				return nil, fmt.Errorf("quota builders must have configuration args.")
+			}
+			quotas, ok := cfg[0].(map[string]*adapter.QuotaDefinition)
+			if !ok {
+				return nil, fmt.Errorf("arg to quota builder must be a map[string]*adapter.QuotaDefinition, got: %#v", cfg[0])
+			}
+			return b.NewQuotasAspect(env, c, quotas)
+		}
+	default:
+		// TODO: should we do something stronger here, or maybe change this func to return `(CreateAspectFunc, error)`?
+		return func(adapter.Env, adapter.Config, ...interface{}) (adapter.Aspect, error) {
+			return nil, fmt.Errorf("Invalid builder type: %#v", builder)
+		}
+	}
+}
 
 func evalAll(expressions map[string]string, attrs attribute.Bag, eval expr.Evaluator) (map[string]interface{}, error) {
 	result := &multierror.Error{}

--- a/pkg/aspect/common.go
+++ b/pkg/aspect/common.go
@@ -84,7 +84,7 @@ func FromBuilder(builder adapter.Builder, kind cfg.Kind) (CreateAspectFunc, erro
 			return nil, fmt.Errorf("invalid builder - kind MetricsKind expected builder implementing MetricsBuilder, got builder: %v", builder)
 		}
 		return func(env adapter.Env, c adapter.Config, cfg ...interface{}) (adapter.Aspect, error) {
-			if len(cfg) < 1 {
+			if len(cfg) != 1 {
 				return nil, fmt.Errorf("metric builders must have configuration args")
 			}
 			metrics, ok := cfg[0].(map[string]*adapter.MetricDefinition)
@@ -99,7 +99,7 @@ func FromBuilder(builder adapter.Builder, kind cfg.Kind) (CreateAspectFunc, erro
 			return nil, fmt.Errorf("invalid builder - kind QuotasKind expected builder implementing QuotasBuilder, go buildert: %v", builder)
 		}
 		return func(env adapter.Env, c adapter.Config, cfg ...interface{}) (adapter.Aspect, error) {
-			if len(cfg) < 1 {
+			if len(cfg) != 1 {
 				return nil, fmt.Errorf("quota builders must have configuration args")
 			}
 			quotas, ok := cfg[0].(map[string]*adapter.QuotaDefinition)

--- a/pkg/aspect/denialsManager_test.go
+++ b/pkg/aspect/denialsManager_test.go
@@ -59,7 +59,8 @@ func TestDenialsManager_NewCheckExecutor(t *testing.T) {
 	}
 
 	dm := newDenialsManager()
-	if _, err := dm.NewCheckExecutor(defaultCfg, FromBuilder(newBuilder(false)), test.Env{}, nil); err != nil {
+	f, _ := FromBuilder(newBuilder(false), config.DenialsKind)
+	if _, err := dm.NewCheckExecutor(defaultCfg, f, test.Env{}, nil); err != nil {
 		t.Errorf("NewCheckExecutor() returned an unexpected error: %v", err)
 	}
 }
@@ -70,7 +71,8 @@ func TestDenialsManager_NewCheckExecutorErrors(t *testing.T) {
 	}
 
 	dm := newDenialsManager()
-	if _, err := dm.NewCheckExecutor(defaultCfg, FromBuilder(newBuilder(true)), test.Env{}, nil); err == nil {
+	f, _ := FromBuilder(newBuilder(true), config.DenialsKind)
+	if _, err := dm.NewCheckExecutor(defaultCfg, f, test.Env{}, nil); err == nil {
 		t.Error("NewCheckExecutor() should have propogated error.")
 	}
 }

--- a/pkg/aspect/denialsManager_test.go
+++ b/pkg/aspect/denialsManager_test.go
@@ -59,7 +59,7 @@ func TestDenialsManager_NewCheckExecutor(t *testing.T) {
 	}
 
 	dm := newDenialsManager()
-	if _, err := dm.NewCheckExecutor(defaultCfg, newBuilder(false), test.Env{}, nil); err != nil {
+	if _, err := dm.NewCheckExecutor(defaultCfg, FromBuilder(newBuilder(false)), test.Env{}, nil); err != nil {
 		t.Errorf("NewCheckExecutor() returned an unexpected error: %v", err)
 	}
 }
@@ -70,7 +70,7 @@ func TestDenialsManager_NewCheckExecutorErrors(t *testing.T) {
 	}
 
 	dm := newDenialsManager()
-	if _, err := dm.NewCheckExecutor(defaultCfg, newBuilder(true), test.Env{}, nil); err == nil {
+	if _, err := dm.NewCheckExecutor(defaultCfg, FromBuilder(newBuilder(true)), test.Env{}, nil); err == nil {
 		t.Error("NewCheckExecutor() should have propogated error.")
 	}
 }

--- a/pkg/aspect/listsManager.go
+++ b/pkg/aspect/listsManager.go
@@ -45,13 +45,14 @@ func newListsManager() CheckManager {
 }
 
 // NewCheckExecutor creates a listChecker aspect.
-func (listsManager) NewCheckExecutor(cfg *cpb.Combined, ga adapter.Builder, env adapter.Env, df descriptor.Finder) (CheckExecutor, error) {
-	aa := ga.(adapter.ListsBuilder)
-	var asp adapter.ListsAspect
-	var err error
-
-	if asp, err = aa.NewListsAspect(env, cfg.Builder.Params.(config.AspectParams)); err != nil {
+func (listsManager) NewCheckExecutor(cfg *cpb.Combined, createAspect CreateAspectFunc, env adapter.Env, df descriptor.Finder) (CheckExecutor, error) {
+	out, err := createAspect(env, cfg.Builder.Params.(config.AspectParams))
+	if err != nil {
 		return nil, err
+	}
+	asp, ok := out.(adapter.ListsAspect)
+	if !ok {
+		return nil, fmt.Errorf("wrong aspect type returned after creation; expected ListsAspect: %#v", out)
 	}
 	return &listsExecutor{
 		aspect: asp,

--- a/pkg/aspect/listsManager_test.go
+++ b/pkg/aspect/listsManager_test.go
@@ -103,7 +103,8 @@ func TestListsManager_NewCheckExecutor(t *testing.T) {
 	}
 
 	lm := newListsManager()
-	if _, err := lm.NewCheckExecutor(defaultCfg, FromBuilder(newListsBuilder(false)), test.Env{}, nil); err != nil {
+	f, _ := FromBuilder(newListsBuilder(false), config.ListsKind)
+	if _, err := lm.NewCheckExecutor(defaultCfg, f, test.Env{}, nil); err != nil {
 		t.Errorf("NewCheckExecutor() returned an unexpected error: %v", err)
 	}
 }
@@ -115,7 +116,8 @@ func TestListsManager_NewCheckExecutorErrors(t *testing.T) {
 	}
 
 	lm := newListsManager()
-	if _, err := lm.NewCheckExecutor(defaultCfg, FromBuilder(newListsBuilder(true)), test.Env{}, nil); err == nil {
+	f, _ := FromBuilder(newListsBuilder(true), config.ListsKind)
+	if _, err := lm.NewCheckExecutor(defaultCfg, f, test.Env{}, nil); err == nil {
 		t.Error("NewCheckExecutor() should have returned an error")
 	}
 }

--- a/pkg/aspect/listsManager_test.go
+++ b/pkg/aspect/listsManager_test.go
@@ -103,7 +103,7 @@ func TestListsManager_NewCheckExecutor(t *testing.T) {
 	}
 
 	lm := newListsManager()
-	if _, err := lm.NewCheckExecutor(defaultCfg, newListsBuilder(false), test.Env{}, nil); err != nil {
+	if _, err := lm.NewCheckExecutor(defaultCfg, FromBuilder(newListsBuilder(false)), test.Env{}, nil); err != nil {
 		t.Errorf("NewCheckExecutor() returned an unexpected error: %v", err)
 	}
 }
@@ -115,7 +115,7 @@ func TestListsManager_NewCheckExecutorErrors(t *testing.T) {
 	}
 
 	lm := newListsManager()
-	if _, err := lm.NewCheckExecutor(defaultCfg, newListsBuilder(true), test.Env{}, nil); err == nil {
+	if _, err := lm.NewCheckExecutor(defaultCfg, FromBuilder(newListsBuilder(true)), test.Env{}, nil); err == nil {
 		t.Error("NewCheckExecutor() should have returned an error")
 	}
 }

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -32,6 +32,8 @@ import (
 )
 
 type (
+	// CreateAspectFunc represents a function capable of returning an aspect instance.
+	// It accepts optional params that may be required for some aspects (Metrics, Quotas).
 	CreateAspectFunc func(env adapter.Env, c adapter.Config, optional ...interface{}) (adapter.Aspect, error)
 
 	// Manager is responsible for a specific aspect and presents a uniform interface

--- a/pkg/aspect/manager.go
+++ b/pkg/aspect/manager.go
@@ -32,6 +32,8 @@ import (
 )
 
 type (
+	CreateAspectFunc func(env adapter.Env, c adapter.Config, optional ...interface{}) (adapter.Aspect, error)
+
 	// Manager is responsible for a specific aspect and presents a uniform interface
 	// to the rest of the system.
 	Manager interface {
@@ -46,7 +48,7 @@ type (
 		Manager
 
 		// NewCheckExecutor creates a new aspect executor given configuration.
-		NewCheckExecutor(cfg *cpb.Combined, builder adapter.Builder, env adapter.Env, df descriptor.Finder) (CheckExecutor, error)
+		NewCheckExecutor(cfg *cpb.Combined, createAspect CreateAspectFunc, env adapter.Env, df descriptor.Finder) (CheckExecutor, error)
 	}
 
 	// ReportManager take care of aspects used to implement the Report API method
@@ -54,7 +56,7 @@ type (
 		Manager
 
 		// NewReportExecutor creates a new aspect executor given configuration.
-		NewReportExecutor(cfg *cpb.Combined, builder adapter.Builder, env adapter.Env, df descriptor.Finder) (ReportExecutor, error)
+		NewReportExecutor(cfg *cpb.Combined, createAspect CreateAspectFunc, env adapter.Env, df descriptor.Finder) (ReportExecutor, error)
 	}
 
 	// QuotaManager take care of aspects used to implement the Quota API method
@@ -62,7 +64,7 @@ type (
 		Manager
 
 		// NewQuotaExecutor creates a new aspect executor given configuration.
-		NewQuotaExecutor(cfg *cpb.Combined, builder adapter.Builder, env adapter.Env, df descriptor.Finder) (QuotaExecutor, error)
+		NewQuotaExecutor(cfg *cpb.Combined, createAspect CreateAspectFunc, env adapter.Env, df descriptor.Finder) (QuotaExecutor, error)
 	}
 
 	// A PreprocessManager handles adapter execution for pre-processing of
@@ -72,7 +74,7 @@ type (
 		Manager
 
 		// NewPreprocessExecutor creates a new executor given configuration.
-		NewPreprocessExecutor(cfg *cpb.Combined, builder adapter.Builder, env adapter.Env, df descriptor.Finder) (PreprocessExecutor, error)
+		NewPreprocessExecutor(cfg *cpb.Combined, createAspect CreateAspectFunc, env adapter.Env, df descriptor.Finder) (PreprocessExecutor, error)
 	}
 
 	// Executor encapsulates a single aspect and allows it to be invoked.

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -55,7 +55,7 @@ func newMetricsManager() ReportManager {
 	return &metricsManager{}
 }
 
-func (m *metricsManager) NewReportExecutor(c *cpb.Combined, createAdapater CreateAspectFunc, env adapter.Env, df descriptor.Finder) (ReportExecutor, error) {
+func (m *metricsManager) NewReportExecutor(c *cpb.Combined, createAspect CreateAspectFunc, env adapter.Env, df descriptor.Finder) (ReportExecutor, error) {
 	params := c.Aspect.Params.(*aconfig.MetricsParams)
 
 	metadata := make(map[string]*metricInfo)
@@ -71,7 +71,7 @@ func (m *metricsManager) NewReportExecutor(c *cpb.Combined, createAdapater Creat
 			labels:     metric.Labels,
 		}
 	}
-	out, err := createAdapater(env, c.Builder.Params.(adapter.Config), defs)
+	out, err := createAspect(env, c.Builder.Params.(adapter.Config), defs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct metrics aspect with config '%v': %v", c, err)
 	}

--- a/pkg/aspect/metricsManager.go
+++ b/pkg/aspect/metricsManager.go
@@ -55,7 +55,7 @@ func newMetricsManager() ReportManager {
 	return &metricsManager{}
 }
 
-func (m *metricsManager) NewReportExecutor(c *cpb.Combined, a adapter.Builder, env adapter.Env, df descriptor.Finder) (ReportExecutor, error) {
+func (m *metricsManager) NewReportExecutor(c *cpb.Combined, createAdapater CreateAspectFunc, env adapter.Env, df descriptor.Finder) (ReportExecutor, error) {
 	params := c.Aspect.Params.(*aconfig.MetricsParams)
 
 	metadata := make(map[string]*metricInfo)
@@ -71,12 +71,15 @@ func (m *metricsManager) NewReportExecutor(c *cpb.Combined, a adapter.Builder, e
 			labels:     metric.Labels,
 		}
 	}
-	b := a.(adapter.MetricsBuilder)
-	asp, err := b.NewMetricsAspect(env, c.Builder.Params.(adapter.Config), defs)
+	out, err := createAdapater(env, c.Builder.Params.(adapter.Config), defs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct metrics aspect with config '%v': %v", c, err)
 	}
-	return &metricsExecutor{b.Name(), asp, metadata}, nil
+	asp, ok := out.(adapter.MetricsAspect)
+	if !ok {
+		return nil, fmt.Errorf("wrong aspect type returned after creation; expected MetricsAspect: %#v", out)
+	}
+	return &metricsExecutor{c.Builder.Name, asp, metadata}, nil
 }
 
 func (*metricsManager) Kind() config.Kind                  { return config.MetricsKind }

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -130,7 +130,7 @@ func TestMetricsManager_NewAspect(t *testing.T) {
 	builder := &fakeBuilder{name: "test", body: func() (adapter.MetricsAspect, error) {
 		return &fakeaspect{body: func([]adapter.Value) error { return nil }}, nil
 	}}
-	if _, err := newMetricsManager().NewReportExecutor(conf, builder, atest.NewEnv(t), df); err != nil {
+	if _, err := newMetricsManager().NewReportExecutor(conf, FromBuilder(builder), atest.NewEnv(t), df); err != nil {
 		t.Errorf("NewExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -251,7 +251,7 @@ func TestMetricsManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.MetricsAspect, error) {
 			return nil, errors.New(errString)
 		}}
-	_, err := newMetricsManager().NewReportExecutor(conf, builder, atest.NewEnv(t), df)
+	_, err := newMetricsManager().NewReportExecutor(conf, FromBuilder(builder), atest.NewEnv(t), df)
 	if err == nil {
 		t.Error("newMetricsManager().NewReportExecutor(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}

--- a/pkg/aspect/metricsManager_test.go
+++ b/pkg/aspect/metricsManager_test.go
@@ -130,7 +130,8 @@ func TestMetricsManager_NewAspect(t *testing.T) {
 	builder := &fakeBuilder{name: "test", body: func() (adapter.MetricsAspect, error) {
 		return &fakeaspect{body: func([]adapter.Value) error { return nil }}, nil
 	}}
-	if _, err := newMetricsManager().NewReportExecutor(conf, FromBuilder(builder), atest.NewEnv(t), df); err != nil {
+	f, _ := FromBuilder(builder, config.MetricsKind)
+	if _, err := newMetricsManager().NewReportExecutor(conf, f, atest.NewEnv(t), df); err != nil {
 		t.Errorf("NewExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -251,7 +252,8 @@ func TestMetricsManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.MetricsAspect, error) {
 			return nil, errors.New(errString)
 		}}
-	_, err := newMetricsManager().NewReportExecutor(conf, FromBuilder(builder), atest.NewEnv(t), df)
+	f, _ := FromBuilder(builder, config.MetricsKind)
+	_, err := newMetricsManager().NewReportExecutor(conf, f, atest.NewEnv(t), df)
 	if err == nil {
 		t.Error("newMetricsManager().NewReportExecutor(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -125,7 +125,8 @@ func TestQuotasManager_NewAspect(t *testing.T) {
 		Builder: &cfgpb.Adapter{Params: &aconfig.QuotasParams{}},
 	}
 
-	if _, err := newQuotasManager().NewQuotaExecutor(conf, FromBuilder(builder), atest.NewEnv(t), df); err != nil {
+	f, _ := FromBuilder(builder, config.QuotasKind)
+	if _, err := newQuotasManager().NewQuotaExecutor(conf, f, atest.NewEnv(t), df); err != nil {
 		t.Fatalf("NewExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -141,7 +142,8 @@ func TestQuotasManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.QuotasAspect, error) {
 			return nil, errors.New(errString)
 		}}
-	_, err := newQuotasManager().NewQuotaExecutor(conf, FromBuilder(builder), atest.NewEnv(t), nil)
+	f, _ := FromBuilder(builder, config.QuotasKind)
+	_, err := newQuotasManager().NewQuotaExecutor(conf, f, atest.NewEnv(t), nil)
 	if err == nil {
 		t.Error("newQuotasManager().NewExecutor(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}

--- a/pkg/aspect/quotasManager_test.go
+++ b/pkg/aspect/quotasManager_test.go
@@ -125,7 +125,7 @@ func TestQuotasManager_NewAspect(t *testing.T) {
 		Builder: &cfgpb.Adapter{Params: &aconfig.QuotasParams{}},
 	}
 
-	if _, err := newQuotasManager().NewQuotaExecutor(conf, builder, atest.NewEnv(t), df); err != nil {
+	if _, err := newQuotasManager().NewQuotaExecutor(conf, FromBuilder(builder), atest.NewEnv(t), df); err != nil {
 		t.Fatalf("NewExecutor(conf, builder, test.NewEnv(t)) = _, %v; wanted no err", err)
 	}
 }
@@ -141,7 +141,7 @@ func TestQuotasManager_NewAspect_PropagatesError(t *testing.T) {
 		body: func() (adapter.QuotasAspect, error) {
 			return nil, errors.New(errString)
 		}}
-	_, err := newQuotasManager().NewQuotaExecutor(conf, builder, atest.NewEnv(t), nil)
+	_, err := newQuotasManager().NewQuotaExecutor(conf, FromBuilder(builder), atest.NewEnv(t), nil)
 	if err == nil {
 		t.Error("newQuotasManager().NewExecutor(conf, builder, test.NewEnv(t)) = _, nil; wanted err")
 	}

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -47,16 +47,18 @@ type mtest struct {
 }
 
 type fakelistener struct {
-	called int
-	rt     Resolver
-	df     descriptor.Finder
+	called   int
+	rt       Resolver
+	df       descriptor.Finder
+	handlers map[string]*HandlerInfo
 	sync.Mutex
 }
 
-func (f *fakelistener) ConfigChange(cfg Resolver, df descriptor.Finder) {
+func (f *fakelistener) ConfigChange(cfg Resolver, df descriptor.Finder, handlers map[string]*HandlerInfo) {
 	f.Lock()
 	f.rt = cfg
 	f.df = df
+	f.handlers = handlers
 	f.called++
 	f.Unlock()
 }

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -164,8 +164,8 @@ type (
 
 	// HandlerInfo stores validated and configured Handlers.
 	HandlerInfo struct {
-		instance       *config.Handler
-		adapterName    string
+		Instance       config.Handler
+		Name           string
 		supportedTmpls []string
 	}
 )
@@ -423,7 +423,7 @@ func (p *validator) validateRules(rules []*pb.Rule, path string) (ce *adapter.Co
 			for _, instName := range aa.GetInstances() {
 				if p.ctors[instName] == nil {
 					hasError = true
-					ce = ce.Appendf(fmt.Sprintf("%s[%d]", path, idx), "instance '%s' is not defined.", instName)
+					ce = ce.Appendf(fmt.Sprintf("%s[%d]", path, idx), "Instance '%s' is not defined.", instName)
 					continue
 				}
 				validInsts = append(validInsts, instName)
@@ -616,7 +616,7 @@ func (p *validator) buildHandlers() (ce *adapter.ConfigErrors) {
 		// error has happened, we need to close the already built handlers since they might have
 		// established connection to back-ends during the build() call.
 		for name, hndlr := range p.validated.handlers {
-			err := (*(hndlr.instance)).Close()
+			err := hndlr.Instance.Close()
 			rce = rce.Appendf("handlerConfig: "+name, "Failed to close the handler: %v", err)
 		}
 		return ce.Appendf("handlerConfig", "failed to build handlers").Extend(rce)
@@ -649,8 +649,8 @@ func (p *validator) buildHandler(builder *HandlerBuilderInfo, handler string) (c
 	}
 
 	p.validated.handlers[handler] = &HandlerInfo{
-		adapterName:    builder.handlerCnfg.GetAdapter(),
-		instance:       &instance,
+		Name:           builder.handlerCnfg.GetAdapter(),
+		Instance:       instance,
 		supportedTmpls: builder.supportedTemplates,
 	}
 

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -423,7 +423,7 @@ func (p *validator) validateRules(rules []*pb.Rule, path string) (ce *adapter.Co
 			for _, instName := range aa.GetInstances() {
 				if p.ctors[instName] == nil {
 					hasError = true
-					ce = ce.Appendf(fmt.Sprintf("%s[%d]", path, idx), "Instance '%s' is not defined.", instName)
+					ce = ce.Appendf(fmt.Sprintf("%s[%d]", path, idx), "instance '%s' is not defined.", instName)
 					continue
 				}
 				validInsts = append(validInsts, instName)

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -955,7 +955,7 @@ func TestBuildHandlers(t *testing.T) {
 
 				if tt.closeMtdCalled {
 					for _, hndlr := range p.validated.handlers {
-						var h interface{} = *(hndlr.instance)
+						var h interface{} = hndlr.Instance
 						if !h.(*fakeGoodHndlr).closeMtdCalled {
 							t.Errorf("got handler.Close method called = %t, want %t", false, true)
 						}
@@ -1089,7 +1089,7 @@ action_rules:
 			2,
 			map[string]*pb.Constructor{},
 			map[string]*HandlerBuilderInfo{},
-			[]string{"handler not specified or is invalid", "instance 'RequestCountByService' is not defined"},
+			[]string{"handler not specified or is invalid", "Instance 'RequestCountByService' is not defined"},
 			0,
 			evaluator,
 		},

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -1089,7 +1089,7 @@ action_rules:
 			2,
 			map[string]*pb.Constructor{},
 			map[string]*HandlerBuilderInfo{},
-			[]string{"handler not specified or is invalid", "Instance 'RequestCountByService' is not defined"},
+			[]string{"handler not specified or is invalid", "instance 'RequestCountByService' is not defined"},
 			0,
 			evaluator,
 		},


### PR DESCRIPTION
This PR allows new adapter model Handlers to be called by the existing adapterManager dispatch code. It accomplishes this by abstracting over aspect creation (the new `aspect.CreateAspectFunc` type), and in `adapterManager/manager.go` checking whether the resolved config references either a builder (old style) or a handler (new style). It then constructs a `CreateAspectFunc` from the builder or handler.

In order to test the new behavior, I needed an `adapter.Builder` instance implementing many Aspect interfaces; as a result the `adapter/noop.Builder` struct is now public. Due to changing our core Aspect interfaces I wound up having to touch a lot of files; most of the changes are not significant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/938)
<!-- Reviewable:end -->
