### PR TITLE
Log errors as error and don't log basic info unless verbosity is at least 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ istio-testing.json
 
 # generated proto artifacts
 *.descriptor_set
-*_processor.gen.go
 
-# generate list file
-list.gen.go
+# generated files
+*.gen.go

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -79,9 +79,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 
 	globalWordCount := int(req.GlobalWordCount)
 
-	if glog.V(1) {
-		glog.Info("Dispatching Preprocess Check")
-	}
+	glog.V(1).Info("Dispatching Preprocess Check")
 	preprocResponseBag := attribute.GetMutableBag(requestBag)
 	out := s.aspectDispatcher.Preprocess(legacyCtx, requestBag, preprocResponseBag)
 
@@ -91,9 +89,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 		preprocResponseBag.Done()
 		return nil, makeGRPCError(out)
 	}
-	if glog.V(1) {
-		glog.Info("Preprocess Check returned with: ", statusString(out))
-	}
+	glog.V(1).Info("Preprocess Check returned with: ", statusString(out))
 
 	if glog.V(2) {
 		glog.Info("Dispatching to main adapters after running processors")
@@ -105,12 +101,10 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 
 	responseBag := attribute.GetMutableBag(nil)
 
-	if glog.V(1) {
-		glog.Info("Dispatching Check")
-	}
+	glog.V(1).Info("Dispatching Check")
 	out = s.aspectDispatcher.Check(legacyCtx, preprocResponseBag, responseBag)
 	if status.IsOK(out) {
-		glog.Info("Check returned with ok : ", statusString(out))
+		glog.V(1).Info("Check returned with ok : ", statusString(out))
 	} else {
 		glog.Error("Check returned with error : ", statusString(out))
 	}
@@ -142,16 +136,12 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 				BestEffort:      param.BestEffort,
 			}
 
-			if glog.V(1) {
-				glog.Info("Dispatching Quota")
-			}
+			glog.V(1).Info("Dispatching Quota")
 			qmr, out := s.aspectDispatcher.Quota(legacyCtx, preprocResponseBag, qma)
 			if status.IsOK(out) {
-				if glog.V(1) {
-					glog.Infof("Quota returned with ok '%s' and quota response '%v'", statusString(out), qmr)
-				} else {
-					glog.Warningf("Quota returned with error '%s' and quota response '%v'", statusString(out), qmr)
-				}
+				glog.V(1).Infof("Quota returned with ok '%s' and quota response '%v'", statusString(out), qmr)
+			} else {
+				glog.Warningf("Quota returned with error '%s' and quota response '%v'", statusString(out), qmr)
 			}
 			if qmr == nil {
 				qmr = &aspect.QuotaMethodResp{}
@@ -210,9 +200,7 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 			}
 		}
 
-		if glog.V(1) {
-			glog.Info("Dispatching Preprocess")
-		}
+		glog.V(1).Info("Dispatching Preprocess")
 		out := s.aspectDispatcher.Preprocess(newctx, requestBag, preprocResponseBag)
 		if !status.IsOK(out) {
 			glog.Error("Preprocess returned with: ", statusString(out))
@@ -221,9 +209,7 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 			span.Finish()
 			break
 		}
-		if glog.V(1) {
-			glog.Info("Preprocess returned with: ", statusString(out))
-		}
+		glog.V(1).Info("Preprocess returned with: ", statusString(out))
 
 		if glog.V(2) {
 			glog.Info("Dispatching to main adapters after running processors")
@@ -233,9 +219,7 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 			}
 		}
 
-		if glog.V(1) {
-			glog.Info("Dispatching Report %d out of %d", i, len(req.Attributes))
-		}
+		glog.V(1).Info("Dispatching Report %d out of %d", i, len(req.Attributes))
 		out = s.aspectDispatcher.Report(legacyCtx, preprocResponseBag)
 
 		if !status.IsOK(out) {
@@ -245,9 +229,7 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 			span.Finish()
 			break
 		}
-		if glog.V(1) {
-			glog.Infof("Report %d returned with: %s", i, statusString(out))
-		}
+		glog.V(1).Infof("Report %d returned with: %s", i, statusString(out))
 
 		span.LogFields(log.String("success", fmt.Sprintf("finished Report for attribute bag %d", i)))
 		span.Finish()

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -192,15 +192,19 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 			}
 		}
 
-		glog.Info("Dispatching Preprocess")
+		if glog.V(1) {
+			glog.Info("Dispatching Preprocess")
+		}
 		out := s.aspectDispatcher.Preprocess(newctx, requestBag, preprocResponseBag)
-		glog.Info("Preprocess returned with: ", statusString(out))
-
 		if !status.IsOK(out) {
+			glog.Error("Preprocess returned with: ", statusString(out))
 			err = makeGRPCError(out)
 			span.LogFields(log.String("error", err.Error()))
 			span.Finish()
 			break
+		}
+		if glog.V(1) {
+			glog.Info("Preprocess returned with: ", statusString(out))
 		}
 
 		if glog.V(2) {
@@ -211,15 +215,20 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 			}
 		}
 
-		glog.Info("Dispatching Report")
+		if glog.V(1) {
+			glog.Info("Dispatching Report %d out of %d", i, len(req.Attributes))
+		}
 		out = s.aspectDispatcher.Report(legacyCtx, preprocResponseBag)
-		glog.Info("Report returned with: ", statusString(out))
 
 		if !status.IsOK(out) {
+			glog.Errorf("Report %d returned with: %s", i, statusString(out))
 			err = makeGRPCError(out)
 			span.LogFields(log.String("error", err.Error()))
 			span.Finish()
 			break
+		}
+		if glog.V(1) {
+			glog.Infof("Report %d returned with: %s", i, statusString(out))
 		}
 
 		span.LogFields(log.String("success", fmt.Sprintf("finished Report for attribute bag %d", i)))


### PR DESCRIPTION
Log errors as error and don't log basic info unless verbosity is at
least 1

This is to avoid
```
0818 22:08:39.405042   21321 grpcServer.go:216] Report 6 returned with: OK 
I0818 22:08:39.405056   21321 grpcServer.go:82] Dispatching Preprocess
I0818 22:08:39.405251   21321 grpcServer.go:85] Preprocess returned with: OK 
I0818 22:08:39.405261   21321 grpcServer.go:82] Dispatching Preprocess
I0818 22:08:39.405280   21321 grpcServer.go:85] Preprocess returned with: OK 
I0818 22:08:39.405284   21321 grpcServer.go:103] Dispatching Check
I0818 22:08:39.405292   21321 grpcServer.go:105] Check returned with: OK 
I0818 22:08:39.405301   21321 grpcServer.go:134] Dispatching Quota
I0818 22:08:39.405263   21321 grpcServer.go:103] Dispatching Check
I0818 22:08:39.405357   21321 grpcServer.go:82] Dispatching Preprocess
I0818 22:08:39.405374   21321 grpcServer.go:105] Check returned with: OK 
```
and show errors when we get `CANCELLED`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1106)
<!-- Reviewable:end -->

```release-note
improve logging (less verbose for normal case, more verbose for errors)
```