### PR TITLE
Add command line main wrapper code for mixer plumbing codegen

### DIFF
--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/golang/glog"
 	rpc "github.com/googleapis/googleapis/google/rpc"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	legacyContext "golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/tools/codegen/cmd/mixgenbootstrap/BUILD
+++ b/tools/codegen/cmd/mixgenbootstrap/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "mixgenbootstrap",
+    srcs = [
+        "main.go",
+    ],
+    deps = [
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)

--- a/tools/codegen/cmd/mixgenbootstrap/BUILD
+++ b/tools/codegen/cmd/mixgenbootstrap/BUILD
@@ -8,6 +8,7 @@ go_binary(
         "main.go",
     ],
     deps = [
+        "//tools/codegen/pkg/bootstrapgen:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/tools/codegen/cmd/mixgenbootstrap/main.go
+++ b/tools/codegen/cmd/mixgenbootstrap/main.go
@@ -1,0 +1,82 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func withArgs(args []string, errorf func(format string, a ...interface{})) {
+
+	var outFilePath string
+	var mappings []string
+
+	// TODO add support for passing import mapping for individual template. For now, this tool just takes
+	// single import mapping which applies to all the passed in templates.
+
+	rootCmd := cobra.Command{
+		Use: "mixgenbootstrap <list of file descriptor set protobufs>",
+		Short: "Parses all the [Templates](http://TODO), defined in each of the input file descriptor set, and generates" +
+			" the required Go file that mixer framework will be compiled with to add support for the pass in templates.",
+		Long: "Each of the input <File descriptor set protobuf> must contain a proto file that defines the template.\n" +
+			"This code generator is meant to be used for creating a new mixer build. The output file suppose to be integrated \n" +
+			"in the mixers build system.\n" +
+			"Example: mixgenbootstrap metricTemplateFileDescriptorSet.pb quotaTemplateFileDescriptorSet.pb quotaTemplateFileDescriptorSet.pb -o template.gen.go",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			if len(args) <= 0 {
+				errorf("Must specify at least one file descriptor set protobuf file.")
+			}
+
+			outFileFullPath, err := filepath.Abs(outFilePath)
+			if err != nil {
+				errorf("Invalid path %s. %v", outFilePath, err)
+			}
+			importMapping := make(map[string]string)
+			for _, maps := range mappings {
+				m := strings.Split(maps, ":")
+				importMapping[strings.TrimSpace(m[0])] = strings.TrimSpace(m[1])
+			}
+			fmt.Println(outFileFullPath, importMapping, args)
+		},
+	}
+
+	rootCmd.SetArgs(args)
+
+	rootCmd.PersistentFlags().StringVarP(&outFilePath, "output", "o", "./template.gen.go", "Output "+
+		"path for generated Go source file.")
+
+	rootCmd.PersistentFlags().StringArrayVarP(&mappings, "importmapping",
+		"m", []string{},
+		"colon separated mapping of proto import to Go package names."+
+			" -m google/protobuf/descriptor.proto:github.com/golang/protobuf/protoc-gen-go/descriptor")
+
+	if err := rootCmd.Execute(); err != nil {
+		errorf("%v", err)
+	}
+}
+
+func main() {
+	withArgs(os.Args[1:],
+		func(format string, a ...interface{}) {
+			fmt.Fprintf(os.Stderr, format+"\n", a...)
+			os.Exit(1)
+		})
+}

--- a/tools/codegen/cmd/mixgenbootstrap/main.go
+++ b/tools/codegen/cmd/mixgenbootstrap/main.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"istio.io/mixer/tools/codegen/pkg/bootstrapgen"
 )
 
 func withArgs(args []string, errorf func(format string, a ...interface{})) {
@@ -37,7 +39,7 @@ func withArgs(args []string, errorf func(format string, a ...interface{})) {
 			" the required Go file that mixer framework will be compiled with to add support for the pass in templates.",
 		Long: "Each of the input <File descriptor set protobuf> must contain a proto file that defines the template.\n" +
 			"This code generator is meant to be used for creating a new mixer build. The output file suppose to be integrated \n" +
-			"in the mixers build system.\n" +
+			"in the mixer's build system.\n" +
 			"Example: mixgenbootstrap metricTemplateFileDescriptorSet.pb quotaTemplateFileDescriptorSet.pb quotaTemplateFileDescriptorSet.pb -o template.gen.go",
 		Run: func(cmd *cobra.Command, args []string) {
 
@@ -54,7 +56,11 @@ func withArgs(args []string, errorf func(format string, a ...interface{})) {
 				m := strings.Split(maps, ":")
 				importMapping[strings.TrimSpace(m[0])] = strings.TrimSpace(m[1])
 			}
-			fmt.Println(outFileFullPath, importMapping, args)
+
+			generator := bootstrapgen.Generator{OutFilePath: outFileFullPath, ImportMapping: importMapping}
+			if err := generator.Generate(args); err != nil {
+				errorf("%v", err)
+			}
 		},
 	}
 

--- a/tools/codegen/pkg/bootstrapgen/BUILD
+++ b/tools/codegen/pkg/bootstrapgen/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "generator.go",
+    ],
+)

--- a/tools/codegen/pkg/bootstrapgen/generator.go
+++ b/tools/codegen/pkg/bootstrapgen/generator.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrapgen
+
+import (
+	"os"
+)
+
+// Generator creates a Go file that will be build inside mixer framework. The generated file contains all the
+// template specific code that mixer needs to add support for different passed in templates.
+type Generator struct {
+	OutFilePath   string
+	ImportMapping map[string]string
+}
+
+// Generate creates a Go file that will be build inside mixer framework. The generated file contains all the
+// template specific code that mixer needs to add support for different passed in templates.
+func (g *Generator) Generate(fdsFiles []string) error {
+
+	// TODO Complete the imlementation here.. Next PR.
+	// ..
+
+	f1, err := os.Create(g.OutFilePath)
+	if err != nil {
+		return err
+	}
+	defer f1.Close()
+	if _, err = f1.Write([]byte{}); err != nil {
+		_ = f1.Close()
+		_ = os.Remove(f1.Name())
+		return err
+	}
+
+	return nil
+}

--- a/tools/codegen/pkg/bootstrapgen/generator.go
+++ b/tools/codegen/pkg/bootstrapgen/generator.go
@@ -27,7 +27,7 @@ type Generator struct {
 
 // Generate creates a Go file that will be build inside mixer framework. The generated file contains all the
 // template specific code that mixer needs to add support for different passed in templates.
-func (g *Generator) Generate(fdsFiles []string) error {
+func (g *Generator) Generate(_ []string) error {
 
 	// TODO Complete the imlementation here.. Next PR.
 	// ..
@@ -36,7 +36,7 @@ func (g *Generator) Generate(fdsFiles []string) error {
 	if err != nil {
 		return err
 	}
-	defer f1.Close()
+	defer func() { _ = f1.Close() }()
 	if _, err = f1.Write([]byte{}); err != nil {
 		_ = f1.Close()
 		_ = os.Remove(f1.Name())


### PR DESCRIPTION
Small PR that defines how the commandline will look for the code generation tool that is responsible for generating code to wire templates in mixer framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/944)
<!-- Reviewable:end -->
