### PR TITLE
fix the warning message on pre-commit check.

### DIFF
--- a/bin/use_bazel_go.sh
+++ b/bin/use_bazel_go.sh
@@ -11,7 +11,7 @@ fi
 
 BDIR=$(dirname $(dirname $(readlink $TARGETBIN)))
 
-export GOROOT=$(ls -1d $BDIR/external/golang_*)
+export GOROOT=$(ls -1d $BDIR/external/go1*)
 export PATH=$GOROOT/bin:$PATH
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
bin/use_bazel_go.sh tries to set GOROOT, however the dependency
path name has been changed -- now it doesn't start with golang_.
It's go1_8_3_linux_amd64 on my environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1016)
<!-- Reviewable:end -->
