### PR TITLE
update global dictionary to 124.

### DIFF
--- a/pkg/api/globalWordList.go
+++ b/pkg/api/globalWordList.go
@@ -129,5 +129,18 @@ var (
 		"text/html; charset=utf-8",
 		"text/plain",
 		"text/plain; charset=utf-8",
+		"0",
+		"1",
+		"true",
+		"false",
+		"gzip, deflate",
+		"max-age=0",
+		"x-envoy-upstream-service-time",
+		"x-envoy-internal",
+		"x-envoy-expected-rq-timeout-ms",
+		"x-ot-span-context",
+		"x-b3-traceid",
+		"x-b3-sampled",
+		"x-b3-spanid",
 	}
 )


### PR DESCRIPTION
There are more global dictionary changes coming.  Need to check this in.

Mixer is still not easy to build by proxy.   The work around  is to create a fork from old version of working mixer and add the global dictionary to that forked mixer.    This mixer is just for proxy integration, as long as its transport layer (attribute extraction code) is not changed, this approach should work.   So far,  it is not changed.

Mixer team is going to build a mixer test stub with gRPC api and attribute extraction with minimum dependency (https://github.com/istio/mixer/pull/1023).  Once this is in,  Istio/Proxy can switch to use that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1036)
<!-- Reviewable:end -->
