### PR TITLE
Move the prometheus adapter over to the new style

### DIFF
--- a/adapter/BUILD
+++ b/adapter/BUILD
@@ -33,10 +33,12 @@ inventory_library(
         "denier": "istio.io/mixer/adapter/denier",
         "list": "istio.io/mixer/adapter/list",
         "noop2": "istio.io/mixer/adapter/noop2",
+        "prometheus": "istio.io/mixer/adapter/prometheus2",
     },
     deps = [
         "//adapter/denier:go_default_library",
         "//adapter/list:go_default_library",
         "//adapter/noop2:go_default_library",
+        "//adapter/prometheus2:go_default_library",
     ],
 )

--- a/adapter/prometheus2/BUILD
+++ b/adapter/prometheus2/BUILD
@@ -1,0 +1,37 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "prometheus.go",
+        "server.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//adapter/prometheus2/config:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//template/metric:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "prometheus_test.go",
+        "server_test.go",
+    ],
+    library = ":go_default_library",
+    deps = [
+        "//adapter/prometheus2/config:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/adapter/test:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_model//go:go_default_library",
+    ],
+)

--- a/adapter/prometheus2/config/BUILD
+++ b/adapter/prometheus2/config/BUILD
@@ -1,0 +1,24 @@
+load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogoslick_proto_library")
+
+gogoslick_proto_library(
+    name = "go_default_library",
+    importmap = {
+        "gogoproto/gogo.proto": "github.com/gogo/protobuf/gogoproto",
+    },
+    imports = [
+        "external/com_github_gogo_protobuf",
+        "external/com_github_google_protobuf/src",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_gogo_protobuf//gogoproto:go_default_library_protos",
+    ],
+    protos = [
+        "config.proto",
+    ],
+    verbose = 0,
+    visibility = ["//adapter/prometheus2:__pkg__"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto:go_default_library",
+    ],
+)

--- a/adapter/prometheus2/config/config.proto
+++ b/adapter/prometheus2/config/config.proto
@@ -1,0 +1,122 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package adapter.prometheus.config;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "config";
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
+
+message Params {
+    message MetricInfo {
+        string name = 1;
+        string description = 2;
+
+        enum Kind {
+            UNSPECIFIED = 0;
+            GAUGE = 1;
+            COUNTER = 2;
+            DISTRIBUTION = 3;
+        }
+        Kind kind = 3;
+
+        message BucketsDefinition {
+            // Specifies a linear sequence of buckets that all have the same width
+            // (except overflow and underflow). Each bucket represents a constant
+            // absolute uncertainty on the specific value in the bucket.
+            //
+            // There are `num_finite_buckets + 2` (= `N`) buckets. The two additional
+            // buckets are the underflow and overflow buckets.
+            //
+            // Bucket `i` has the following boundaries:
+            //
+            // * Upper bound (`0 <= i < N-1`): `offset + (width * i)`
+            // * Lower bound (`1 <= i < N`): `offset + (width * (i - 1))`
+            message Linear {
+                // Must be greater than 0.
+                int32 num_finite_buckets = 1;
+
+                // Must be greater than 0.
+                double width = 2;
+
+                // Lower bound of the first bucket.
+                double offset = 3;
+            }
+
+            // Specifies an exponential sequence of buckets that have a width that is
+            // proportional to the value of the lower bound. Each bucket represents a
+            // constant relative uncertainty on a specific value in the bucket.
+            //
+            // There are `num_finite_buckets + 2` (= `N`) buckets. The two additional
+            // buckets are the underflow and overflow buckets.
+            //
+            // Bucket `i` has the following boundaries:
+            //
+            // * Upper bound (0 <= i < N-1): `scale * (growth_factor ^ i)`
+            // * Lower bound (1 <= i < N): `scale * (growth_factor ^ (i - 1))`
+            message Exponential {
+                // Must be greater than 0.
+                int32 num_finite_buckets = 1;
+
+                // Must be greater than 1.
+                double growth_factor = 2;
+
+                // Must be greater than 0.
+                double scale = 3;
+            }
+
+            // Specifies a set of buckets with arbitrary widths.
+            //
+            // There are `size(bounds) + 1` (= `N`) buckets. Bucket `i` has the following
+            // boundaries:
+            //
+            // * Upper bound (`0 <= i < N-1`): `bounds[i]`
+            // * Lower bound (`1 <= i < N`): `bounds[i - 1]`
+            //
+            // The `bounds` field must contain at least one element. If `bounds` has
+            // only one element, then there are no finite buckets, and that single
+            // element is the common boundary of the overflow and underflow buckets.
+            message Explicit {
+                // The values must be monotonically increasing.
+                repeated double bounds = 1;
+            }
+
+            // Exactly one of these three fields must be set.
+            oneof definition {
+                // The linear buckets.
+                Linear linear_buckets = 1;
+
+                // The exponential buckets.
+                Exponential exponential_buckets = 2;
+
+                // The explicit buckets.
+                Explicit explicit_buckets = 3;
+            }
+        }
+
+        // For metrics with a metric kind of DISTRIBUTION, this provides a mechanism
+        // for configuring the buckets that will be used to store the aggregated values.
+        // This field must be provided for metrics declared to be of type DISTRIBUTION.
+        // This field will be ignored for non-distribution metric kinds.
+        BucketsDefinition buckets = 4;
+
+        repeated string label_names = 5;
+    }
+    repeated MetricInfo metrics = 1;
+}

