### PR TITLE
prevent gazelle to generate wrong go_library rules.

### DIFF
--- a/bin/gazelle
+++ b/bin/gazelle
@@ -11,6 +11,10 @@ if ! gazelle --help 2>&1 | grep build_file_name >/dev/null; then
     go get -u github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle
 fi
 
+# Remove the symbolic link of generated pb.go files and .gen.go files
+# to prevent gazelle from creating wrong go_proto_library.
+find . -type l \( -name '*.pb.go' -o -name '*.gen.go' \) | xargs rm -f
+
 gazelle \
     -go_prefix istio.io/mixer \
     -build_file_name BUILD

--- a/template/sample/check/BUILD
+++ b/template/sample/check/BUILD
@@ -1,4 +1,3 @@
-# gazelle:ignore
 package(default_visibility = ["//visibility:public"])
 
 load("//tools/codegen:generate.bzl", "mixer_proto_library")

--- a/template/sample/quota/BUILD
+++ b/template/sample/quota/BUILD
@@ -1,4 +1,3 @@
-# gazelle:ignore
 package(default_visibility = ["//visibility:public"])
 
 load("//tools/codegen:generate.bzl", "mixer_proto_library")

--- a/template/sample/report/BUILD
+++ b/template/sample/report/BUILD
@@ -1,4 +1,3 @@
-# gazelle:ignore
 package(default_visibility = ["//visibility:public"])
 
 load("//tools/codegen:generate.bzl", "mixer_proto_library")


### PR DESCRIPTION
bin/bazel_to_go.py (and bin/linters.sh which runs this) creates
symbolic links to auto generated pb.go files and gen.go files.

This PR removes such symbolic links before gazelle runs, so that
gazelle doesn't create incorrect rules anymore. This allows to
remove some gazelle:ignore markers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1007)
<!-- Reviewable:end -->
