### PR TITLE
Update mixer logging to spew less irrelevant info

### DIFF
--- a/pkg/adapterManager/manager.go
+++ b/pkg/adapterManager/manager.go
@@ -240,7 +240,7 @@ func (m *Manager) loadConfigs(attrs attribute.Bag, ks config.KindSet, isPreproce
 		return nil, fmt.Errorf("unable to resolve config: %v", err)
 	}
 	if glog.V(2) {
-		glog.Infof("Resolved %d configs: %v ", len(configs), configs)
+		glog.Infof("Resolved %d configs", len(configs))
 	}
 	return configs, nil
 }

--- a/pkg/attribute/protoBag.go
+++ b/pkg/attribute/protoBag.go
@@ -37,6 +37,7 @@ type ProtoBag struct {
 
 // NewProtoBag creates a new proto-based attribute bag.
 func NewProtoBag(proto *mixerpb.Attributes, globalDict map[string]int32, globalWordList []string) *ProtoBag {
+	glog.V(4).Infof("Creating bag with attributes: %v", proto)
 	return &ProtoBag{
 		proto:          proto,
 		globalDict:     globalDict,
@@ -49,6 +50,7 @@ func (pb *ProtoBag) Get(name string) (interface{}, bool) {
 	// find the dictionary index for the given string
 	index, ok := pb.getIndex(name)
 	if !ok {
+		glog.Warningf("Attribute '%s' not in either global or message dictionaries", name)
 		// the string is not in the dictionary, and hence the attribute is not in the proto either
 		return nil, false
 	}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -153,7 +153,7 @@ func (c *Manager) fetch() (*runtime, descriptor.Finder, map[string]*HandlerInfo,
 
 	data, shas, index, err := readdb(c.store, "/")
 	if glog.V(9) {
-		glog.Info(data)
+		glog.Infof("Fetched config payload:\n%v", data)
 	}
 	if err != nil {
 		return nil, nil, nil, errors.New("Unable to read database: " + err.Error())
@@ -172,6 +172,9 @@ func (c *Manager) fetch() (*runtime, descriptor.Finder, map[string]*HandlerInfo,
 	if cerr != nil {
 		glog.Warningf("Validation failed: %v", cerr)
 		return nil, nil, nil, cerr
+	}
+	if glog.V(4) {
+		glog.Infof("Fetched and validated config payload:\n%v", data)
 	}
 	c.lastFetchIndex = index
 	vd.shas = shas
@@ -192,7 +195,6 @@ func (c *Manager) fetchAndNotify() {
 		return
 	}
 
-	glog.Infof("Loaded new config %s", c.store)
 	for _, cl := range c.cl {
 		cl.ConfigChange(rt, df, handlers)
 	}

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -81,7 +81,15 @@ func GetScopes(attr string, domain string, scopes []string) ([]string, error) {
 func (r *runtime) Resolve(bag attribute.Bag, set KindSet, strict bool) (dlist []*pb.Combined, err error) {
 	if glog.V(4) {
 		glog.Infof("resolving for kinds: %s", set)
-		defer func() { glog.Infof("resolved configs (err=%v): %s", err, dlist) }()
+		defer func() {
+			builders := make([]string, len(dlist))
+			for i, o := range dlist {
+				if o.Builder != nil {
+					builders[i] = o.Builder.Impl
+				}
+			}
+			glog.Infof("resolved configs (err=%v): %v", err, builders)
+		}()
 	}
 	return resolve(
 		bag,
@@ -103,7 +111,15 @@ func (r *runtime) Resolve(bag attribute.Bag, set KindSet, strict bool) (dlist []
 func (r *runtime) ResolveUnconditional(bag attribute.Bag, set KindSet, strict bool) (out []*pb.Combined, err error) {
 	if glog.V(2) {
 		glog.Infof("unconditionally resolving for kinds: %s", set)
-		defer func() { glog.Infof("unconditionally resolved configs (err=%v): %s", err, out) }()
+		defer func() {
+			builders := make([]string, len(out))
+			for i, o := range out {
+				if o.Builder != nil {
+					builders[i] = o.Builder.Impl
+				}
+			}
+			glog.Infof("unconditionally resolved configs (err=%v): %v", err, builders)
+		}()
 	}
 	return resolve(
 		bag,
@@ -205,7 +221,7 @@ func (r *runtime) resolveRules(bag attribute.Bag, kindSet KindSet, rules []*pb.A
 		// they're all in a single log line and not interleaved with logs from other requests.
 		logMsg := ""
 		if glog.V(3) {
-			glog.Infof("resolveRules (%v) ==> %v ", rule, path)
+			glog.Infof("resolveRules (%v) ==> %v ", rule.Selector, path)
 		}
 
 		sel := rule.GetSelector()


### PR DESCRIPTION
Today Mixer logs are very verbose, and filled with info that is almost never relevant for debugging.

Today Mixer logs for a Check request look like this:
```
I0801 21:16:59.929233       1 grpcServer.go:79] Dispatching Preprocess
I0801 21:16:59.929265       1 runtime.go:105] unconditionally resolving for kinds: [attributes]
I0801 21:16:59.929309       1 runtime.go:208] resolveRules (aspects:<kind:"attributes" adapter:"default" params:&AttributesGeneratorParams{InputExpressions:map[string]string{originUID: origin.uid | "",sourceUID: source.uid | "",targetUID: target.uid | "",},AttributeBindings:map[string]string{source.ip: sourcePodIp,source.labels: sourceLabels,source.name: sourcePodName,source.namespace: sourceNamespace,source.service: sourceService,source.serviceAccount: sourceServiceAccountName,target.ip: targetPodIp,target.labels: targetLabels,target.name: targetPodName,target.namespace: targetNamespace,target.service: targetService,target.serviceAccount: targetServiceAccountName,},} > aspects:<kind:"quotas" adapter:"default" params:&QuotasParams{Quotas:[&QuotasParams_Quota{DescriptorName:RequestCount,Labels:map[string]string{},MaxAmount:5000,Expiration:1s,}],} > aspects:<kind:"metrics" adapter:"prometheus" params:&MetricsParams{Metrics:[&MetricsParams_Metric{DescriptorName:request_count,Value:1,Labels:map[string]string{method: request.path | "unknown",response_code: response.code | 200,service: target.labels["app"] | "unknown",source: source.labels["app"] | "unknown",target: target.service | "unknown",version: target.labels["version"] | "unknown",},} &MetricsParams_Metric{DescriptorName:request_duration,Value:response.latency | response.duration | "0ms",Labels:map[string]string{method: request.path | "unknown",response_code: response.code | 200,service: target.labels["app"] | "unknown",source: source.labels["app"] | "unknown",target: target.service | "unknown",version: target.labels["version"] | "unknown",},}],} > aspects:<kind:"access-logs" adapter:"default" params:&AccessLogsParams{LogName:access_log,Log:AccessLogsParams_AccessLog{DescriptorName:accesslog.common,TemplateExpressions:map[string]string{method: request.method,originIp: origin.ip,protocol: request.scheme,responseCode: response.code,responseSize: response.size,sourceUser: origin.user,timestamp: request.time,url: request.path,},Labels:map[string]string{method: request.method,originIp: origin.ip,protocol: request.scheme,responseCode: response.code,responseSize: response.size,sourceUser: origin.user,timestamp: request.time,url: request.path,},},} > ) ==> / 
I0801 21:16:59.929550       1 runtime.go:248] Rule () applies, using aspect kinds [attributes]:
- selected aspect kind attributes with config: name:"default" kind:"attributes" impl:"kubernetes" params:&Params{KubeconfigPath:,CacheRefreshDuration:5m0s,SourceUidInputName:sourceUID,TargetUidInputName:targetUID,OriginUidInputName:originUID,PodLabelForService:app,SourcePrefix:source,TargetPrefix:target,OriginPrefix:origin,LabelsValueName:Labels,PodNameValueName:PodName,PodIpValueName:PodIP,HostIpValueName:HostIP,NamespaceValueName:Namespace,ServiceAccountValueName:ServiceAccountName,ServiceValueName:Service,ClusterDomainName:svc.cluster.local,} 
- did not select aspect kind quotas named 'default', wrong kind
- did not select aspect kind metrics named 'prometheus', wrong kind
- did not select aspect kind access-logs named 'default', wrong kind
I0801 21:16:59.929570       1 runtime.go:154] no rules for global/default.svc.cluster.local
I0801 21:16:59.929577       1 runtime.go:154] no rules for global/details.default.svc.cluster.local
I0801 21:16:59.929581       1 runtime.go:154] no rules for default.svc.cluster.local/default.svc.cluster.local
I0801 21:16:59.929585       1 runtime.go:154] no rules for default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:16:59.929589       1 runtime.go:154] no rules for details.default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:16:59.929592       1 runtime.go:106] unconditionally resolved configs (err=<nil>): [builder: name:"default" kind:"attributes" impl:"kubernetes" params:&Params{KubeconfigPath:,CacheRefreshDuration:5m0s,SourceUidInputName:sourceUID,TargetUidInputName:targetUID,OriginUidInputName:originUID,PodLabelForService:app,SourcePrefix:source,TargetPrefix:target,OriginPrefix:origin,LabelsValueName:Labels,PodNameValueName:PodName,PodIpValueName:PodIP,HostIpValueName:HostIP,NamespaceValueName:Namespace,ServiceAccountValueName:ServiceAccountName,ServiceValueName:Service,ClusterDomainName:svc.cluster.local,}  aspect: kind:"attributes" adapter:"default" params:&AttributesGeneratorParams{InputExpressions:map[string]string{originUID: origin.uid | "",sourceUID: source.uid | "",targetUID: target.uid | "",},AttributeBindings:map[string]string{source.ip: sourcePodIp,source.labels: sourceLabels,source.name: sourcePodName,source.namespace: sourceNamespace,source.service: sourceService,source.serviceAccount: sourceServiceAccountName,target.ip: targetPodIp,target.labels: targetLabels,target.name: targetPodName,target.namespace: targetNamespace,target.service: targetService,target.serviceAccount: targetServiceAccountName,},} ]
I0801 21:16:59.929638       1 manager.go:243] Resolved 1 configs: [builder: name:"default" kind:"attributes" impl:"kubernetes" params:&Params{KubeconfigPath:,CacheRefreshDuration:5m0s,SourceUidInputName:sourceUID,TargetUidInputName:targetUID,OriginUidInputName:originUID,PodLabelForService:app,SourcePrefix:source,TargetPrefix:target,OriginPrefix:origin,LabelsValueName:Labels,PodNameValueName:PodName,PodIpValueName:PodIP,HostIpValueName:HostIP,NamespaceValueName:Namespace,ServiceAccountValueName:ServiceAccountName,ServiceValueName:Service,ClusterDomainName:svc.cluster.local,}  aspect: kind:"attributes" adapter:"default" params:&AttributesGeneratorParams{InputExpressions:map[string]string{originUID: origin.uid | "",sourceUID: source.uid | "",targetUID: target.uid | "",},AttributeBindings:map[string]string{source.ip: sourcePodIp,source.labels: sourceLabels,source.name: sourcePodName,source.namespace: sourceNamespace,source.service: sourceService,source.serviceAccount: sourceServiceAccountName,target.ip: targetPodIp,target.labels: targetLabels,target.name: targetPodName,target.namespace: targetNamespace,target.service: targetService,target.serviceAccount: targetServiceAccountName,},} ] 
W0801 21:16:59.930079       1 attrgenmgr.go:112] Generated value 'targetPodIP' was not mapped to an attribute.
W0801 21:16:59.930097       1 attrgenmgr.go:112] Generated value 'sourceHostIP' was not mapped to an attribute.
W0801 21:16:59.930101       1 attrgenmgr.go:112] Generated value 'targetHostIP' was not mapped to an attribute.
W0801 21:16:59.930105       1 attrgenmgr.go:112] Generated value 'sourcePodIP' was not mapped to an attribute.
I0801 21:16:59.930177       1 grpcServer.go:82] Preprocess returned with: OK 
I0801 21:16:59.930196       1 grpcServer.go:91] Dispatching to main adapters after running processors
I0801 21:16:59.930214       1 grpcServer.go:94]   target.name: details-v1-1939900939-s1h4w
I0801 21:16:59.930229       1 grpcServer.go:94]   source.serviceAccount: default
I0801 21:16:59.930234       1 grpcServer.go:94]   source.ip: 172.17.0.21
I0801 21:16:59.930239       1 grpcServer.go:94]   target.ip: 172.17.0.15
I0801 21:16:59.930253       1 grpcServer.go:94]   request.scheme: http
I0801 21:16:59.930258       1 grpcServer.go:94]   request.useragent: python-requests/2.11.1
I0801 21:16:59.930263       1 grpcServer.go:94]   request.method: GET
I0801 21:16:59.930267       1 grpcServer.go:94]   target.uid: kubernetes://details-v1-1939900939-s1h4w.default
I0801 21:16:59.930271       1 grpcServer.go:94]   source.name: productpage-v1-2251119181-w7z5q
I0801 21:16:59.930276       1 grpcServer.go:94]   request.time: 2017-08-01 21:16:59.922752774 +0000 UTC
I0801 21:16:59.930297       1 grpcServer.go:94]   request.path: /details
I0801 21:16:59.930302       1 grpcServer.go:94]   quota.name: RequestCount
I0801 21:16:59.930306       1 grpcServer.go:94]   target.namespace: default
I0801 21:16:59.930310       1 grpcServer.go:94]   source.namespace: default
I0801 21:16:59.930314       1 grpcServer.go:94]   request.host: details:9080
I0801 21:16:59.930324       1 grpcServer.go:94]   request.headers: map[x-b3-parentspanid:000013852ead8724 accept-encoding:gzip, deflate x-ot-span-context:000013852ead8724;000059245dda363b;000013852ead8724;sr x-forwarded-proto:http content-length:0 :path:/details :method:GET x-request-id:997098f5-4220-90f5-8586-ca3c05a8c90c accept:*/* x-b3-traceid:000013852ead8724 x-b3-spanid:000059245dda363b user-agent:python-requests/2.11.1 :authority:details:9080 x-b3-sampled:1]
I0801 21:16:59.930350       1 grpcServer.go:94]   target.service: details.default.svc.cluster.local
I0801 21:16:59.930355       1 grpcServer.go:94]   source.service: productpage.default.svc.cluster.local
I0801 21:16:59.930360       1 grpcServer.go:94]   source.uid: kubernetes://productpage-v1-2251119181-w7z5q.default
I0801 21:16:59.930364       1 grpcServer.go:94]   quota.amount: 1
I0801 21:16:59.930369       1 grpcServer.go:94]   target.serviceAccount: default
I0801 21:16:59.930373       1 grpcServer.go:94]   source.labels: map[version:v1 app:productpage pod-template-hash:2251119181]
I0801 21:16:59.930390       1 grpcServer.go:94]   target.labels: map[pod-template-hash:1939900939 version:v1 app:details]
I0801 21:16:59.930397       1 grpcServer.go:100] Dispatching Check
I0801 21:16:59.930401       1 runtime.go:83] resolving for kinds: [lists, denials]
I0801 21:16:59.930411       1 runtime.go:208] resolveRules (aspects:<kind:"attributes" adapter:"default" params:&AttributesGeneratorParams{InputExpressions:map[string]string{originUID: origin.uid | "",sourceUID: source.uid | "",targetUID: target.uid | "",},AttributeBindings:map[string]string{source.ip: sourcePodIp,source.labels: sourceLabels,source.name: sourcePodName,source.namespace: sourceNamespace,source.service: sourceService,source.serviceAccount: sourceServiceAccountName,target.ip: targetPodIp,target.labels: targetLabels,target.name: targetPodName,target.namespace: targetNamespace,target.service: targetService,target.serviceAccount: targetServiceAccountName,},} > aspects:<kind:"quotas" adapter:"default" params:&QuotasParams{Quotas:[&QuotasParams_Quota{DescriptorName:RequestCount,Labels:map[string]string{},MaxAmount:5000,Expiration:1s,}],} > aspects:<kind:"metrics" adapter:"prometheus" params:&MetricsParams{Metrics:[&MetricsParams_Metric{DescriptorName:request_count,Value:1,Labels:map[string]string{method: request.path | "unknown",response_code: response.code | 200,service: target.labels["app"] | "unknown",source: source.labels["app"] | "unknown",target: target.service | "unknown",version: target.labels["version"] | "unknown",},} &MetricsParams_Metric{DescriptorName:request_duration,Value:response.latency | response.duration | "0ms",Labels:map[string]string{method: request.path | "unknown",response_code: response.code | 200,service: target.labels["app"] | "unknown",source: source.labels["app"] | "unknown",target: target.service | "unknown",version: target.labels["version"] | "unknown",},}],} > aspects:<kind:"access-logs" adapter:"default" params:&AccessLogsParams{LogName:access_log,Log:AccessLogsParams_AccessLog{DescriptorName:accesslog.common,TemplateExpressions:map[string]string{method: request.method,originIp: origin.ip,protocol: request.scheme,responseCode: response.code,responseSize: response.size,sourceUser: origin.user,timestamp: request.time,url: request.path,},Labels:map[string]string{method: request.method,originIp: origin.ip,protocol: request.scheme,responseCode: response.code,responseSize: response.size,sourceUser: origin.user,timestamp: request.time,url: request.path,},},} > ) ==> / 
I0801 21:16:59.930543       1 runtime.go:248] Rule () applies, using aspect kinds [denials, lists]:
- did not select aspect kind attributes named 'default', wrong kind
- did not select aspect kind quotas named 'default', wrong kind
- did not select aspect kind metrics named 'prometheus', wrong kind
- did not select aspect kind access-logs named 'default', wrong kind
I0801 21:16:59.930562       1 runtime.go:154] no rules for global/default.svc.cluster.local
I0801 21:16:59.930567       1 runtime.go:154] no rules for global/details.default.svc.cluster.local
I0801 21:16:59.930571       1 runtime.go:154] no rules for default.svc.cluster.local/default.svc.cluster.local
I0801 21:16:59.930575       1 runtime.go:154] no rules for default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:16:59.930579       1 runtime.go:154] no rules for details.default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:16:59.930582       1 runtime.go:84] resolved configs (err=<nil>): []
I0801 21:16:59.930586       1 manager.go:243] Resolved 0 configs: [] 
I0801 21:16:59.930593       1 grpcServer.go:102] Check returned with: OK 
I0801 21:16:59.930599       1 grpcServer.go:126] Dispatching Quota
I0801 21:16:59.930613       1 runtime.go:83] resolving for kinds: [quotas]
I0801 21:16:59.930623       1 runtime.go:208] resolveRules (aspects:<kind:"attributes" adapter:"default" params:&AttributesGeneratorParams{InputExpressions:map[string]string{originUID: origin.uid | "",sourceUID: source.uid | "",targetUID: target.uid | "",},AttributeBindings:map[string]string{source.ip: sourcePodIp,source.labels: sourceLabels,source.name: sourcePodName,source.namespace: sourceNamespace,source.service: sourceService,source.serviceAccount: sourceServiceAccountName,target.ip: targetPodIp,target.labels: targetLabels,target.name: targetPodName,target.namespace: targetNamespace,target.service: targetService,target.serviceAccount: targetServiceAccountName,},} > aspects:<kind:"quotas" adapter:"default" params:&QuotasParams{Quotas:[&QuotasParams_Quota{DescriptorName:RequestCount,Labels:map[string]string{},MaxAmount:5000,Expiration:1s,}],} > aspects:<kind:"metrics" adapter:"prometheus" params:&MetricsParams{Metrics:[&MetricsParams_Metric{DescriptorName:request_count,Value:1,Labels:map[string]string{method: request.path | "unknown",response_code: response.code | 200,service: target.labels["app"] | "unknown",source: source.labels["app"] | "unknown",target: target.service | "unknown",version: target.labels["version"] | "unknown",},} &MetricsParams_Metric{DescriptorName:request_duration,Value:response.latency | response.duration | "0ms",Labels:map[string]string{method: request.path | "unknown",response_code: response.code | 200,service: target.labels["app"] | "unknown",source: source.labels["app"] | "unknown",target: target.service | "unknown",version: target.labels["version"] | "unknown",},}],} > aspects:<kind:"access-logs" adapter:"default" params:&AccessLogsParams{LogName:access_log,Log:AccessLogsParams_AccessLog{DescriptorName:accesslog.common,TemplateExpressions:map[string]string{method: request.method,originIp: origin.ip,protocol: request.scheme,responseCode: response.code,responseSize: response.size,sourceUser: origin.user,timestamp: request.time,url: request.path,},Labels:map[string]string{method: request.method,originIp: origin.ip,protocol: request.scheme,responseCode: response.code,responseSize: response.size,sourceUser: origin.user,timestamp: request.time,url: request.path,},},} > ) ==> / 
I0801 21:16:59.930715       1 runtime.go:248] Rule () applies, using aspect kinds [quotas]:
- did not select aspect kind attributes named 'default', wrong kind
- selected aspect kind quotas with config: name:"default" kind:"quotas" impl:"memQuota" params:&Params{MinDeduplicationDuration:1s,} 
- did not select aspect kind metrics named 'prometheus', wrong kind
- did not select aspect kind access-logs named 'default', wrong kind
I0801 21:16:59.930748       1 runtime.go:154] no rules for global/default.svc.cluster.local
I0801 21:16:59.930754       1 runtime.go:154] no rules for global/details.default.svc.cluster.local
I0801 21:16:59.930758       1 runtime.go:154] no rules for default.svc.cluster.local/default.svc.cluster.local
I0801 21:16:59.930762       1 runtime.go:154] no rules for default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:16:59.930766       1 runtime.go:154] no rules for details.default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:16:59.930769       1 runtime.go:84] resolved configs (err=<nil>): [builder: name:"default" kind:"quotas" impl:"memQuota" params:&Params{MinDeduplicationDuration:1s,}  aspect: kind:"quotas" adapter:"default" params:&QuotasParams{Quotas:[&QuotasParams_Quota{DescriptorName:RequestCount,Labels:map[string]string{},MaxAmount:5000,Expiration:1s,}],} ]
I0801 21:16:59.930800       1 manager.go:243] Resolved 1 configs: [builder: name:"default" kind:"quotas" impl:"memQuota" params:&Params{MinDeduplicationDuration:1s,}  aspect: kind:"quotas" adapter:"default" params:&QuotasParams{Quotas:[&QuotasParams_Quota{DescriptorName:RequestCount,Labels:map[string]string{},MaxAmount:5000,Expiration:1s,}],} ] 
I0801 21:16:59.930871       1 quotasManager.go:151] Invoking adapter default for quota RequestCount with amount 1, labels map[]
I0801 21:16:59.930935       1 quotasManager.go:172] Allocated 1 units from quota RequestCount
I0801 21:16:59.930971       1 grpcServer.go:128] Quota returned with status 'OK ' and quota response '&{1s 1}'
```

With this PR a Check call looks like:
```
I0801 21:08:27.798459       1 protoBag.go:40] Creating bag with attributes: &Attributes{Words:[quota.amount quota.name RequestCount details:9080 /details */* gzip, deflate 0 python-requests/2.11.1 x-b3-parentspanid 000048adf9c2b71e x-b3-sampled 1 x-b3-spanid 000061764f56e2f7 x-b3-traceid x-ot-span-context 000048adf9c2b71e;000061764f56e2f7;000048adf9c2b71e;sr 1105dbcc-8adb-9ee1-ab30-c15b49457e2a 172.17.0.21 kubernetes://productpage-v1-2251119181-w7z5q.default 172.17.0.15 details.default.svc.cluster.local kubernetes://details-v1-1939900939-s1h4w.default],Strings:map[int32]int32{-2: -3,0: -20,3: -21,7: -22,9: -23,11: -24,17: -5,18: -4,19: 90,22: 92,25: -9,},Int64S:map[int32]int64{-1: 1,},Doubles:map[int32]float64{},Bools:map[int32]bool{},Timestamps:map[int32]time.Time{24: 2017-08-01 21:08:27.794939338 +0000 UTC,},Durations:map[int32]time.Duration{},Bytes:map[int32][]byte{},StringMaps:map[int32]StringMap{15: {map[-10:-11 33:-5 -14:-15 -17:-18 102:-19 32:90 55:-8 86:-9 -16:-11 100:92 -12:-13 46:-6 43:-7 31:-4]},},}
I0801 21:08:27.798787       1 grpcServer.go:79] Dispatching Preprocess
I0801 21:08:27.798796       1 runtime.go:113] unconditionally resolving for kinds: [attributes]
I0801 21:08:27.798813       1 runtime.go:224] resolveRules () ==> / 
I0801 21:08:27.798865       1 runtime.go:264] Rule () applies, using aspect kinds [attributes]:
- selected aspect kind attributes with config: name:"default" kind:"attributes" impl:"kubernetes" params:&Params{KubeconfigPath:,CacheRefreshDuration:5m0s,SourceUidInputName:sourceUID,TargetUidInputName:targetUID,OriginUidInputName:originUID,PodLabelForService:app,SourcePrefix:source,TargetPrefix:target,OriginPrefix:origin,LabelsValueName:Labels,PodNameValueName:PodName,PodIpValueName:PodIP,HostIpValueName:HostIP,NamespaceValueName:Namespace,ServiceAccountValueName:ServiceAccountName,ServiceValueName:Service,ClusterDomainName:svc.cluster.local,} 
- did not select aspect kind quotas named 'default', wrong kind
- did not select aspect kind metrics named 'prometheus', wrong kind
- did not select aspect kind access-logs named 'default', wrong kind
I0801 21:08:27.798872       1 runtime.go:170] no rules for global/default.svc.cluster.local
I0801 21:08:27.798877       1 runtime.go:170] no rules for global/details.default.svc.cluster.local
I0801 21:08:27.798882       1 runtime.go:170] no rules for default.svc.cluster.local/default.svc.cluster.local
I0801 21:08:27.798885       1 runtime.go:170] no rules for default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:08:27.798889       1 runtime.go:170] no rules for details.default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:08:27.798893       1 runtime.go:121] unconditionally resolved configs (err=<nil>): [kubernetes]
I0801 21:08:27.798898       1 manager.go:243] Resolved 1 configs
W0801 21:08:27.799538       1 protoBag.go:53] Attribute 'origin.uid' not in either global or message dictionaries
W0801 21:08:27.799572       1 attrgenmgr.go:112] Generated value 'targetHostIP' was not mapped to an attribute.
W0801 21:08:27.799577       1 attrgenmgr.go:112] Generated value 'targetPodIP' was not mapped to an attribute.
W0801 21:08:27.799581       1 attrgenmgr.go:112] Generated value 'sourcePodIP' was not mapped to an attribute.
W0801 21:08:27.799585       1 attrgenmgr.go:112] Generated value 'sourceHostIP' was not mapped to an attribute.
I0801 21:08:27.799643       1 grpcServer.go:82] Preprocess returned with: OK 
I0801 21:08:27.799650       1 grpcServer.go:91] Dispatching to main adapters after running processors
I0801 21:08:27.799672       1 grpcServer.go:94]   request.headers: map[content-length:0 user-agent:python-requests/2.11.1 :path:/details x-request-id:1105dbcc-8adb-9ee1-ab30-c15b49457e2a accept-encoding:gzip, deflate :authority:details:9080 x-b3-spanid:000061764f56e2f7 x-ot-span-context:000048adf9c2b71e;000061764f56e2f7;000048adf9c2b71e;sr :method:GET x-forwarded-proto:http x-b3-sampled:1 accept:*/* x-b3-traceid:000048adf9c2b71e x-b3-parentspanid:000048adf9c2b71e]
I0801 21:08:27.799686       1 grpcServer.go:94]   target.ip: 172.17.0.15
I0801 21:08:27.799691       1 grpcServer.go:94]   target.name: details-v1-1939900939-s1h4w
I0801 21:08:27.799695       1 grpcServer.go:94]   source.service: productpage.default.svc.cluster.local
I0801 21:08:27.799699       1 grpcServer.go:94]   target.namespace: default
I0801 21:08:27.799703       1 grpcServer.go:94]   request.host: details:9080
I0801 21:08:27.799707       1 grpcServer.go:94]   request.path: /details
I0801 21:08:27.799711       1 grpcServer.go:94]   target.service: details.default.svc.cluster.local
I0801 21:08:27.799716       1 grpcServer.go:94]   quota.amount: 1
I0801 21:08:27.799720       1 grpcServer.go:94]   source.labels: map[app:productpage pod-template-hash:2251119181 version:v1]
I0801 21:08:27.799726       1 grpcServer.go:94]   source.namespace: default
I0801 21:08:27.799731       1 grpcServer.go:94]   request.time: 2017-08-01 21:08:27.794939338 +0000 UTC
I0801 21:08:27.799739       1 grpcServer.go:94]   quota.name: RequestCount
I0801 21:08:27.799743       1 grpcServer.go:94]   request.method: GET
I0801 21:08:27.799747       1 grpcServer.go:94]   target.serviceAccount: default
I0801 21:08:27.799752       1 grpcServer.go:94]   request.useragent: python-requests/2.11.1
I0801 21:08:27.799756       1 grpcServer.go:94]   source.ip: 172.17.0.21
I0801 21:08:27.799760       1 grpcServer.go:94]   target.uid: kubernetes://details-v1-1939900939-s1h4w.default
I0801 21:08:27.799764       1 grpcServer.go:94]   source.serviceAccount: default
I0801 21:08:27.799768       1 grpcServer.go:94]   target.labels: map[pod-template-hash:1939900939 version:v1 app:details]
I0801 21:08:27.799774       1 grpcServer.go:94]   source.name: productpage-v1-2251119181-w7z5q
I0801 21:08:27.799778       1 grpcServer.go:94]   source.uid: kubernetes://productpage-v1-2251119181-w7z5q.default
I0801 21:08:27.799782       1 grpcServer.go:94]   request.scheme: http
I0801 21:08:27.799785       1 grpcServer.go:100] Dispatching Check
I0801 21:08:27.799789       1 runtime.go:83] resolving for kinds: [denials, lists]
I0801 21:08:27.799799       1 runtime.go:224] resolveRules () ==> / 
I0801 21:08:27.799810       1 runtime.go:264] Rule () applies, using aspect kinds [denials, lists]:
- did not select aspect kind attributes named 'default', wrong kind
- did not select aspect kind quotas named 'default', wrong kind
- did not select aspect kind metrics named 'prometheus', wrong kind
- did not select aspect kind access-logs named 'default', wrong kind
I0801 21:08:27.799814       1 runtime.go:170] no rules for global/default.svc.cluster.local
I0801 21:08:27.799818       1 runtime.go:170] no rules for global/details.default.svc.cluster.local
I0801 21:08:27.799822       1 runtime.go:170] no rules for default.svc.cluster.local/default.svc.cluster.local
I0801 21:08:27.799826       1 runtime.go:170] no rules for default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:08:27.799831       1 runtime.go:170] no rules for details.default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:08:27.799836       1 runtime.go:91] resolved configs (err=<nil>): []
I0801 21:08:27.799839       1 manager.go:243] Resolved 0 configs
I0801 21:08:27.799845       1 grpcServer.go:102] Check returned with: OK 
I0801 21:08:27.799851       1 grpcServer.go:126] Dispatching Quota
I0801 21:08:27.799854       1 runtime.go:83] resolving for kinds: [quotas]
I0801 21:08:27.799862       1 runtime.go:224] resolveRules () ==> / 
I0801 21:08:27.799881       1 runtime.go:264] Rule () applies, using aspect kinds [quotas]:
- did not select aspect kind attributes named 'default', wrong kind
- selected aspect kind quotas with config: name:"default" kind:"quotas" impl:"memQuota" params:&Params{MinDeduplicationDuration:1s,} 
- did not select aspect kind metrics named 'prometheus', wrong kind
- did not select aspect kind access-logs named 'default', wrong kind
I0801 21:08:27.799886       1 runtime.go:170] no rules for global/default.svc.cluster.local
I0801 21:08:27.799980       1 runtime.go:170] no rules for global/details.default.svc.cluster.local
I0801 21:08:27.799986       1 runtime.go:170] no rules for default.svc.cluster.local/default.svc.cluster.local
I0801 21:08:27.799990       1 runtime.go:170] no rules for default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:08:27.799993       1 runtime.go:170] no rules for details.default.svc.cluster.local/details.default.svc.cluster.local
I0801 21:08:27.799997       1 runtime.go:91] resolved configs (err=<nil>): [memQuota]
I0801 21:08:27.800001       1 manager.go:243] Resolved 1 configs
I0801 21:08:27.800327       1 quotasManager.go:151] Invoking adapter default for quota RequestCount with amount 1, labels map[]
I0801 21:08:27.800343       1 quotasManager.go:172] Allocated 1 units from quota RequestCount
I0801 21:08:27.800369       1 grpcServer.go:128] Quota returned with status 'OK ' and quota response '&{1s 1}'  
```

The biggest difference is on the lines w/ runtime.go:208 and manager.go:243: both log exactly the same thing, back to back, and it's very verbose. Github doesn't wrap `code` text so the amount of junk there is harder to see.

With this PR Mixer also logs the config its using to serve when that config is updated (and once at startup), so debuggability is maintained (or improved).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/984)
<!-- Reviewable:end -->