--- a/adapter/prometheus2/config/config.proto
+++ b/adapter/prometheus2/config/config.proto
@@ -24,10 +24,14 @@ option (gogoproto.equal_all) = false;
 option (gogoproto.gostring_all) = false;
 
 message Params {
+    // Describes how a metric should be represented in Prometheus.
     message MetricInfo {
+        // Required. The name of the Istio metric instance this MetricInfo describes the shape of.
         string name = 1;
+        // Optional. A human readable description of this metric.
         string description = 2;
 
+        // Describes what kind of metric this is.
         enum Kind {
             UNSPECIFIED = 0;
             GAUGE = 1;
@@ -36,6 +40,7 @@ message Params {
         }
         Kind kind = 3;
 
+        // Describes buckets for DISTRIBUTION kind metrics.
         message BucketsDefinition {
             // Specifies a linear sequence of buckets that all have the same width
             // (except overflow and underflow). Each bucket represents a constant
@@ -116,7 +121,11 @@ message Params {
         // This field will be ignored for non-distribution metric kinds.
         BucketsDefinition buckets = 4;
 
+        // The names of labels to use: these need to match the dimensions of the Istio metric.
+        // TODO: see if we can remove this and rely on only the dimensions in the future.
         repeated string label_names = 5;
     }
+    // The set of metrics to represent in Prometheus. If a metric is defined in Istio but doesn't have a corresponding
+    // shape here, it will not be populated at runtime.
     repeated MetricInfo metrics = 1;
 }

--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -1,0 +1,289 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prometheus publishes metric values collected by Mixer for
+// ingestion by prometheus.
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"istio.io/mixer/adapter/prometheus2/config"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/template/metric"
+)
+
+type (
+	factory struct {
+		srv      server
+		registry *prometheus.Registry
+		once     sync.Once
+	}
+
+	prom struct {
+		metrics map[string]prometheus.Collector
+		kinds   map[string]config.Params_MetricInfo_Kind
+	}
+)
+
+var (
+	charReplacer = strings.NewReplacer("/", "_", ".", "_", " ", "_")
+
+	_ metric.HandlerBuilder = &factory{}
+	_ metric.Handler        = &prom{}
+)
+
+// GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
+func GetBuilderInfo() adapter.BuilderInfo {
+	return adapter.BuilderInfo{
+		Name:        "prometheus",
+		Description: "Publishes prometheus metrics",
+		SupportedTemplates: []string{
+			metric.TemplateName,
+		},
+		CreateHandlerBuilder: func() adapter.HandlerBuilder { return newFactory(newServer(defaultAddr)) },
+		DefaultConfig:        &config.Params{},
+		ValidateConfig:       func(msg adapter.Config) *adapter.ConfigErrors { return nil },
+	}
+}
+
+func newFactory(srv server) *factory {
+	return &factory{srv, prometheus.NewPedanticRegistry(), sync.Once{}}
+}
+
+func (f *factory) ConfigureMetricHandler(map[string]*metric.Type) error {
+	return nil
+}
+
+func (f *factory) Build(c adapter.Config, env adapter.Env) (adapter.Handler, error) {
+	var serverErr error
+	f.once.Do(func() {
+		serverErr = f.srv.Start(env, promhttp.HandlerFor(f.registry, promhttp.HandlerOpts{}))
+	})
+	if serverErr != nil {
+		return nil, fmt.Errorf("could not start prometheus server: %v", serverErr)
+	}
+
+	cfg := c.(*config.Params)
+	var metricErr *multierror.Error
+	metricsMap := make(map[string]prometheus.Collector, len(cfg.Metrics))
+	kinds := make(map[string]config.Params_MetricInfo_Kind, len(cfg.Metrics))
+	for _, m := range cfg.Metrics {
+		switch m.Kind {
+		case config.GAUGE:
+			c, err := registerOrGet(f.registry, newGaugeVec(m.Name, m.Description, m.LabelNames))
+			if err != nil {
+				metricErr = multierror.Append(metricErr, fmt.Errorf("could not register metric: %v", err))
+				continue
+			}
+			metricsMap[m.Name] = c
+			kinds[m.Name] = config.GAUGE
+		case config.COUNTER:
+			c, err := registerOrGet(f.registry, newCounterVec(m.Name, m.Description, m.LabelNames))
+			if err != nil {
+				metricErr = multierror.Append(metricErr, fmt.Errorf("could not register metric: %v", err))
+				continue
+			}
+			metricsMap[m.Name] = c
+			kinds[m.Name] = config.COUNTER
+		case config.DISTRIBUTION:
+			c, err := registerOrGet(f.registry, newHistogramVec(m.Name, m.Description, m.LabelNames, m.Buckets))
+			if err != nil {
+				metricErr = multierror.Append(metricErr, fmt.Errorf("could not register metric: %v", err))
+				continue
+			}
+			metricsMap[m.Name] = c
+			kinds[m.Name] = config.DISTRIBUTION
+		default:
+			metricErr = multierror.Append(metricErr, fmt.Errorf("unknown metric kind (%d); could not register metric", m.Kind))
+		}
+	}
+	return &prom{metricsMap, kinds}, metricErr.ErrorOrNil()
+}
+
+// TODO: figure out ownership semantics, because factory.close will never be called in the new scheme.
+func (f *factory) Close() error {
+	return f.srv.Close()
+}
+
+func (p *prom) HandleMetric(_ context.Context, vals []*metric.Instance) error {
+	var result *multierror.Error
+
+	for _, val := range vals {
+		collector, found := p.metrics[val.Name]
+		if !found {
+			result = multierror.Append(result, fmt.Errorf("could not find metric info from adapter config for %s", val.Name))
+			continue
+		}
+		kind, found := p.kinds[val.Name]
+		if !found {
+			result = multierror.Append(result, fmt.Errorf("could not find kind for metric %s", val.Name))
+			continue
+		}
+		switch kind {
+		case config.GAUGE:
+			vec := collector.(*prometheus.GaugeVec)
+			amt, err := promValue(val.Value)
+			if err != nil {
+				result = multierror.Append(result, fmt.Errorf("could not get value for metric %s: %v", val.Name, err))
+				continue
+			}
+			vec.With(promLabels(val.Dimensions)).Set(amt)
+		case config.COUNTER:
+			vec := collector.(*prometheus.CounterVec)
+			amt, err := promValue(val.Value)
+			if err != nil {
+				result = multierror.Append(result, fmt.Errorf("could not get value for metric %s: %v", val.Name, err))
+				continue
+			}
+			vec.With(promLabels(val.Dimensions)).Add(amt)
+		case config.DISTRIBUTION:
+			vec := collector.(*prometheus.HistogramVec)
+			amt, err := promValue(val.Value)
+			if err != nil {
+				result = multierror.Append(result, fmt.Errorf("could not get value for metric %s: %v", val.Name, err))
+				continue
+			}
+			vec.With(promLabels(val.Dimensions)).Observe(amt)
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (*prom) Close() error { return nil }
+
+func newCounterVec(name, desc string, labels []string) *prometheus.CounterVec {
+	if desc == "" {
+		desc = name
+	}
+	c := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: safeName(name),
+			Help: desc,
+		},
+		labelNames(labels),
+	)
+	return c
+}
+
+func newGaugeVec(name, desc string, labels []string) *prometheus.GaugeVec {
+	if desc == "" {
+		desc = name
+	}
+	c := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: safeName(name),
+			Help: desc,
+		},
+		labelNames(labels),
+	)
+	return c
+}
+
+func newHistogramVec(name, desc string, labels []string, bucketDef adapter.BucketDefinition) *prometheus.HistogramVec {
+	if desc == "" {
+		desc = name
+	}
+	c := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    safeName(name),
+			Help:    desc,
+			Buckets: buckets(bucketDef),
+		},
+		labelNames(labels),
+	)
+	return c
+}
+
+func buckets(def adapter.BucketDefinition) []float64 {
+	switch def.(type) {
+	case *adapter.ExplicitBuckets:
+		b := def.(*adapter.ExplicitBuckets)
+		return b.Bounds
+	case *adapter.LinearBuckets:
+		lb := def.(*adapter.LinearBuckets)
+		return prometheus.LinearBuckets(lb.Offset, lb.Width, int(lb.Count+1))
+	case *adapter.ExponentialBuckets:
+		eb := def.(*adapter.ExponentialBuckets)
+		return prometheus.ExponentialBuckets(eb.Scale, eb.GrowthFactor, int(eb.Count+1))
+	default:
+		return prometheus.DefBuckets
+	}
+}
+
+func labelNames(m []string) []string {
+	out := make([]string, len(m))
+	for i, s := range m {
+		out[i] = safeName(s)
+	}
+	return out
+}
+
+// borrowed from prometheus.RegisterOrGet. However, that method is
+// targeted for removal soon(tm). So, we duplicate that functionality here
+// to maintain it long-term, as we have a use case for the convenience.
+func registerOrGet(registry *prometheus.Registry, c prometheus.Collector) (prometheus.Collector, error) {
+	if err := registry.Register(c); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return are.ExistingCollector, nil
+		}
+		return nil, err
+	}
+	return c, nil
+}
+
+func safeName(n string) string {
+	s := strings.TrimPrefix(n, "/")
+	return charReplacer.Replace(s)
+}
+
+func promValue(val interface{}) (float64, error) {
+	switch i := val.(type) {
+	case float64:
+		return i, nil
+	case int64:
+		return float64(i), nil
+	case time.Duration:
+		// TODO: what is the right thing here?
+		// use seconds for now, as we get fractional values...
+		return i.Seconds(), nil
+	case string:
+		f, err := strconv.ParseFloat(i, 64)
+		if err != nil {
+			return math.NaN(), err
+		}
+		return f, err
+	default:
+		return math.NaN(), fmt.Errorf("could not extract numeric value for %v", val)
+	}
+}
+
+func promLabels(l map[string]interface{}) prometheus.Labels {
+	labels := make(prometheus.Labels, len(l))
+	for i, label := range l {
+		labels[i] = fmt.Sprintf("%v", label)
+	}
+	return labels
+}

