### PR TITLE
Add Quota template support in codegen.

### DIFF
--- a/tools/codegen/generate.bzl
+++ b/tools/codegen/generate.bzl
@@ -33,6 +33,7 @@ mixer_gen = rule(
 )
 
 MIXER_DEPS = [
+    "//pkg/adapter:go_default_library",
     "//pkg/adapter/config:go_default_library",
     "//pkg/adapter/template:go_default_library",
     "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep

--- a/tools/codegen/pkg/interfacegen/template/interface.go
+++ b/tools/codegen/pkg/interfacegen/template/interface.go
@@ -22,6 +22,9 @@ package {{.GoPackageName}}
 
 import (
 "istio.io/mixer/pkg/adapter/config"
+{{if eq .VarietyName "TEMPLATE_VARIETY_QUOTA" -}}
+"istio.io/mixer/pkg/adapter"
+{{end}}
 )
 
 const TemplateName = "{{.PackageName}}.{{.Name}}"
@@ -42,6 +45,8 @@ type {{.Name}}Processor interface {
   config.Handler
   {{if eq .VarietyName "TEMPLATE_VARIETY_CHECK" -}}
     Check{{.Name}}(instance *Instance) (bool, config.CacheabilityInfo, error)
+  {{else if eq .VarietyName "TEMPLATE_VARIETY_QUOTA" -}}
+    Alloc{{.Name}}Quota([]*Instance, adapter.QuotaRequestArgs) (adapter.QuotaResult, error)
   {{else -}}
     Report{{.Name}}(instances []*Instance) error
   {{end}}

--- a/tools/codegen/pkg/interfacegen/testdata/QuotaTemplate.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/QuotaTemplate.proto
@@ -5,9 +5,8 @@ package istio.mixer.adapter.quota;
 import "mixer/v1/config/descriptor/value_type.proto";
 import "pkg/adapter/template/TemplateExtensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 option (istio.mixer.v1.config.template.template_name) = "Quota";
-
 
 message Template {
     map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 1;

--- a/tools/codegen/pkg/interfacegen/testdata/QuotaTemplateGenerated.golden.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/QuotaTemplateGenerated.golden.proto
@@ -21,7 +21,7 @@ package istio.mixer.adapter.quota;
 import "mixer/v1/config/descriptor/value_type.proto";
 import "pkg/adapter/template/TemplateExtensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 option (istio.mixer.v1.config.template.template_name) = "Quota";
 
 message Type {

--- a/tools/codegen/pkg/interfacegen/testdata/QuotaTemplateProcessorInterface.golden.go
+++ b/tools/codegen/pkg/interfacegen/testdata/QuotaTemplateProcessorInterface.golden.go
@@ -17,6 +17,7 @@
 package istio_mixer_adapter_quota
 
 import (
+	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/adapter/config"
 )
 
@@ -35,5 +36,5 @@ type QuotaProcessorBuilder interface {
 
 type QuotaProcessor interface {
 	config.Handler
-	ReportQuota(instances []*Instance) error
+	AllocQuotaQuota([]*Instance, adapter.QuotaRequestArgs) (adapter.QuotaResult, error)
 }


### PR DESCRIPTION
Till now codegen work was not considering QUOTA kind template at all, since we were not sure of the signature of the processor interface. Now since there is some clarity, this PR add support for Quota kind in processor interface code generator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/971)
<!-- Reviewable:end -->
