### PR TITLE
Use the zipkin option to ensure that mixer generates its own span, s…

### DIFF
--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -308,7 +308,7 @@ func runServer(sa *serverArgs, tmplRepo template.Repository, printf, fatalf shar
 			}
 			recorder = zt.NewRecorder(col, false /* debug */, fmt.Sprintf("0.0.0.0:%d", sa.port), "istio-mixer")
 		}
-		tracer, err := zt.NewTracer(recorder)
+		tracer, err := zt.NewTracer(recorder, zt.ClientServerSameSpan(false))
 		if err != nil {
 			fatalf("Failed to construct zipkin tracer: %v", err)
 		}


### PR DESCRIPTION
…eparate from the client's

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- Ensures Zipkin generates new child spans for Mixer rather than using the same span for both client and server.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1035)
<!-- Reviewable:end -->