--- a/adapter/prometheus2/prometheus_test.go
+++ b/adapter/prometheus2/prometheus_test.go
@@ -135,11 +135,6 @@ var (
 	}
 
 	gaugeVal = newGaugeVal(gaugeNoLabels.Name, int64(993))
-	//gaugeVal = &metric.Instance{
-	//	Name: gaugeNoLabels.Name,
-	//	Value: 993,
-	//	Dimensions: map[string]interface{}{},
-	//}
 )
 
 func TestFactory_NewMetricsAspect(t *testing.T) {

--- a/adapter/prometheus2/prometheus_test.go
+++ b/adapter/prometheus2/prometheus_test.go
@@ -1,0 +1,391 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"istio.io/mixer/adapter/prometheus2/config"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/adapter/test"
+	"istio.io/mixer/template/metric"
+)
+
+type testServer struct {
+	server
+
+	errOnStart bool
+}
+
+func (t testServer) Start(adapter.Env, http.Handler) error {
+	if t.errOnStart {
+		return errors.New("could not start server")
+	}
+	return nil
+}
+
+var (
+	gaugeNoLabels = &config.Params_MetricInfo{
+		Name:        "/funky::gauge",
+		Description: "funky all the time",
+		Kind:        config.GAUGE,
+		LabelNames:  []string{},
+	}
+
+	histogramNoLabels = &config.Params_MetricInfo{
+		Name:        "happy_histogram",
+		Description: "fun with buckets",
+		Kind:        config.DISTRIBUTION,
+		LabelNames:  []string{},
+		Buckets: &config.Params_MetricInfo_BucketsDefinition{
+			&config.Params_MetricInfo_BucketsDefinition_ExplicitBuckets{
+				&config.Params_MetricInfo_BucketsDefinition_Explicit{Bounds: []float64{0.5434}}}},
+	}
+
+	counterNoLabels = &config.Params_MetricInfo{
+		Name:        "the.counter",
+		Description: "count all the tests",
+		Kind:        config.COUNTER,
+		LabelNames:  []string{},
+	}
+
+	gaugeNoLabelsNoDesc = &config.Params_MetricInfo{
+		Name:       "/funky::gauge.nodesc",
+		Kind:       config.GAUGE,
+		LabelNames: []string{},
+	}
+
+	counterNoLabelsNoDesc = &config.Params_MetricInfo{
+		Name:       "the.counter.nodesc",
+		Kind:       config.COUNTER,
+		LabelNames: []string{},
+	}
+
+	histogramNoLabelsNoDesc = &config.Params_MetricInfo{
+		Name:       "happy_histogram_the_elder",
+		Kind:       config.DISTRIBUTION,
+		LabelNames: []string{},
+		Buckets: &config.Params_MetricInfo_BucketsDefinition{
+			&config.Params_MetricInfo_BucketsDefinition_LinearBuckets{
+				&config.Params_MetricInfo_BucketsDefinition_Linear{NumFiniteBuckets: 5, Offset: 45, Width: 12}}},
+	}
+
+	counter = &config.Params_MetricInfo{
+		Name:        "special_counter",
+		Description: "count all the special tests",
+		Kind:        config.COUNTER,
+		LabelNames:  []string{"bool", "string", "email"},
+	}
+
+	histogram = &config.Params_MetricInfo{
+		Name:        "happy_histogram_the_younger",
+		Description: "fun with buckets",
+		Kind:        config.DISTRIBUTION,
+		Buckets: &config.Params_MetricInfo_BucketsDefinition{
+			&config.Params_MetricInfo_BucketsDefinition_ExponentialBuckets{
+				&config.Params_MetricInfo_BucketsDefinition_Exponential{Scale: .14, GrowthFactor: 2, NumFiniteBuckets: 198}},
+		},
+		LabelNames: []string{"bool", "string", "email"},
+	}
+
+	unknown = &config.Params_MetricInfo{
+		Name:        "unknown",
+		Description: "unknown",
+		Kind:        config.UNSPECIFIED,
+		LabelNames:  []string{},
+	}
+
+	counterVal = &metric.Instance{
+		Name: counter.Name,
+		Dimensions: map[string]interface{}{
+			"bool":   true,
+			"string": "testing",
+			"email":  "test@istio.io",
+		},
+		Value: float64(45),
+	}
+
+	histogramVal = &metric.Instance{
+		Name: histogram.Name,
+		Dimensions: map[string]interface{}{
+			"bool":   true,
+			"string": "testing",
+			"email":  "test@istio.io",
+		},
+		Value: float64(234.23),
+	}
+
+	gaugeVal = newGaugeVal(gaugeNoLabels.Name, int64(993))
+	//gaugeVal = &metric.Instance{
+	//	Name: gaugeNoLabels.Name,
+	//	Value: 993,
+	//	Dimensions: map[string]interface{}{},
+	//}
+)
+
+func TestFactory_NewMetricsAspect(t *testing.T) {
+	f := newFactory(&testServer{})
+
+	tests := []struct {
+		name    string
+		metrics []*config.Params_MetricInfo
+	}{
+		{"No Metrics", []*config.Params_MetricInfo{}},
+		{"One Gauge", []*config.Params_MetricInfo{gaugeNoLabels}},
+		{"One Counter", []*config.Params_MetricInfo{counterNoLabels}},
+		{"Distribution", []*config.Params_MetricInfo{histogramNoLabels}},
+		{"Multiple Metrics", []*config.Params_MetricInfo{counterNoLabels, gaugeNoLabels, histogramNoLabels}},
+		{"With Labels", []*config.Params_MetricInfo{counter, histogram}},
+		{"No Descriptions", []*config.Params_MetricInfo{counterNoLabelsNoDesc, gaugeNoLabelsNoDesc, histogramNoLabelsNoDesc}},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			if _, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t)); err != nil {
+				t.Errorf("NewMetricsAspect() => unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestFactory_NewMetricsAspectServerFail(t *testing.T) {
+	f := newFactory(&testServer{errOnStart: true})
+	if _, err := f.Build(makeConfig(), test.NewEnv(t)); err == nil {
+		t.Error("NewMetricsAspect() => expected error on server startup")
+	}
+}
+
+func TestNewMetricsAspect_MetricDefinitionErrors(t *testing.T) {
+	f := newFactory(&testServer{})
+	tests := []struct {
+		name    string
+		metrics []*config.Params_MetricInfo
+	}{
+		{"Unknown MetricKind", []*config.Params_MetricInfo{unknown}},
+	}
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			if _, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t)); err == nil {
+				t.Errorf("Expected error for NewMetricsAspect(%#v)", v.metrics)
+			}
+		})
+	}
+}
+
+func TestFactory_NewMetricsAspect_MetricDefinitionConflicts(t *testing.T) {
+	f := newFactory(&testServer{})
+
+	gaugeWithLabels := &config.Params_MetricInfo{
+		Name:        "/funky::gauge",
+		Description: "funky all the time",
+		Kind:        config.GAUGE,
+		LabelNames:  []string{"test"},
+	}
+
+	altCounter := &config.Params_MetricInfo{
+		Name:        "special_counter",
+		Description: "count all the special tests",
+		Kind:        config.COUNTER,
+		LabelNames:  []string{"email"},
+	}
+
+	altHistogram := &config.Params_MetricInfo{
+		Name:        "happy_histogram",
+		Description: "fun with buckets",
+		Kind:        config.DISTRIBUTION,
+		LabelNames:  []string{"test"},
+	}
+
+	tests := []struct {
+		name    string
+		metrics []*config.Params_MetricInfo
+	}{
+		{"Gauge Definition Conflicts", []*config.Params_MetricInfo{gaugeNoLabels, gaugeWithLabels}},
+		{"Counter Definition Conflicts", []*config.Params_MetricInfo{counter, altCounter}},
+		{"Histogram Definition Conflicts", []*config.Params_MetricInfo{histogramNoLabels, altHistogram}},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			for i, met := range v.metrics {
+				_, err := f.Build(makeConfig(met), test.NewEnv(t))
+				if i > 0 && err == nil {
+					t.Error("NewMetricsAspect() => expected error during metrics registration")
+				}
+			}
+		})
+	}
+}
+
+func TestProm_Close(t *testing.T) {
+	f := newFactory(&testServer{})
+	prom, _ := f.Build(&config.Params{}, test.NewEnv(t))
+	if err := prom.Close(); err != nil {
+		t.Errorf("Close() should not have returned an error: %v", err)
+	}
+}
+
+func TestProm_Record(t *testing.T) {
+	duration, _ := time.ParseDuration("386ms")
+
+	f := newFactory(&testServer{})
+	tests := []struct {
+		name    string
+		metrics []*config.Params_MetricInfo
+		values  []*metric.Instance
+	}{
+		{"Increment Counter", []*config.Params_MetricInfo{counter}, []*metric.Instance{counterVal}},
+		{"Histogram Observation", []*config.Params_MetricInfo{histogram}, []*metric.Instance{histogramVal}},
+		{"Change Gauge", []*config.Params_MetricInfo{gaugeNoLabels}, []*metric.Instance{gaugeVal}},
+		{"Counter and Gauge",
+			[]*config.Params_MetricInfo{counterNoLabels, gaugeNoLabels},
+			[]*metric.Instance{gaugeVal, newCounterVal(counterNoLabels.Name, float64(16))}},
+		{"Int64", []*config.Params_MetricInfo{gaugeNoLabels}, []*metric.Instance{newGaugeVal(gaugeVal.Name, int64(8))}},
+		{"Duration", []*config.Params_MetricInfo{gaugeNoLabels}, []*metric.Instance{newGaugeVal(gaugeVal.Name, duration)}},
+		{"String", []*config.Params_MetricInfo{gaugeNoLabels}, []*metric.Instance{newGaugeVal(gaugeVal.Name, "8.243543")}},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			a, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t))
+			if err != nil {
+				t.Errorf("NewMetricsAspect() => unexpected error: %v", err)
+			}
+			aspect := a.(metric.Handler)
+
+			err = aspect.HandleMetric(context.Background(), v.values)
+			if err != nil {
+				t.Errorf("Record() => unexpected error: %v", err)
+			}
+			// Check tautological recording of entries.
+			pr := aspect.(*prom)
+			for _, adapterVal := range v.values {
+				c, ok := pr.metrics[adapterVal.Name]
+				if !ok {
+					t.Errorf("Record() could not find metric with name %s:", adapterVal.Name)
+					continue
+				}
+
+				m := new(dto.Metric)
+				switch c.(type) {
+				case *prometheus.CounterVec:
+					if err := c.(*prometheus.CounterVec).With(promLabels(adapterVal.Dimensions)).Write(m); err != nil {
+						t.Errorf("Error writing metric value to proto: %v", err)
+						continue
+					}
+				case *prometheus.GaugeVec:
+					if err := c.(*prometheus.GaugeVec).With(promLabels(adapterVal.Dimensions)).Write(m); err != nil {
+						t.Errorf("Error writing metric value to proto: %v", err)
+						continue
+					}
+				case *prometheus.HistogramVec:
+					if err := c.(*prometheus.HistogramVec).With(promLabels(adapterVal.Dimensions)).Write(m); err != nil {
+						t.Errorf("Error writing metric value to proto: %v", err)
+						continue
+					}
+				}
+
+				got := metricValue(m)
+				want, err := promValue(adapterVal.Value)
+				if err != nil {
+					t.Errorf("Record(%s) could not get desired value: %v", adapterVal.Name, err)
+				}
+				if got != want {
+					t.Errorf("Record(%s) => %f, want %f", adapterVal.Name, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestProm_RecordFailures(t *testing.T) {
+	f := newFactory(&testServer{})
+	tests := []struct {
+		name    string
+		metrics []*config.Params_MetricInfo
+		values  []*metric.Instance
+	}{
+		{"Not Found", []*config.Params_MetricInfo{counterNoLabels}, []*metric.Instance{newGaugeVal(gaugeVal.Name, true)}},
+		{"Bool", []*config.Params_MetricInfo{gaugeNoLabels}, []*metric.Instance{newGaugeVal(gaugeVal.Name, true)}},
+		{"Text String (Gauge)", []*config.Params_MetricInfo{gaugeNoLabels}, []*metric.Instance{newGaugeVal(gaugeVal.Name, "not a value")}},
+		{"Text String (Counter)", []*config.Params_MetricInfo{counterNoLabels}, []*metric.Instance{newCounterVal(counterVal.Name, "not a value")}},
+		{"Text String (Histogram)", []*config.Params_MetricInfo{histogramNoLabels}, []*metric.Instance{newHistogramVal(histogramVal.Name, "not a value")}},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			a, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t))
+			if err != nil {
+				t.Errorf("NewMetricsAspect() => unexpected error: %v", err)
+			}
+			aspect := a.(metric.Handler)
+			err = aspect.HandleMetric(context.Background(), v.values)
+			if err == nil {
+				t.Error("Record() - expected error, got none")
+			}
+		})
+	}
+}
+
+func metricValue(m *dto.Metric) float64 {
+	if c := m.GetCounter(); c != nil {
+		return *c.Value
+	}
+	if c := m.GetGauge(); c != nil {
+		return *c.Value
+	}
+	if c := m.GetHistogram(); c != nil {
+		return *c.SampleSum
+	}
+	if c := m.GetUntyped(); c != nil {
+		return *c.Value
+	}
+	return -1
+}
+
+func newGaugeVal(name string, val interface{}) *metric.Instance {
+	return &metric.Instance{
+		Name:       name,
+		Value:      val,
+		Dimensions: map[string]interface{}{},
+	}
+}
+
+func newCounterVal(name string, val interface{}) *metric.Instance {
+	return &metric.Instance{
+		Name:       name,
+		Value:      val,
+		Dimensions: map[string]interface{}{},
+	}
+}
+
+func newHistogramVal(name string, val interface{}) *metric.Instance {
+	return &metric.Instance{
+		Name:       name,
+		Value:      val,
+		Dimensions: map[string]interface{}{},
+	}
+}
+
+func makeConfig(metrics ...*config.Params_MetricInfo) *config.Params {
+	return &config.Params{Metrics: metrics}
+}

