### PR TITLE
Track which attributes are used during request processing.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -210,7 +210,7 @@ load("//:repositories.bzl", "new_git_or_local_repository")
 new_git_or_local_repository(
     name = "com_github_istio_api",
     build_file = "BUILD.api",
-    commit = "ee9769f5b3304d9e01cd7ed6fb1dbb9b08e96210",  # June 29, 2017 (no releases)
+    commit = "192ece51b211685e1b2898374d02a5061c735c31",  # August 1, 2017 (no releases)
     path = "../api",
     remote = "https://github.com/istio/api.git",
     # Change this to True to use ../api directory

--- a/cmd/client/cmd/util.go
+++ b/cmd/client/cmd/util.go
@@ -214,7 +214,7 @@ func parseAttributes(rootArgs *rootArgs) (*mixerpb.Attributes, error) {
 	}
 
 	var attrs mixerpb.Attributes
-	b.ToProto(&attrs, nil)
+	b.ToProto(&attrs, nil, 0)
 
 	return &attrs, nil
 }

--- a/pkg/api/perf_test.go
+++ b/pkg/api/perf_test.go
@@ -197,9 +197,9 @@ func unaryBench(b *testing.B, grpcCompression, useGlobalDict bool) {
 		request := &mixerpb.CheckRequest{}
 
 		if useGlobalDict {
-			bag.ToProto(&request.Attributes, revGlobalDict)
+			bag.ToProto(&request.Attributes, revGlobalDict, len(revGlobalDict))
 		} else {
-			bag.ToProto(&request.Attributes, nil)
+			bag.ToProto(&request.Attributes, nil, 0)
 		}
 
 		wg.Add(1)

--- a/pkg/attribute/BUILD
+++ b/pkg/attribute/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bag.go",
+        "dictState.go",
         "emptyBag.go",
         "mutableBag.go",
         "protoBag.go",

--- a/pkg/attribute/dictState.go
+++ b/pkg/attribute/dictState.go
@@ -1,0 +1,82 @@
+// Copyright 2016 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+type dictState struct {
+	globalDict      map[string]int32
+	messageDict     map[string]int32
+	globalWordCount int
+}
+
+// newDictState initializes a new dictionary state. Given a set of words,
+// this code creates a message word list suitable for use in an Attributes proto.
+//
+// globalWordCount indicates the maximum allowed global dictionary index to
+// use.
+func newDictState(globalDict map[string]int32, globalWordCount int) *dictState {
+	return &dictState{
+		globalDict:      globalDict,
+		globalWordCount: globalWordCount,
+	}
+}
+
+// assignDictIndex determines whether a word is in the allowed subset of the
+// global word list or whether it should be added to the message word list
+// being accumulated. It then returns the appropriate dictionary index given
+// the selected word list.
+func (ds *dictState) assignDictIndex(word string) int32 {
+	if index, ok := ds.globalDict[word]; ok {
+
+		// ensure the returned index doesn't exceed the max we're allowed
+		if index < int32(ds.globalWordCount) {
+			return index
+		}
+	}
+
+	if ds.messageDict == nil {
+		ds.messageDict = make(map[string]int32)
+	} else if index, ok := ds.messageDict[word]; ok {
+		return index
+	}
+
+	index := slotToIndex(len(ds.messageDict))
+	ds.messageDict[word] = index
+	return index
+}
+
+// getMessageWordList returns the list of words suitable for use
+// in an Attributes message.
+func (ds *dictState) getMessageWordList() []string {
+	if len(ds.messageDict) == 0 {
+		return nil
+	}
+
+	words := make([]string, len(ds.messageDict))
+	for k, v := range ds.messageDict {
+		words[indexToSlot(v)] = k
+	}
+
+	return words
+}
+
+// slotToIndex converts from a message word list slot into a dictionary index
+func slotToIndex(slot int) int32 {
+	return int32(-slot - 1)
+}
+
+// indexToSlot converts from a dictionary index into a message word list slot
+func indexToSlot(index int32) int {
+	return int(-index - 1)
+}

--- a/pkg/attribute/protoBag.go
+++ b/pkg/attribute/protoBag.go
@@ -33,15 +33,28 @@ type ProtoBag struct {
 	messageDict         map[string]int32
 	convertedStringMaps map[int32]map[string]string
 	stringMapMutex      sync.RWMutex
+
+	// to keep track of attributes that are referenced
+	referencedAttrs      map[string]mixerpb.ReferencedAttributes_Condition
+	referencedAttrsMutex sync.Mutex
 }
 
 // NewProtoBag creates a new proto-based attribute bag.
 func NewProtoBag(proto *mixerpb.Attributes, globalDict map[string]int32, globalWordList []string) *ProtoBag {
 	glog.V(4).Infof("Creating bag with attributes: %v", proto)
+
+	// build the message-level dictionary
+	d := make(map[string]int32, len(proto.Words))
+	for i, name := range proto.Words {
+		d[name] = slotToIndex(i)
+	}
+
 	return &ProtoBag{
-		proto:          proto,
-		globalDict:     globalDict,
-		globalWordList: globalWordList,
+		proto:           proto,
+		globalDict:      globalDict,
+		globalWordList:  globalWordList,
+		messageDict:     d,
+		referencedAttrs: make(map[string]mixerpb.ReferencedAttributes_Condition, 16),
 	}
 }
 
