### PR TITLE
Cleanup codegen ViewModel by moving type manipulation logic into the view rendering

### DIFF
--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -88,8 +88,8 @@ func TestNewBadRequest(t *testing.T) {
 		err   error
 		want  *rpc.BadRequest
 	}{
-		{"simple error", "field", errors.New("error"), newBadReq(newViolation("field", "error"))},
-		{"go-multierror", "field", me, newBadReq(newViolation("field", "error one"), newViolation("field", "error two"))},
+		{"simple error", "field", errors.New("error"), newBadReq(newViolation("error"))},
+		{"go-multierror", "field", me, newBadReq(newViolation("error one"), newViolation("error two"))},
 	}
 	for _, v := range cases {
 		t.Run(v.name, func(t *testing.T) {
@@ -101,8 +101,8 @@ func TestNewBadRequest(t *testing.T) {
 	}
 }
 
-func newViolation(field, desc string) *rpc.BadRequest_FieldViolation {
-	return &rpc.BadRequest_FieldViolation{Field: field, Description: desc}
+func newViolation(desc string) *rpc.BadRequest_FieldViolation {
+	return &rpc.BadRequest_FieldViolation{Field: "field", Description: desc}
 }
 
 func newBadReq(violations ...*rpc.BadRequest_FieldViolation) *rpc.BadRequest {

--- a/tools/codegen/pkg/interfacegen/generator.go
+++ b/tools/codegen/pkg/interfacegen/generator.go
@@ -20,6 +20,7 @@ import (
 	"go/format"
 	"io/ioutil"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/gogo/protobuf/proto"
@@ -37,10 +38,18 @@ type Generator struct {
 	ImptMap            map[string]string
 }
 
+const fullProtoNameOfValueTypeEnum = "istio.mixer.v1.config.descriptor.ValueType"
+const fullGoNameOfValueTypeEnum = "istio_mixer_v1_config_descriptor.ValueType"
+
 // Generate creates a Go interfaces for adapters to implement for a given Template.
 func (g *Generator) Generate(fdsFile string) error {
 
-	intfaceTmpl, err := template.New("ProcInterface").Parse(tmpl.InterfaceTemplate)
+	intfaceTmpl, err := template.New("ProcInterface").Funcs(
+		template.FuncMap{
+			"replaceGoValueTypeToInterface": func(typeName string) string {
+				return strings.Replace(typeName, fullGoNameOfValueTypeEnum, "interface{}", 1)
+			},
+		}).Parse(tmpl.InterfaceTemplate)
 	if err != nil {
 		return fmt.Errorf("cannot load template: %v", err)
 	}
@@ -50,7 +59,7 @@ func (g *Generator) Generate(fdsFile string) error {
 		return fmt.Errorf("cannot parse file '%s' as a FileDescriptorSetProto: %v", fdsFile, err)
 	}
 
-	parser, err := modelgen.CreateFileDescriptorSetParser(fds, g.ImptMap)
+	parser, err := modelgen.CreateFileDescriptorSetParser(fds, g.ImptMap, "")
 	if err != nil {
 		return fmt.Errorf("cannot parse file '%s' as a FileDescriptorSetProto: %v", fdsFile, err)
 	}
@@ -78,7 +87,22 @@ func (g *Generator) Generate(fdsFile string) error {
 		return fmt.Errorf("could not fix imports for generated code: %v", err)
 	}
 
-	revisedTemplateTmpl, err := template.New("RevisedTemplateTmpl").Parse(tmpl.RevisedTemplateTmpl)
+	revisedTemplateTmpl, err := template.New("RevisedTemplateTmpl").Funcs(
+		template.FuncMap{
+			"replacePrimitiveToValueType": func(typeName string) string {
+				// transform the primitives into ValueType
+				// We only support primitives that can be represented as ValueTypes, ValueType itself, or map<string, ValueType>.
+				// So, if the fields is not a map, it's type should be converted into ValueType inside the generated Type Message.
+				if !strings.Contains(typeName, "map<") {
+					typeName = fullProtoNameOfValueTypeEnum
+				}
+				return typeName
+			},
+			"replaceValueTypeToString": func(typeName string) string {
+				return strings.Replace(typeName, fullProtoNameOfValueTypeEnum, "string", 1)
+			},
+			// strings.Replace(typename, fullProtoNameOfValueTypeEnum, "string", 1)
+		}).Parse(tmpl.RevisedTemplateTmpl)
 	if err != nil {
 		return fmt.Errorf("cannot load template: %v", err)
 	}

--- a/tools/codegen/pkg/interfacegen/generator.go
+++ b/tools/codegen/pkg/interfacegen/generator.go
@@ -118,7 +118,7 @@ func (g *Generator) Generate(fdsFile string) error {
 	if err != nil {
 		return err
 	}
-	defer f1.Close()
+	defer func() { _ = f1.Close() }()
 
 	if _, err = f1.Write(imptd); err != nil {
 		_ = f1.Close()
@@ -130,7 +130,7 @@ func (g *Generator) Generate(fdsFile string) error {
 	if err != nil {
 		return err
 	}
-	defer f2.Close()
+	defer func() { _ = f2.Close() }()
 	if _, err = f2.Write(tmplBuf.Bytes()); err != nil {
 		_ = f2.Close()
 		_ = os.Remove(f2.Name())

--- a/tools/codegen/pkg/interfacegen/template/interface.go
+++ b/tools/codegen/pkg/interfacegen/template/interface.go
@@ -28,8 +28,8 @@ const TemplateName = "{{.PackageName}}.{{.Name}}"
 
 type Instance struct {
   Name string
-  {{range .InstanceStruct.Fields}}
-  {{.Name}} {{.Type.Name}}
+  {{range .TemplateMessage.Fields}}
+  {{.GoName}} {{replaceGoValueTypeToInterface .GoType}}
   {{end}}
 }
 

--- a/tools/codegen/pkg/interfacegen/template/templateproto.go
+++ b/tools/codegen/pkg/interfacegen/template/templateproto.go
@@ -28,14 +28,14 @@ option (istio.mixer.v1.config.template.template_variety) = {{.VarietyName}};
 option (istio.mixer.v1.config.template.template_name) = "{{.Name}}";
 
 message Type {
-  {{range .TypeMessage.Fields}}
-  {{.Type.Name}} {{.Name}} = {{.Number}};
+  {{range .TemplateMessage.Fields}}
+  {{replacePrimitiveToValueType .Type}} {{.Name}} = {{.Number}};
   {{end}}
 }
 
 message ConstructorParam {
-  {{range .ConstructorParamMessage.Fields}}
-  {{.Type.Name}} {{.Name}} = {{.Number}};
+  {{range .TemplateMessage.Fields}}
+  {{replaceValueTypeToString .Type}} {{.Name}} = {{.Number}};
   {{end}}
 }
 `

--- a/tools/codegen/pkg/modelgen/diag.go
+++ b/tools/codegen/pkg/modelgen/diag.go
@@ -80,17 +80,13 @@ func stringifyDiags(diags []diag) string {
 }
 
 func (m *Model) addError(file string, line string, format string, a ...interface{}) {
-	m.addDiag(errorDiag, file, line, format, a)
+	m.diags = append(m.diags, createError(file, line, format, a))
 }
 
-func (m *Model) addDiag(kind diagKind, file string, line string, format string, a []interface{}) {
-	m.diags = append(m.diags, createDiag(kind, file, line, format, a))
-}
-
-func createDiag(kind diagKind, file string, line string, format string, a []interface{}) diag {
+func createError(file string, line string, format string, a []interface{}) diag {
 	if len(a) == 0 {
-		return diag{kind: kind, location: location{file: file, line: line}, message: format}
+		return diag{kind: errorDiag, location: location{file: file, line: line}, message: format}
 	}
 
-	return diag{kind: kind, location: location{file: file, line: line}, message: fmt.Sprintf(format, a...)}
+	return diag{kind: errorDiag, location: location{file: file, line: line}, message: fmt.Sprintf(format, a...)}
 }

--- a/tools/codegen/pkg/modelgen/model.go
+++ b/tools/codegen/pkg/modelgen/model.go
@@ -121,7 +121,13 @@ func (m *Model) addTemplateMessage(parser *FileDescriptorSetParser, templateProt
 				templateProto.getLineNumber(getPathForField(tmplDesc, i)),
 				err.Error())
 		}
-		m.TemplateMessage.Fields = append(m.TemplateMessage.Fields, fieldInfo{Name: fieldName, GoName: camelCase(fieldName), GoType: parser.goType(tmplDesc.DescriptorProto, fieldDesc), Type: typename, Number: strconv.FormatInt(int64(fieldDesc.GetNumber()), 10)})
+		m.TemplateMessage.Fields = append(m.TemplateMessage.Fields, fieldInfo{
+			Name: fieldName,
+			GoName: camelCase(fieldName),
+			GoType: parser.goType(tmplDesc.DescriptorProto, fieldDesc),
+			Type: typename,
+			Number: strconv.FormatInt(int64(fieldDesc.GetNumber()), 10),
+		})
 	}
 }
 

--- a/tools/codegen/pkg/modelgen/model_test.go
+++ b/tools/codegen/pkg/modelgen/model_test.go
@@ -82,18 +82,19 @@ func TestTypeFields(t *testing.T) {
 	if len(model.TemplateMessage.Fields) != 3 {
 		t.Fatalf("len(CreateModel(%s).TypeMessage.Fields) = %v, wanted %d", testFilename, len(model.TemplateMessage.Fields), 3)
 	}
-	testField(t, testFilename, model.TemplateMessage.Fields,
+	testField(t, model.TemplateMessage.Fields,
 		"blacklist", "bool", "Blacklist", "bool")
-	testField(t, testFilename, model.TemplateMessage.Fields,
+	testField(t, model.TemplateMessage.Fields,
 		"val", "istio.mixer.v1.config.descriptor.ValueType", "Val",
 		"istio_mixer_v1_config_descriptor.ValueType")
-	testField(t, testFilename, model.TemplateMessage.Fields,
+	testField(t, model.TemplateMessage.Fields,
 		"dimensions", "map<string, istio.mixer.v1.config.descriptor.ValueType>",
 		"Dimensions", "map[string]istio_mixer_v1_config_descriptor.ValueType")
 }
 
-func testField(t *testing.T, testFilename string, fields []fieldInfo, protoFldName string, protoFldType string,
+func testField(t *testing.T, fields []fieldInfo, protoFldName string, protoFldType string,
 	goFldName string, goFldType string) {
+	testFilename := "testdata/simple_template.descriptor_set"
 	found := false
 	for _, cf := range fields {
 		if cf.Name == protoFldName {

--- a/tools/codegen/pkg/modelgen/model_test.go
+++ b/tools/codegen/pkg/modelgen/model_test.go
@@ -49,9 +49,11 @@ func TestErrorInTemplate(t *testing.T) {
 			_, err := createTestModel(t, tt.src)
 
 			if err == nil {
-				t.Fatalf("CreateModel(%s) caused error 'nil', \n wanted err that contains string `%v`", tt.src, fmt.Errorf(tt.expectedError))
+				t.Fatalf("CreateModel(%s) caused error 'nil', \n wanted err that contains string `%v`",
+					tt.src, fmt.Errorf(tt.expectedError))
 			} else if !strings.Contains(err.Error(), tt.expectedError) {
-				t.Errorf("CreateModel(%s) caused error '%v', \n wanted err that contains string `%v`", tt.src, err, fmt.Errorf(tt.expectedError))
+				t.Errorf("CreateModel(%s) caused error '%v', \n wanted err that contains string `%v`",
+					tt.src, err, fmt.Errorf(tt.expectedError))
 			}
 		})
 	}
@@ -72,57 +74,39 @@ func TestBasicTopLevelFields(t *testing.T) {
 	}
 }
 
-func TestInstanceFields(t *testing.T) {
-	testFilename := "testdata/simple_template.descriptor_set"
-	model, _ := createTestModel(t,
-		testFilename)
-
-	if len(model.InstanceStruct.Fields) != 3 {
-		t.Fatalf("len(CreateModel(%s).InstanceStruct.Fields) = %v, wanted %d", testFilename, len(model.InstanceStruct.Fields), 3)
-	}
-	testField(t, testFilename, model.InstanceStruct.Fields, "Blacklist", "bool")
-	testField(t, testFilename, model.InstanceStruct.Fields, "Val", "interface{}")
-	testField(t, testFilename, model.InstanceStruct.Fields, "Dimensions", "map[string]interface{}")
-}
-
 func TestTypeFields(t *testing.T) {
 	testFilename := "testdata/simple_template.descriptor_set"
 	model, _ := createTestModel(t,
 		testFilename)
 
-	if len(model.TypeMessage.Fields) != 3 {
-		t.Fatalf("len(CreateModel(%s).TypeMessage.Fields) = %v, wanted %d", testFilename, len(model.TypeMessage.Fields), 3)
+	if len(model.TemplateMessage.Fields) != 3 {
+		t.Fatalf("len(CreateModel(%s).TypeMessage.Fields) = %v, wanted %d", testFilename, len(model.TemplateMessage.Fields), 3)
 	}
-	testField(t, testFilename, model.TypeMessage.Fields, "blacklist", fullProtoNameOfValueTypeEnum)
-	testField(t, testFilename, model.TypeMessage.Fields, "val", fullProtoNameOfValueTypeEnum)
-	testField(t, testFilename, model.TypeMessage.Fields, "dimensions", fmt.Sprintf("map<string, %s>", fullProtoNameOfValueTypeEnum))
+	testField(t, testFilename, model.TemplateMessage.Fields,
+		"blacklist", "bool", "Blacklist", "bool")
+	testField(t, testFilename, model.TemplateMessage.Fields,
+		"val", "istio.mixer.v1.config.descriptor.ValueType", "Val",
+		"istio_mixer_v1_config_descriptor.ValueType")
+	testField(t, testFilename, model.TemplateMessage.Fields,
+		"dimensions", "map<string, istio.mixer.v1.config.descriptor.ValueType>",
+		"Dimensions", "map[string]istio_mixer_v1_config_descriptor.ValueType")
 }
 
-func TestConstructorParamFields(t *testing.T) {
-	testFilename := "testdata/simple_template.descriptor_set"
-	model, _ := createTestModel(t,
-		testFilename)
-
-	if len(model.ConstructorParamMessage.Fields) != 3 {
-		t.Fatalf("len(CreateModel(%s).ConstructorParamMessage.Fields) = %v, wanted %d", testFilename, len(model.ConstructorParamMessage.Fields), 3)
-	}
-	testField(t, testFilename, model.ConstructorParamMessage.Fields, "blacklist", "bool")
-	testField(t, testFilename, model.ConstructorParamMessage.Fields, "val", "string")
-	testField(t, testFilename, model.ConstructorParamMessage.Fields, "dimensions", "map<string, string>")
-}
-
-func testField(t *testing.T, testFilename string, fields []fieldInfo, fldName string, expectedFldType string) {
+func testField(t *testing.T, testFilename string, fields []fieldInfo, protoFldName string, protoFldType string,
+	goFldName string, goFldType string) {
 	found := false
 	for _, cf := range fields {
-		if cf.Name == fldName {
+		if cf.Name == protoFldName {
 			found = true
-			if cf.Type.Name != expectedFldType {
-				t.Fatalf("CreateModel(%s).ConstructorFields[%s] = %s, wanted %s", testFilename, fldName, cf.Type.Name, expectedFldType)
+			if cf.GoName != goFldName || cf.Type != protoFldType || cf.GoType != goFldType {
+				t.Fatalf("Got CreateModel(%s).TemplateMessage.Fields[%s] = GoName:%s, Type:%s, GoType:%s, "+
+					"\nwanted GoName:%s, Type:%s, GoType:%s",
+					testFilename, protoFldName, cf.GoName, cf.Type, cf.GoType, goFldName, protoFldType, goFldType)
 			}
 		}
 	}
 	if !found {
-		t.Fatalf("CreateModel(%s).ConstructorFields = %v, wanted to contain field with name '%s'", testFilename, fields, fldName)
+		t.Fatalf("CreateModel(%s).TemplateMessage = %v, wanted to contain field with name '%s'", testFilename, fields, protoFldName)
 	}
 }
 
@@ -133,7 +117,7 @@ func createTestModel(t *testing.T, inputFDS string) (*Model, error) {
 
 	}
 
-	parser, _ := CreateFileDescriptorSetParser(fds, map[string]string{})
+	parser, _ := CreateFileDescriptorSetParser(fds, map[string]string{}, "")
 	return Create(parser)
 }
 

--- a/tools/codegen/pkg/modelgen/parser.go
+++ b/tools/codegen/pkg/modelgen/parser.go
@@ -33,7 +33,6 @@ package modelgen
 import (
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"unicode"
@@ -296,74 +295,12 @@ func (e *EnumDescriptor) Path() string {
 	return e.path
 }
 
-// File level methods
-
-func (d *FileDescriptor) goFileName() string {
-	name := *d.Name
-	if ext := path.Ext(name); ext == ".proto" || ext == ".protodevel" {
-		name = name[:len(name)-len(ext)]
-	}
-	name += ".pb.go"
-
-	// Does the file have a "go_package" option?
-	// If it does, it may override the filename.
-	if impPath, _, ok := d.goPackageOption(); ok && impPath != "" {
-		// Replace the existing dirname with the declared import path.
-		_, name = path.Split(name)
-		name = path.Join(impPath, name)
-		return name
-	}
-
-	return name
-}
-
-// goPackageOption interprets the file's go_package option.
-// If there is no go_package, it returns ("", "", false).
-// If there's a simple name, it returns ("", pkg, true).
-// If the option implies an import path, it returns (impPath, pkg, true).
-func (d *FileDescriptor) goPackageOption() (impPath, pkg string, ok bool) {
-	pkg = d.GetOptions().GetGoPackage()
-	if pkg == "" {
-		return
-	}
-	ok = true
-	// The presence of a slash implies there's an import path.
-	slash := strings.LastIndex(pkg, "/")
-	if slash < 0 {
-		return
-	}
-	impPath, pkg = pkg, pkg[slash+1:]
-	// A semicolon-delimited suffix overrides the package name.
-	sc := strings.IndexByte(impPath, ';')
-	if sc < 0 {
-		return
-	}
-	impPath, pkg = impPath[:sc], impPath[sc+1:]
-	return
-}
-
-func (d *FileDescriptor) packageName() string { return goPackageName(*d.FileDescriptorProto.Name) }
-
 // FileDescriptorSetParser methods
 
 func (g *FileDescriptorSetParser) fail(msgs ...string) {
 	s := strings.Join(msgs, " ")
 	fmt.Fprintln(os.Stderr, "model_generator: error:", s)
 	os.Exit(1)
-}
-
-func (g *FileDescriptorSetParser) fileOf(fd *descriptor.FileDescriptorProto) *FileDescriptor {
-	for _, file := range g.allFiles {
-		if file.FileDescriptorProto == fd {
-			return file
-		}
-	}
-	g.fail("could not find file in table:", fd.GetName())
-	return nil
-}
-
-func (g *FileDescriptorSetParser) fileByName(filename string) *FileDescriptor {
-	return g.allFilesByName[filename]
 }
 
 const (

--- a/tools/codegen/pkg/modelgen/parser.go
+++ b/tools/codegen/pkg/modelgen/parser.go
@@ -102,8 +102,8 @@ type Object interface {
 }
 
 // CreateFileDescriptorSetParser builds a FileDescriptorSetParser instance.
-func CreateFileDescriptorSetParser(fds *descriptor.FileDescriptorSet, importMap map[string]string) (*FileDescriptorSetParser, error) {
-	parser := &FileDescriptorSetParser{ImportMap: importMap}
+func CreateFileDescriptorSetParser(fds *descriptor.FileDescriptorSet, importMap map[string]string, packageImportPath string) (*FileDescriptorSetParser, error) {
+	parser := &FileDescriptorSetParser{ImportMap: importMap, PackageImportPath: packageImportPath}
 	parser.WrapTypes(fds)
 	parser.BuildTypeNameMap()
 	return parser, nil


### PR DESCRIPTION
View model (model.java) for the code generator had 3 objects that were derived from single Template message, provided by user. All three were very similar except some values were different.
These three sub objects inside model.java.Model were : InstanceStruct, TypeMessage and ConstructorParamMessage. In all three, the type of the fields were slightly different(example ValueType -> interface{} etc.). If we move the logic of manipulating the types (example ValueType -> interface{} etc.) into the rendering code, the Model becomes much simpler and we don't need separate objects for the above three constructs. We can just have one object that represents the Template message and just before rendering we do any modification we want right at the view rendering layer. 
This simplifies the model.

This PR achieves that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/954)
<!-- Reviewable:end -->