--- a/adapter/prometheus2/server.go
+++ b/adapter/prometheus2/server.go
@@ -33,8 +33,6 @@ type (
 	}
 
 	serverInst struct {
-		server
-
 		addr string
 		srv  *http.Server
 	}
@@ -64,7 +62,6 @@ func (s *serverInst) Start(env adapter.Env, metricsHandler http.Handler) error {
 			_ = env.Logger().Errorf("prometheus HTTP server error: %v", err) // nolint: gas
 		}
 	})
-
 	return nil
 }
 

--- a/adapter/prometheus2/server.go
+++ b/adapter/prometheus2/server.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"istio.io/mixer/pkg/adapter"
+)
+
+type (
+	server interface {
+		io.Closer
+
+		Start(adapter.Env, http.Handler) error
+	}
+
+	serverInst struct {
+		server
+
+		addr string
+		srv  *http.Server
+	}
+)
+
+const (
+	metricsPath = "/metrics"
+	defaultAddr = ":42422"
+)
+
+func newServer(addr string) server {
+	return &serverInst{addr: addr}
+}
+
+func (s *serverInst) Start(env adapter.Env, metricsHandler http.Handler) error {
+	var listener net.Listener
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("could not start prometheus metrics server: %v", err)
+	}
+	srvMux := http.NewServeMux()
+	srvMux.Handle(metricsPath, metricsHandler)
+	s.srv = &http.Server{Addr: s.addr, Handler: srvMux}
+	env.ScheduleDaemon(func() {
+		env.Logger().Infof("serving prometheus metrics on %s", s.addr)
+		if err := s.srv.Serve(listener.(*net.TCPListener)); err != nil {
+			_ = env.Logger().Errorf("prometheus HTTP server error: %v", err) // nolint: gas
+		}
+	})
+
+	return nil
+}
+
+func (s *serverInst) Close() error {
+	if s.srv == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return s.srv.Shutdown(ctx)
+}

