### PR TITLE
Create adapter_deps.bzl for Mixer

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,9 +20,9 @@ load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories")
 
 docker_repositories()
 
-load(":proto_deps.bzl", "mixer_proto_repositories")
+load(":adapter_author_deps.bzl", "mixer_adapter_repositories")
 
-mixer_proto_repositories()
+mixer_adapter_repositories()
 
 git_repository(
     name = "com_github_grpc_grpc",
@@ -383,13 +383,6 @@ go_repository(
     name = "com_github_PuerkitoBio_purell",
     commit = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4",  # Nov 14, 2016 (v1.1.0)
     importpath = "github.com/PuerkitoBio/purell",
-)
-
-go_repository(
-    name = "org_golang_x_text",
-    build_file_name = "BUILD.bazel",
-    commit = "f4b4367115ec2de254587813edaa901bc1c723a8",  # Mar 31, 2017 (no releases)
-    importpath = "golang.org/x/text",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,51 +20,9 @@ load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories")
 
 docker_repositories()
 
-git_repository(
-    name = "org_pubref_rules_protobuf",
-    commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31, 2017 (gogo* support)
-    remote = "https://github.com/pubref/rules_protobuf",
-)
+load(":proto_deps.bzl", "mixer_proto_repositories")
 
-git_repository(
-    name = "com_github_google_protobuf",
-    commit = "52ab3b07ac9a6889ed0ac9bf21afd8dab8ef0014",  # Oct 4, 2016 (match pubref dep)
-    remote = "https://github.com/google/protobuf.git",
-)
-
-load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_repositories")
-
-proto_repositories()
-
-go_repository(
-    name = "org_golang_x_net",
-    commit = "f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f",  # Jul 26, 2017 (no releases)
-    importpath = "golang.org/x/net",
-)
-
-go_repository(
-    name = "com_github_golang_glog",
-    commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",  # Jan 26, 2016 (no releases)
-    importpath = "github.com/golang/glog",
-)
-
-go_repository(
-    name = "com_github_golang_protobuf",
-    commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",  # Nov 16, 2016 (match pubref dep)
-    importpath = "github.com/golang/protobuf",
-)
-
-go_repository(
-    name = "com_github_gogo_protobuf",
-    commit = "100ba4e885062801d56799d78530b73b178a78f3",  # Mar 7, 2017 (match pubref dep)
-    importpath = "github.com/gogo/protobuf",
-)
-
-go_repository(
-    name = "org_golang_google_grpc",
-    commit = "8050b9cbc271307e5a716a9d782803d09b0d6f2d",  # Apr 7, 2017 (v1.2.1)
-    importpath = "google.golang.org/grpc",
-)
+mixer_proto_repositories()
 
 git_repository(
     name = "com_github_grpc_grpc",

--- a/adapter/list/list_test.go
+++ b/adapter/list/list_test.go
@@ -37,7 +37,7 @@ import (
 func TestBasic(t *testing.T) {
 	info := GetBuilderInfo()
 
-	if !contains(info.SupportedTemplates, listentry.TemplateName) {
+	if !containsListEntryTemplate(info.SupportedTemplates) {
 		t.Error("Didn't find all expected supported templates")
 	}
 
@@ -63,9 +63,9 @@ func TestBasic(t *testing.T) {
 	}
 }
 
-func contains(s []string, e string) bool {
+func containsListEntryTemplate(s []string) bool {
 	for _, a := range s {
-		if a == e {
+		if a == listentry.TemplateName {
 			return true
 		}
 	}

--- a/adapter_author_deps.bzl
+++ b/adapter_author_deps.bzl
@@ -1,14 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
-load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
 
 def mixer_adapter_repositories():
-    git_repository(
+    native.git_repository(
         name = "org_pubref_rules_protobuf",
         commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31, 2017 (gogo* support)
         remote = "https://github.com/pubref/rules_protobuf",
     )
 
-    git_repository(
+    native.git_repository(
         name = "com_github_google_protobuf",
         commit = "52ab3b07ac9a6889ed0ac9bf21afd8dab8ef0014",  # Oct 4, 2016 (match pubref dep)
         remote = "https://github.com/google/protobuf.git",

--- a/adapter_author_deps.bzl
+++ b/adapter_author_deps.bzl
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
 
-def mixer_proto_repositories():
+def mixer_adapter_repositories():
     git_repository(
         name = "org_pubref_rules_protobuf",
         commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31, 2017 (gogo* support)

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -78,7 +78,7 @@ class WORKSPACE(object):
 
 
 def process(fl, external, genfiles, vendor):
-    src = subprocess.Popen("bazel query 'kind(go_repository, //external:*)' --output=build", shell=True, stdout=subprocess.PIPE).stdout.read()
+    src = subprocess.Popen("bazel query 'kind(\"go_repository|new_git.*_repository\", \"//external:*\")' --output=build", shell=True, stdout=subprocess.PIPE).stdout.read()
     #print src
     tree = ast.parse(src, fl)
     lst = []
@@ -176,7 +176,6 @@ def bazel_to_vendor(WKSPC):
     tools_generated_files(WKSPC)
     config_proto(WKSPC, genfiles)
     attributes_list(WKSPC, genfiles)
-    alt_proto_gen_files(WKSPC, genfiles)
 
 def get_external_links(external):
     return [file for file in os.listdir(external) if os.path.isdir(external+"/"+file)]
@@ -244,13 +243,6 @@ def config_proto(WKSPC, genfiles):
 def attributes_list(WKSPC, genfiles):
     if os.path.exists(WKSPC + "/bazel-genfiles/pkg/attribute/list.gen.go"):
         makelink(WKSPC + "/bazel-genfiles/pkg/attribute/list.gen.go", WKSPC + "/pkg/attribute/list.gen.go")
-
-def alt_proto_gen_files(WKSPC, genfiles):
-    for file in os.listdir(WKSPC + "/bazel-genfiles/external/"):
-        path = pathmap.get(file, file)
-        link = repos(path)
-        makelink(WKSPC + "/bazel-genfiles/external/" + file, WKSPC + "/vendor/" + link)
-
 
 
 if __name__ == "__main__":

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -86,12 +86,7 @@ def process(fl, external, genfiles, vendor):
         stmttype = type(stmt)
         if stmttype == ast.Call:
 
-            if type(stmt.func) == ast.Name:
-                fn = getattr(wksp, stmt.func.id, "")
-
-            if type(stmt.func) == ast.Attribute:
-                fn = getattr(wksp, stmt.func.attr, "")
-
+            fn = getattr(wksp, stmt.func.id, "")
             if not callable(fn):
                 continue
 
@@ -132,11 +127,6 @@ def bazel_to_vendor(WKSPC):
         print "WORKSPACE file not found in " + WKSPC
         print "prog BAZEL_WORKSPACE_DIR"
         return -1
-    mixer_adapter_repos = WKSPC + "/adapter_author_deps.bzl"
-    if not os.path.isfile(mixer_adapter_repos):
-        print "Adapter authors deps file not found in " + WKSPC
-        print "prog BAZEL_WORKSPACE_DIR"
-        return -1
     lf = os.readlink(WKSPC + "/bazel-mixer")
     EXEC_ROOT = os.path.dirname(lf)
     BLD_DIR = os.path.dirname(EXEC_ROOT)
@@ -145,7 +135,6 @@ def bazel_to_vendor(WKSPC):
     genfiles = WKSPC + "/bazel-genfiles/external"
 
     links = {target: linksrc for(target, linksrc) in process(workspace, external, genfiles, vendor)}
-    links.update({target: linksrc for (target, linksrc) in process(mixer_adapter_repos, external, genfiles, vendor)})
 
     bysrc = {}
 

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -176,6 +176,7 @@ def bazel_to_vendor(WKSPC):
     tools_generated_files(WKSPC)
     config_proto(WKSPC, genfiles)
     attributes_list(WKSPC, genfiles)
+    alt_proto_gen_files(WKSPC, genfiles)
 
 def get_external_links(external):
     return [file for file in os.listdir(external) if os.path.isdir(external+"/"+file)]
@@ -243,6 +244,14 @@ def config_proto(WKSPC, genfiles):
 def attributes_list(WKSPC, genfiles):
     if os.path.exists(WKSPC + "/bazel-genfiles/pkg/attribute/list.gen.go"):
         makelink(WKSPC + "/bazel-genfiles/pkg/attribute/list.gen.go", WKSPC + "/pkg/attribute/list.gen.go")
+
+def alt_proto_gen_files(WKSPC, genfiles):
+    for file in os.listdir(WKSPC + "/bazel-genfiles/external/"):
+        path = pathmap.get(file, file)
+        link = repos(path)
+        makelink(WKSPC + "/bazel-genfiles/external/" + file, WKSPC + "/vendor/" + link)
+
+
 
 if __name__ == "__main__":
     import sys

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -132,7 +132,7 @@ def bazel_to_vendor(WKSPC):
     BLD_DIR = os.path.dirname(EXEC_ROOT)
     external =  BLD_DIR + "/external"
     vendor = WKSPC + "/vendor"
-    genfiles = WKSPC + "/bazel-genfiles/external"
+    genfiles = WKSPC + "/bazel-genfiles/external/"
 
     links = {target: linksrc for(target, linksrc) in process(workspace, external, genfiles, vendor)}
 
@@ -164,7 +164,7 @@ def bazel_to_vendor(WKSPC):
             continue
 
         makelink(target, linksrc)
-        # print "Vendored", linksrc, '-->', target
+        #print "Vendored", linksrc, '-->', target
 
     adapter_protos(WKSPC)
     aspect_protos(WKSPC)

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -14,6 +14,7 @@ import os
 
 import ast
 from urlparse import urlparse
+import subprocess
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -77,7 +78,8 @@ class WORKSPACE(object):
 
 
 def process(fl, external, genfiles, vendor):
-    src = open(fl).read()
+    src = subprocess.Popen("bazel query 'kind(go_repository, //external:*)' --output=build", shell=True, stdout=subprocess.PIPE).stdout.read()
+    #print src
     tree = ast.parse(src, fl)
     lst = []
     wksp = WORKSPACE(external, genfiles, vendor)
@@ -140,7 +142,7 @@ def bazel_to_vendor(WKSPC):
 
     for (target, linksrc) in links.items():
         makelink(target, linksrc)
-        # print "Vendored", linksrc, '-->', target
+        #print "Vendored", linksrc, '-->', target
         bysrc[linksrc] = target
 
     # check other directories in external
@@ -156,6 +158,7 @@ def bazel_to_vendor(WKSPC):
         if link in pathmap:
             # skip remapped deps
             continue
+        # print ext_target, link
         linksrc = vendor + "/" + link
 
         # only make this link if we have not made it above
@@ -164,7 +167,7 @@ def bazel_to_vendor(WKSPC):
             continue
 
         makelink(target, linksrc)
-        #print "Vendored", linksrc, '-->', target
+        # print "Vendored", linksrc, '-->', target
 
     adapter_protos(WKSPC)
     aspect_protos(WKSPC)

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -100,9 +100,7 @@ def process(fl, external, genfiles, vendor):
                 path = path[:-4]
             path = pathmap.get(path, path)
             tup = fn(name, path)
-#            print tup
             lst.append(tup)
-
 
     return lst
 
@@ -144,16 +142,16 @@ def bazel_to_vendor(WKSPC):
     BLD_DIR = os.path.dirname(EXEC_ROOT)
     external =  BLD_DIR + "/external"
     vendor = WKSPC + "/vendor"
-    genfiles = WKSPC + "/bazel-genfiles/external/"
+    genfiles = WKSPC + "/bazel-genfiles/external"
 
     links = {target: linksrc for(target, linksrc) in process(workspace, external, genfiles, vendor)}
-    links = {target: linksrc for (target, linksrc) in process(mixer_adapter_repos, external, genfiles, vendor)}
+    links.update({target: linksrc for (target, linksrc) in process(mixer_adapter_repos, external, genfiles, vendor)})
 
     bysrc = {}
 
     for (target, linksrc) in links.items():
         makelink(target, linksrc)
-        #print "Vendored", linksrc, '-->', target
+        # print "Vendored", linksrc, '-->', target
         bysrc[linksrc] = target
 
     # check other directories in external

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -82,6 +82,7 @@ go_metalinter() {
         --enable=vet\
         --enable=vetshadow\
         --skip=testdata\
+        --skip=vendor\
         --vendor\
         $PKGS
 }

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -67,7 +67,7 @@ go_metalinter() {
         --enable=goconst\
         --enable=gofmt\
         --enable=goimports\
-        --enable=golint --min-confidence=0 --exclude=.pb.go --exclude=pkg/config/proto/combined.go --exclude=.*.gen.go --exclude="should have a package comment"\
+        --enable=golint --min-confidence=0 --exclude=vendor --exclude=.pb.go --exclude=pkg/config/proto/combined.go --exclude=.*.gen.go --exclude="should have a package comment"\
         --exclude=".*pkg/config/apiserver_test.go:.* method WriteHeaderAndJson should be WriteHeaderAndJSON"\
         --enable=ineffassign\
         --enable=interfacer\

--- a/proto_deps.bzl
+++ b/proto_deps.bzl
@@ -1,0 +1,57 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_repository")
+load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+
+def mixer_proto_repositories():
+    git_repository(
+        name = "org_pubref_rules_protobuf",
+        commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31, 2017 (gogo* support)
+        remote = "https://github.com/pubref/rules_protobuf",
+    )
+
+    git_repository(
+        name = "com_github_google_protobuf",
+        commit = "52ab3b07ac9a6889ed0ac9bf21afd8dab8ef0014",  # Oct 4, 2016 (match pubref dep)
+        remote = "https://github.com/google/protobuf.git",
+    )
+
+    native.bind(
+        name = "protoc",
+        actual = "@com_github_google_protobuf//:protoc",
+    )
+
+    go_repository(
+        name = "org_golang_x_net",
+        commit = "f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f",  # Jul 26, 2017 (no releases)
+        importpath = "golang.org/x/net",
+    )
+
+    go_repository(
+        name = "com_github_golang_glog",
+        commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",  # Jan 26, 2016 (no releases)
+        importpath = "github.com/golang/glog",
+    )
+
+    go_repository(
+        name = "com_github_golang_protobuf",
+        commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",  # Nov 16, 2016 (match pubref dep)
+        importpath = "github.com/golang/protobuf",
+    )
+
+    go_repository(
+        name = "com_github_gogo_protobuf",
+        commit = "100ba4e885062801d56799d78530b73b178a78f3",  # Mar 7, 2017 (match pubref dep)
+        importpath = "github.com/gogo/protobuf",
+    )
+
+    go_repository(
+        name = "org_golang_google_grpc",
+        commit = "8050b9cbc271307e5a716a9d782803d09b0d6f2d",  # Apr 7, 2017 (v1.2.1)
+        importpath = "google.golang.org/grpc",
+    )
+
+    go_repository(
+        name = "org_golang_x_text",
+        build_file_name = "BUILD.bazel",
+        commit = "f4b4367115ec2de254587813edaa901bc1c723a8",  # Mar 31, 2017 (no releases)
+        importpath = "golang.org/x/text",
+    )


### PR DESCRIPTION
This PR separates out the core dependencies that Mixer uses to compile protos (primarily, adapter config protos) into a skylark set of repository rules.

The goal of this PR is to establish an easy-to-use rule in WORKSPACE files to import the same deps that Mixer is using internally. The intent is to enable adapter authors to quickly establish the bazel-ification necessary to mirror Mixer setup. This should enable adapter authors to test/build outside of mixer repo (in advance of mixer repo integration).

The set of dependencies was created based on a set of bazel queries to inspect various adapter config `BUILD`s.

Example:

```bash
$ bazel query 'deps("//adapter/serviceControl/config:go_default_library")' | grep -iv "go1_" | grep -iv "local_config" | sed -e "s/\/\/.*//g" | sort | uniq -c
   7
   7 @bazel_tools
  94 @com_github_gogo_protobuf
   4 @com_github_golang_glog
  13 @com_github_golang_protobuf
 430 @com_github_google_protobuf
  23 @io_bazel_rules_go
   2 @io_bazel_rules_go_toolchain
  47 @org_golang_google_grpc
  55 @org_golang_x_net
  22 @org_golang_x_text
   2 @org_pubref_rules_protobuf
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create skylark rules for core mixer proto dependencies.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1077)
<!-- Reviewable:end -->
