### PR TITLE
Add dns1035 compatible shortname to builderInfo

### DIFF
--- a/pkg/adapter/info.go
+++ b/pkg/adapter/info.go
@@ -23,6 +23,9 @@ import (
 type BuilderInfo struct {
 	// Name returns the official name of the adapter.
 	Name string
+	// ShortName is used to register this type with the config system.
+	// It must be DNS-1035 compatible. If it is not specified, it will be derived from 'Name'.
+	ShortName string
 	// Description returns a user-friendly description of the adapter.
 	Description string
 	// CreateHandlerBuilder is a function that creates a HandlerBuilder which implements Builders associated

--- a/pkg/adapterManager/e2e_configuration_test.go
+++ b/pkg/adapterManager/e2e_configuration_test.go
@@ -79,7 +79,7 @@ subject: namespace:ns
 revision: "2022"
 handlers:
   - name: fooHandler
-    adapter: fakeHandler
+    adapter: fakehandler
 
 manifests:
   - name: istio-proxy

--- a/pkg/config/adapterInfoRegistry.go
+++ b/pkg/config/adapterInfoRegistry.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/golang/glog"
@@ -27,47 +28,104 @@ type adapterInfoRegistry struct {
 	adapterInfosByName map[string]*adapter.BuilderInfo
 }
 
+// DNS1035Str defines regex to test for DNS-1035 compatible names.
+const DNS1035Str = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+
+// DNS1035 is the prebuilt matcher for DNS-1035 compatible names.
+var DNS1035 = regexp.MustCompile(DNS1035Str)
+
+func dns1035Err(name string) error {
+	return fmt.Errorf("%s cannot be converted to a DNS-1035 compatible name %s", name, DNS1035Str)
+}
+
+// NameToCfgKind returns Kind name given an adapter name.
+// istio.io/mixer/adapter/denier --> denier-mixer-istio-io
+// github.com/user1/mixerAdapters/denier --> denier-mixeradapters-user1
+// metricsco.io/mixerAdapters/metrics1 --> metrics1-mixeradapters-metricso-io
+// metricsco.io/mixerAdapters/adapters/metrics2 --> metrics2-mixeradapters-metricsco-io
+// kind = $pkg-$reponame-$org
+// Resulting name is DNS-1035 compatible. [a-z]([-a-z0-9]*[a-z0-9])?
+func NameToCfgKind(adapterName string) (string, error) {
+	adapterName = strings.ToLower(adapterName)
+	adapterName = strings.Replace(adapterName, ".", "-", -1)
+	const github = "github-com" // since . is replaced by - above.
+
+	// if name is already compatible just use it.
+	if DNS1035.MatchString(adapterName) {
+		return adapterName, nil
+	}
+
+	comps := strings.Split(adapterName, "/")
+	if len(comps) < 3 || (comps[0] == github && len(comps) < 4) {
+		return "", dns1035Err(adapterName)
+	}
+
+	pkg := comps[len(comps)-1]
+
+	// username is the org if repo starts with github
+	cidx := 0
+	if comps[0] == github {
+		cidx++
+	}
+	org := comps[cidx]
+	reponame := comps[cidx+1]
+
+	name := pkg + "-" + reponame + "-" + org
+	if !DNS1035.MatchString(name) {
+		return "", dns1035Err(adapterName)
+	}
+
+	return name, nil
+}
+
 type handlerBuilderValidator func(hndlrBuilder adapter.HandlerBuilder, t string) (bool, string)
 
-// newRegistry2 returns a new adapterInfoRegistry.
-func newRegistry2(infos []adapter.InfoFn, hndlrBldrValidator handlerBuilderValidator) *adapterInfoRegistry {
+// newRegistry2 returns a new adapterInfoRegistry or error.
+func newRegistry2Internal(infos []adapter.InfoFn, hndlrBldrValidator handlerBuilderValidator) (*adapterInfoRegistry, error) {
 	r := &adapterInfoRegistry{make(map[string]*adapter.BuilderInfo)}
 	for idx, info := range infos {
 		glog.V(3).Infof("Registering [%d] %#v", idx, info)
 		adptInfo := info()
-		if a, ok := r.adapterInfosByName[adptInfo.Name]; ok {
-			// panic only if 2 different adapter.Info objects are trying to identify by the
-			// same Name.
-			msg := fmt.Errorf("duplicate registration for '%s' : old = %v new = %v", a.Name, adptInfo, a)
-			glog.Error(msg)
-			panic(msg)
-		} else {
-			if adptInfo.ValidateConfig == nil {
-				// panic if adapter has not provided the ValidateConfig func.
-				msg := fmt.Errorf("Adapter info %v from adapter %s does not contain value for ValidateConfig"+
-					" function field.", adptInfo, adptInfo.Name)
-				glog.Error(msg)
-				panic(msg)
-			}
-			if adptInfo.DefaultConfig == nil {
-				// panic if adapter has not provided the DefaultConfig func.
-				msg := fmt.Errorf("Adapter info %v from adapter %s does not contain value for DefaultConfig "+
-					"field.", adptInfo, adptInfo.Name)
-				glog.Error(msg)
-				panic(msg)
-			}
-			if ok, errMsg := doesBuilderSupportsTemplates(adptInfo, hndlrBldrValidator); !ok {
-				// panic if an Adapter's HandlerBuilder does not implement interfaces that it says it wants to support.
-				msg := fmt.Errorf("HandlerBuilder from adapter %s does not implement the required interfaces"+
-					" for the templates it supports: %s", adptInfo.Name, errMsg)
-				glog.Error(msg)
-				panic(msg)
-			}
 
-			r.adapterInfosByName[adptInfo.Name] = &adptInfo
+		if len(adptInfo.ShortName) == 0 {
+			var err error
+			if adptInfo.ShortName, err = NameToCfgKind(adptInfo.Name); err != nil {
+				return nil, err
+			}
 		}
+
+		if a, ok := r.adapterInfosByName[adptInfo.ShortName]; ok {
+			// error only if 2 different adapter.Info objects are trying to identify by the
+			// same Name.
+			return nil, fmt.Errorf("duplicate registration for '%s' : old = %v new = %v", a.Name, adptInfo, a)
+		}
+		if adptInfo.ValidateConfig == nil {
+			// error if adapter has not provided the ValidateConfig func.
+			return nil, fmt.Errorf("Adapter info %v from adapter %s does not contain value for ValidateConfig"+
+				" function field.", adptInfo, adptInfo.Name)
+		}
+		if adptInfo.DefaultConfig == nil {
+			// error if adapter has not provided the DefaultConfig func.
+			return nil, fmt.Errorf("Adapter info %v from adapter %s does not contain value for DefaultConfig "+
+				"field.", adptInfo, adptInfo.Name)
+		}
+		if ok, errMsg := doesBuilderSupportsTemplates(adptInfo, hndlrBldrValidator); !ok {
+			// error if an Adapter's HandlerBuilder does not implement interfaces that it says it wants to support.
+			return nil, fmt.Errorf("HandlerBuilder from adapter %s does not implement the required interfaces"+
+				" for the templates it supports: %s", adptInfo.Name, errMsg)
+		}
+		r.adapterInfosByName[adptInfo.ShortName] = &adptInfo
 	}
-	return r
+	return r, nil
+}
+
+// newRegistry2 returns a new adapterInfoRegistry.
+func newRegistry2(infos []adapter.InfoFn, hndlrBldrValidator handlerBuilderValidator) (r *adapterInfoRegistry) {
+	var err error
+	if r, err = newRegistry2Internal(infos, hndlrBldrValidator); err != nil {
+		panic(err)
+	}
+	return
 }
 
 // AdapterInfoMap returns the known adapter.Infos, indexed by their names.

--- a/pkg/config/adapterInfoRegistry_test.go
+++ b/pkg/config/adapterInfoRegistry_test.go
@@ -197,3 +197,41 @@ func TestBuilderNotImplementRightTemplateInterface(t *testing.T) {
 
 	t.Error("Should not reach this statement due to panic.")
 }
+
+func TestNameToCfgKind(t *testing.T) {
+	tests := map[string]string{
+		"istio.io/mixer/adapter/denier":                "denier-mixer-istio-io",
+		"github.com/user1/mixerAdapters/denier":        "denier-mixeradapters-user1",
+		"metricsco.io/mixerAdapters/metrics1":          "metrics1-mixeradapters-metricsco-io",
+		"metricsco.io/mixerAdapters/adapters/metrics2": "metrics2-mixeradapters-metricsco-io",
+		"mixerAdapterDenier":                           "mixeradapterdenier",
+		"mixer.Adapter.Denier":                         "mixer-adapter-denier",
+	}
+
+	for q, a := range tests {
+		t.Run(q, func(t *testing.T) {
+			aa, err := NameToCfgKind(q)
+			if err != nil {
+				t.Fatalf("Unexpected error %v", err)
+			}
+			if aa != a {
+				t.Fatalf("got %s, want %s", aa, a)
+			}
+			if !DNS1035.MatchString(aa) {
+				t.Fatalf("did not return DNS1035 compatible string")
+			}
+		})
+	}
+
+	// test failures
+	for _, str := range []string{"istio.io/mixer",
+		"github.com/user1/mixerAdapters",
+		"metricsco.io/mixerAdapters/adapters/2metrics2"} {
+		t.Run(str, func(t *testing.T) {
+			_, err := NameToCfgKind(str)
+			if err == nil {
+				t.Fatalf("expected error, got success")
+			}
+		})
+	}
+}


### PR DESCRIPTION
All adapter configs (handlers) and template configs (instances) are CRD types in kubernetes.

In order to register a K8s type, the names must be a dns label (dns1035) compatible.
This PR introduces a derived BuilderInfo.ShortName that is computed from `.Name`.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1111)
<!-- Reviewable:end -->
