### PR TITLE
Update Result.Interface{} behavior to be inline with the old evaluator.

### DIFF
--- a/pkg/il/interpreter/result.go
+++ b/pkg/il/interpreter/result.go
@@ -95,7 +95,12 @@ func (r Result) Interface() interface{} {
 	case il.Bool:
 		return r.Bool()
 	case il.String:
-		return r.String()
+		s := r.String()
+		// Align with the mechanics of the old expr evaluator.
+		if s == "" {
+			return nil
+		}
+		return s
 	case il.Integer:
 		return r.Integer()
 	case il.Double:

--- a/pkg/il/interpreter/result_test.go
+++ b/pkg/il/interpreter/result_test.go
@@ -100,6 +100,20 @@ func Test_String_WithNonString(t *testing.T) {
 	}
 }
 
+func Test_Interface_EmptyStringReturnsNull(t *testing.T) {
+	p := il.NewProgram()
+	sid := p.Strings().GetID("")
+	r := Result{
+		t:  il.String,
+		v1: sid,
+		s:  p.Strings(),
+	}
+
+	if r.Interface() != nil {
+		t.Fatalf("Expected empty string to be converted to nil.")
+	}
+}
+
 func Test_Type(t *testing.T) {
 	r := Result{
 		t: il.Integer,


### PR DESCRIPTION
The old evaluator returns nil (interface{}) when it encounters an
empty string. This change mimics the same behavior.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1044)
<!-- Reviewable:end -->
