### PR TITLE
Remove problematic alternate target service derivation

### DIFF
--- a/adapter/kubernetes/config/config.proto
+++ b/adapter/kubernetes/config/config.proto
@@ -40,6 +40,7 @@ option (gogoproto.gostring_all) = false;
 // sourceUID and the output value of pod ip, this adapter will output a map
 // that includes a key of "sourcePodIP" (assuming parameter defaults).
 message Params {
+    reserved 17;
     // next field id: 19
 
     // File path to discover kubeconfig. For in-cluster configuration,
@@ -78,14 +79,6 @@ message Params {
     //
     // Default: originUID
     string origin_uid_input_name = 5;
-
-    // Configures how the identifier for the target service is populated in
-    // the input map (if at all). When supplied, this value will be used (after
-    // successful normalization) in place of the value derived from the pod
-    // cache for the target pod in the generated map of output values.
-    //
-    // Default: targetService
-    string target_service_input_name = 17;
 
     // Configures the cluster domain name to use for service name normalization.
     //

--- a/adapter/kubernetes/kubernetes.go
+++ b/adapter/kubernetes/kubernetes.go
@@ -64,8 +64,7 @@ const (
 	desc = "Provides platform specific functionality for the kubernetes environment"
 
 	// parsing
-	kubePrefix       = "kubernetes://"
-	defaultNamespace = "default"
+	kubePrefix = "kubernetes://"
 
 	// input/output naming
 	sourceUID         = "sourceUID"
@@ -83,7 +82,6 @@ const (
 	serviceVal        = "Service"
 
 	// value extraction
-	targetService   = "targetService"
 	clusterDomain   = "svc.cluster.local"
 	podServiceLabel = "app"
 
@@ -99,7 +97,6 @@ var (
 		SourceUidInputName:      sourceUID,
 		TargetUidInputName:      targetUID,
 		OriginUidInputName:      originUID,
-		TargetServiceInputName:  targetService,
 		ClusterDomainName:       clusterDomain,
 		PodLabelForService:      podServiceLabel,
 		SourcePrefix:            sourcePrefix,
@@ -180,9 +177,6 @@ func (*builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	}
 	if len(params.PodLabelForService) == 0 {
 		ce = ce.Appendf("podLabelName", "field must be populated")
-	}
-	if len(params.TargetServiceInputName) == 0 {
-		ce = ce.Appendf("targetServiceInputName", "field must be populated")
 	}
 	if len(params.ClusterDomainName) == 0 {
 		ce = ce.Appendf("clusterDomainName", "field must be populated")
@@ -265,18 +259,6 @@ func (k *kubegen) Generate(inputs map[string]interface{}) (map[string]interface{
 		uidstr, ok := uid.(string)
 		if ok && len(uidstr) > 0 {
 			k.addValues(values, uidstr, k.params.OriginPrefix)
-		}
-	}
-	if targetSvc, found := inputs[k.params.TargetServiceInputName]; found {
-		svc, ok := targetSvc.(string)
-		if ok && len(svc) > 0 {
-			n, err := canonicalName(svc, defaultNamespace, k.params.ClusterDomainName)
-			key := valueName(k.params.TargetPrefix, k.params.ServiceValueName)
-			if err != nil {
-				k.log.Warningf("could not canonicalize target service: %v", err)
-			} else if _, ok := values[key]; !ok {
-				values[key] = n
-			}
 		}
 	}
 	return values, nil

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -9,10 +9,9 @@ rules:
   - kind: attributes
     params:
       input_expressions:
-        sourceUID: source.uid | ""
-        targetUID: target.uid | ""
-        originUID: origin.uid | ""
-        targetService: target.service | request.headers["authority"] | request.host | ""
+        sourceUID: source.uid
+        targetUID: target.uid
+        originUID: origin.uid
       attribute_bindings:
         source.ip: sourcePodIp
         source.labels: sourceLabels

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -9,9 +9,9 @@ rules:
   - kind: attributes
     params:
       input_expressions:
-        sourceUID: source.uid
-        targetUID: target.uid
-        originUID: origin.uid
+        sourceUID: source.uid | ""
+        targetUID: target.uid | ""
+        originUID: origin.uid | ""
       attribute_bindings:
         source.ip: sourcePodIp
         source.labels: sourceLabels


### PR DESCRIPTION
This PR removes the problematic code in the k8s adapter related to `targetService` derivation based on inputs other than `target.uid`.

The k8s adapter was previously taking an input named `targetService` and attempting to derive the FQDN for the target service based on this input. At best, operator config would supply the attribute `target.service` for that input, rendering the derivation useless. At worst, the operator would use a non-namespace-aware input, such as the attribute `request.host`, leading to overriding the derived FQDN with a service name in the `default` namespace (leading to incorrect application of config by Mixer).

We expect `target.uid` to always be available (and likely to have `target.service` as well). This eliminates a hard-to-debug surprise derivation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/955)
<!-- Reviewable:end -->