--- a/adapter/prometheus2/server_test.go
+++ b/adapter/prometheus2/server_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"istio.io/mixer/pkg/adapter/test"
+)
+
+func doesNothing(w http.ResponseWriter, r *http.Request) {}
+
+func TestServer(t *testing.T) {
+	testAddr := "127.0.0.1:9992"
+	s := newServer(testAddr)
+
+	if err := s.Start(test.NewEnv(t), http.HandlerFunc(doesNothing)); err != nil {
+		t.Fatalf("Start() failed unexpectedly: %v", err)
+	}
+
+	testURL := fmt.Sprintf("http://%s%s", testAddr, metricsPath)
+	// verify a response is returned from "/metrics"
+	resp, err := http.Get(testURL)
+	if err != nil {
+		t.Fatalf("Failed to retrieve '%s' path: %v", metricsPath, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("http.GET => %v, wanted '%v'", resp.StatusCode, http.StatusOK)
+	}
+
+	_ = resp.Body.Close()
+
+	s2 := newServer(testAddr)
+	if err := s2.Start(test.NewEnv(t), http.HandlerFunc(doesNothing)); err == nil {
+		t.Fatal("Start() succeeded, expecting a failure")
+	}
+
+	if err := s.Close(); err != nil {
+		t.Errorf("Failed to close server properly: %v", err)
+	}
+
+	if err := s2.Close(); err != nil {
+		t.Errorf("Failed to close server properly: %v", err)
+	}
+}

--- a/adapter/prometheus2/server_test.go
+++ b/adapter/prometheus2/server_test.go
@@ -22,7 +22,7 @@ import (
 	"istio.io/mixer/pkg/adapter/test"
 )
 
-func doesNothing(w http.ResponseWriter, r *http.Request) {}
+func doesNothing(http.ResponseWriter, *http.Request) {}
 
 func TestServer(t *testing.T) {
 	testAddr := "127.0.0.1:9992"


### PR DESCRIPTION
Called prometheus2 to avoid conflicts for now.

Unfortunately github doesn't show the diff against //adapter/prometheus, but so it goes.

**Release note**:
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1122)
<!-- Reviewable:end -->
