### PR TITLE
Set LAST_GOOD_GITSHA for linting only changed files.

### DIFF
--- a/prow/mixer-presubmit.sh
+++ b/prow/mixer-presubmit.sh
@@ -46,6 +46,7 @@ echo "=== Bazel Tests ==="
 bazel test --features=race //...
 
 echo "=== Code Check ==="
+export LAST_GOOD_GITSHA="${PULL_BASE_SHA}"
 ./bin/linters.sh
 
 echo "=== Code Coverage ==="


### PR DESCRIPTION
It seems currently linters.sh execution in prow's presubmit
does check all the files in mixer repository. That would be very
slow.

LAST_GOOD_GITSHA is an environment variable used by linters.sh
in mixer to limit the files to be checked.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1121)
<!-- Reviewable:end -->