@@ -52,9 +65,56 @@ func (pb *ProtoBag) Get(name string) (interface{}, bool) {
 	if !ok {
 		glog.Warningf("Attribute '%s' not in either global or message dictionaries", name)
 		// the string is not in the dictionary, and hence the attribute is not in the proto either
+		pb.trackReference(name, mixerpb.ABSENCE)
 		return nil, false
 	}
 
+	result, ok := pb.internalGet(name, index)
+	if !ok {
+		// the named attribute was not present
+		pb.trackReference(name, mixerpb.ABSENCE)
+		return nil, false
+	}
+
+	pb.trackReference(name, mixerpb.EXACT)
+	return result, ok
+}
+
+// GetReferencedAttributes returns the set of attributes that have been referenced through this bag.
+func (pb *ProtoBag) GetReferencedAttributes(globalDict map[string]int32, globalWordCount int) mixerpb.ReferencedAttributes {
+	output := mixerpb.ReferencedAttributes{}
+
+	ds := newDictState(globalDict, globalWordCount)
+
+	output.AttributeMatches = make([]mixerpb.ReferencedAttributes_AttributeMatch, len(pb.referencedAttrs))
+	i := 0
+	for k, v := range pb.referencedAttrs {
+		output.AttributeMatches[i] = mixerpb.ReferencedAttributes_AttributeMatch{
+			Name:      ds.assignDictIndex(k),
+			Condition: v,
+		}
+		i++
+	}
+
+	output.Words = ds.getMessageWordList()
+
+	return output
+}
+
+// ClearReferencedAttributes clears the list of referenced attributes being tracked by this bag
+func (pb *ProtoBag) ClearReferencedAttributes() {
+	for k := range pb.referencedAttrs {
+		delete(pb.referencedAttrs, k)
+	}
+}
+
+func (pb *ProtoBag) trackReference(name string, condition mixerpb.ReferencedAttributes_Condition) {
+	pb.referencedAttrsMutex.Lock()
+	pb.referencedAttrs[name] = condition
+	pb.referencedAttrsMutex.Unlock()
+}
+
+func (pb *ProtoBag) internalGet(name string, index int32) (interface{}, bool) {
 	strIndex, ok := pb.proto.Strings[index]
 	if ok {
 		// found the attribute, now convert its value from a dictionary index to a string
@@ -69,7 +129,7 @@ func (pb *ProtoBag) Get(name string) (interface{}, bool) {
 
 	var value interface{}
 
-	// see if the requested attribte is a string map that's already been converted
+	// see if the requested attribute is a string map that's already been converted
 	pb.stringMapMutex.RLock()
 	value, ok = pb.convertedStringMaps[index]
 	pb.stringMapMutex.RUnlock()
@@ -135,13 +195,11 @@ func (pb *ProtoBag) Get(name string) (interface{}, bool) {
 
 // given a string, find the corresponding dictionary index if it exists
 func (pb *ProtoBag) getIndex(str string) (int32, bool) {
-	if index, ok := pb.globalDict[str]; ok {
+	if index, ok := pb.messageDict[str]; ok {
 		return index, true
 	}
 
-	md := pb.getMessageDict()
-
-	if index, ok := md[str]; ok {
+	if index, ok := pb.globalDict[str]; ok {
 		return index, true
 	}
 
@@ -151,8 +209,9 @@ func (pb *ProtoBag) getIndex(str string) (int32, bool) {
 // given a dictionary index, find the corresponding string if it exists
 func (pb *ProtoBag) lookup(index int32) (string, error) {
 	if index < 0 {
-		if -index-1 < int32(len(pb.proto.Words)) {
-			return pb.proto.Words[-index-1], nil
+		slot := indexToSlot(index)
+		if slot < len(pb.proto.Words) {
+			return pb.proto.Words[slot], nil
 		}
 	} else if index < int32(len(pb.globalWordList)) {
 		return pb.globalWordList[index], nil
@@ -245,22 +304,4 @@ func (pb *ProtoBag) Names() []string {
 // Done indicates the bag can be reclaimed.
 func (pb *ProtoBag) Done() {
 	// NOP
-}
-
-// Lazily produce the message-level dictionary
-func (pb *ProtoBag) getMessageDict() map[string]int32 {
-	if pb.messageDict == nil {
-		// build the message-level dictionary
-
-		d := make(map[string]int32, len(pb.proto.Words))
-		for i, name := range pb.proto.Words {
-			// indexes into the message-level dictionary are negative
-			d[name] = -int32(i) - 1
-		}
-
-		// potentially racy update, but that's fine since all generate maps are equivalent
-		pb.messageDict = d
-	}
-
-	return pb.messageDict
 }


### PR DESCRIPTION
- We track which attributes are referenced for each Mixer Check call and report this to Envoy. Envoy uses this information to properly cache the Check response.

- Fixes a bug in the proto bag code which didn't correctly handle the case where a word was both in the global and the message-level word lists. The message-level word list now takes precedence in all cases.

- Adds the needed support to enable upgrades of the global word list by limiting used of the global word list in generated Attributes messages to what the caller indicated is its maximum support word count.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/985)
<!-- Reviewable:end -->
