### PR TITLE
New handler factory

### DIFF
--- a/pkg/runtime/BUILD.bazel
+++ b/pkg/runtime/BUILD.bazel
@@ -4,9 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = [
         "dispatcher.go",
+        "handler.go",
         "monitor.go",
         "resolver.go",
-        "handler.go"
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -14,6 +14,7 @@ go_library(
         "//pkg/adapter/template:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/config/descriptor:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
         "//pkg/pool:go_default_library",
@@ -24,7 +25,6 @@ go_library(
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
-        "//pkg/config/descriptor:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_opentracing_opentracing_go//log:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/pkg/runtime/BUILD.bazel
+++ b/pkg/runtime/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "dispatcher.go",
         "monitor.go",
         "resolver.go",
+        "handler.go"
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -22,6 +23,8 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
+        "//pkg/config/descriptor:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_opentracing_opentracing_go//log:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/pkg/runtime/dispatcher_test.go
+++ b/pkg/runtime/dispatcher_test.go
@@ -318,19 +318,19 @@ type fakeProc struct {
 	quotaResult adapter.QuotaResult2
 }
 
-func (f *fakeProc) ProcessReport(ctx context.Context, instCfg map[string]proto.Message,
-	attrs attribute.Bag, mapper expr.Evaluator, handler adapter.Handler) error {
+func (f *fakeProc) ProcessReport(_ context.Context, _ map[string]proto.Message,
+	_ attribute.Bag, _ expr.Evaluator, _ adapter.Handler) error {
 	f.called++
 	return f.err
 }
-func (f *fakeProc) ProcessCheck(ctx context.Context, instName string, instCfg proto.Message, attrs attribute.Bag,
-	mapper expr.Evaluator, handler adapter.Handler) (adapter.CheckResult, error) {
+func (f *fakeProc) ProcessCheck(_ context.Context, _ string, _ proto.Message, _ attribute.Bag,
+	_ expr.Evaluator, _ adapter.Handler) (adapter.CheckResult, error) {
 	f.called++
 	return f.checkResult, f.err
 }
 
-func (f *fakeProc) ProcessQuota(ctx context.Context, quotaName string, quotaCfg proto.Message, attrs attribute.Bag,
-	mapper expr.Evaluator, handler adapter.Handler, args adapter.QuotaRequestArgs) (adapter.QuotaResult2, error) {
+func (f *fakeProc) ProcessQuota(_ context.Context, _ string, _ proto.Message, _ attribute.Bag,
+	_ expr.Evaluator, _ adapter.Handler, _ adapter.QuotaRequestArgs) (adapter.QuotaResult2, error) {
 	f.called++
 	return f.quotaResult, f.err
 }

--- a/pkg/runtime/dispatcher_test.go
+++ b/pkg/runtime/dispatcher_test.go
@@ -59,7 +59,7 @@ func TestReport(t *testing.T) {
 			if s.resolveErr {
 				resolveErr = s.callErr
 			}
-			rt := newResolver("myhandler", "i1", s.tn, resolveErr, false, fp)
+			rt := newResolver(s.tn, resolveErr, false, fp)
 			m := NewDispatcher(nil, rt, gp)
 
 			err := m.Report(context.Background(), nil)
@@ -101,7 +101,7 @@ func TestCheck(t *testing.T) {
 			if s.resolveErr {
 				resolveErr = s.callErr
 			}
-			rt := newResolver("myhandler", "i1", s.tn, resolveErr, false, fp)
+			rt := newResolver(s.tn, resolveErr, false, fp)
 			m := NewDispatcher(nil, rt, gp)
 
 			cr, err := m.Check(context.Background(), nil)
@@ -156,7 +156,7 @@ func TestQuota(t *testing.T) {
 			if s.resolveErr {
 				resolveErr = s.callErr
 			}
-			rt := newResolver("myhandler", "i1", s.tn, resolveErr, s.emptyResult, fp)
+			rt := newResolver(s.tn, resolveErr, s.emptyResult, fp)
 			m := NewDispatcher(nil, rt, gp)
 
 			cr, err := m.Quota(context.Background(), nil,
@@ -237,7 +237,10 @@ func (a *fakeActions) Done()          { a.done = true }
 
 var _ Resolver = &fakeResolver{}
 
-func newResolver(hndlr string, instanceName string, tname string, resolveErr error, emptyResult bool, fproc *fakeProc) *fakeResolver {
+func newResolver(tname string, resolveErr error, emptyResult bool, fproc *fakeProc) *fakeResolver {
+	hndlr := "myhandler"
+	instanceName := "i1"
+
 	rt := &fakeResolver{
 		ra: []*Action{
 			{

--- a/pkg/runtime/handler.go
+++ b/pkg/runtime/handler.go
@@ -52,9 +52,10 @@ type (
 	typeMap map[string]proto.Message
 )
 
-// Create instantiates a HandlerFactory, the state of the HandlerFactory is only valid for a snapshot of a configuration.
+// NewHandlerFactory instantiates a HandlerFactory, the state of the HandlerFactory is only valid for a snapshot of a configuration.
 // Therefore, a new HandlerFactory should be created upon every configuration change.
-func NewHandlerFactory(tmplRepo template.Repository, expr expr.TypeChecker, df expr.AttributeDescriptorFinder, builderInfoFinder BuilderInfoFinder) HandlerFactory {
+func NewHandlerFactory(tmplRepo template.Repository, expr expr.TypeChecker, df expr.AttributeDescriptorFinder,
+	builderInfoFinder BuilderInfoFinder) HandlerFactory {
 	return &handlerFactory{
 		tmplRepo:          tmplRepo,
 		attrDescFinder:    df,

--- a/pkg/runtime/handler.go
+++ b/pkg/runtime/handler.go
@@ -1,0 +1,167 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+
+	pbd "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/mixer/pkg/adapter"
+	pb "istio.io/mixer/pkg/config/proto"
+	"istio.io/mixer/pkg/expr"
+	"istio.io/mixer/pkg/template"
+)
+
+type (
+	// BuilderInfoFinder is used to find specific handlers BuilderInfo for configuration.
+	BuilderInfoFinder func(name string) (*adapter.BuilderInfo, bool)
+
+	// HandlerFactory builds adapter.Handler object from adapter and instances configuration.
+	HandlerFactory interface {
+		Build(*pb.Handler, []*pb.Instance, adapter.Env) (adapter.Handler, error)
+	}
+
+	handlerFactory struct {
+		tmplRepo          template.Repository
+		typeChecker       expr.TypeChecker
+		attrDescFinder    expr.AttributeDescriptorFinder
+		builderInfoFinder BuilderInfoFinder
+
+		// protects cache
+		lock           sync.RWMutex
+		infrdTypsCache map[string]proto.Message
+	}
+
+	// Map of instance name to inferred type (proto.Message)
+	types map[string]proto.Message
+)
+
+// Create instantiates a HandlerFactory, the state of the HandlerFactory is only valid for a snapshot of a configuration.
+// Therefore, a new HandlerFactory should be created upon every configuration change.
+func Create(tmplRepo template.Repository, expr expr.TypeChecker, df expr.AttributeDescriptorFinder, builderInfoFinder BuilderInfoFinder) HandlerFactory {
+	return &handlerFactory{
+		tmplRepo:          tmplRepo,
+		attrDescFinder:    df,
+		typeChecker:       expr,
+		infrdTypsCache:    make(map[string]proto.Message),
+		builderInfoFinder: builderInfoFinder,
+	}
+}
+
+// Build instantiates a Handler object using the passed in handler and instances configuration.
+func (h *handlerFactory) Build(handler *pb.Handler, instances []*pb.Instance, env adapter.Env) (adapter.Handler, error) {
+	infrdTypsByTmpl, err := h.inferTypesGrpdByTmpl(instances)
+	if err != nil {
+		return nil, err
+	}
+
+	// HandlerBuilder should always be present for a valid configuration (reference integrity should already be checked).
+	hndlrBldrInfo, _ := h.builderInfoFinder(handler.Adapter)
+
+	hndlrBldr := hndlrBldrInfo.CreateHandlerBuilder()
+	if hndlrBldr == nil {
+		msg := fmt.Sprintf("nil HandlerBuilder instantiated for adapter '%s' in handler config '%s'", handler.Adapter, handler.Name)
+		glog.Warning(msg)
+		return nil, fmt.Errorf(msg)
+	}
+
+	var hndlr adapter.Handler
+	hndlr, err = h.build(hndlrBldr, infrdTypsByTmpl, handler.Params, env)
+	if err != nil {
+		msg := fmt.Sprintf("cannot configure adapter '%s' in handler config '%s': %v", handler.Adapter, handler.Name, err)
+		glog.Warning(msg)
+		return nil, fmt.Errorf(msg)
+	}
+
+	return hndlr, err
+}
+
+func (h *handlerFactory) build(hndlrBldr adapter.HandlerBuilder, infrdTypesByTmpl map[string]types,
+	adapterCnfg interface{}, env adapter.Env) (handler adapter.Handler, err error) {
+	// calls into handler can panic. If that happens, we will log and return error with nil handler
+	defer func() {
+		if r := recover(); r != nil {
+			msg := fmt.Sprintf("handler panicked with '%v' when trying to configure the associated adapter."+
+				" Please remove the handler or fix the configuration.", r)
+			glog.Warningf(msg)
+			handler = nil
+			err = fmt.Errorf(msg)
+			return
+		}
+	}()
+
+	for tmplName, typs := range infrdTypesByTmpl {
+		// ti should be there for a valid configuration.
+		ti, _ := h.tmplRepo.GetTemplateInfo(tmplName)
+		if err := ti.ConfigureType(typs, &hndlrBldr); err != nil {
+			return nil, fmt.Errorf("cannot configure handler types %v for mesh function name '%s': %v", typs, tmplName, err)
+		}
+	}
+
+	return hndlrBldr.Build(adapterCnfg.(proto.Message), env)
+}
+
+func (h *handlerFactory) inferTypesGrpdByTmpl(instances []*pb.Instance) (map[string]types, error) {
+	infrdTypesByTmpl := make(map[string]types)
+	for _, instance := range instances {
+		infrdType, err := h.inferType(instance)
+		if err != nil {
+			return infrdTypesByTmpl, err
+		}
+
+		if _, exists := infrdTypesByTmpl[instance.GetTemplate()]; !exists {
+			infrdTypesByTmpl[instance.GetTemplate()] = make(types)
+		}
+
+		infrdTypesByTmpl[instance.GetTemplate()][instance.Name] = infrdType
+	}
+	return infrdTypesByTmpl, nil
+}
+
+func (h *handlerFactory) inferType(instance *pb.Instance) (proto.Message, error) {
+
+	var infrdType proto.Message
+	var err error
+	var found bool
+
+	h.lock.RLock()
+	infrdType, found = h.infrdTypsCache[instance.Name]
+	h.lock.RUnlock()
+
+	if found {
+		return infrdType, nil
+	}
+
+	// ti should be there since the config is already validated
+	tmplInfo, _ := h.tmplRepo.GetTemplateInfo(instance.GetTemplate())
+
+	infrdType, err = tmplInfo.InferType(instance.GetParams().(proto.Message), func(expr string) (pbd.ValueType, error) {
+		return h.typeChecker.EvalType(expr, h.attrDescFinder)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot infer type information from params in instance '%s': %v", instance.Name, err)
+	}
+
+	// obtain write lock
+	h.lock.Lock()
+	h.infrdTypsCache[instance.Name] = infrdType
+	h.lock.Unlock()
+
+	return infrdType, nil
+}

--- a/pkg/runtime/handler_test.go
+++ b/pkg/runtime/handler_test.go
@@ -159,7 +159,7 @@ func TestBuild_Error(t *testing.T) {
 				return &adapter.BuilderInfo{CreateHandlerBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
 			}
 
-			hf := Create(tt.tmplRepo, nil, nil, bldrInfoFinder)
+			hf := NewHandlerFactory(tt.tmplRepo, nil, nil, bldrInfoFinder)
 			_, err := hf.Build(tt.hndlrCnfg, tt.instsCnfg, nil)
 			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
 				t.Errorf("got error %v\nwant %v", err, tt.wantError)
@@ -276,7 +276,7 @@ func TestBuild_Valid(t *testing.T) {
 				return &adapter.BuilderInfo{CreateHandlerBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
 			}
 
-			hf := Create(tt.tmplRepo, nil, nil, bldrInfoFinder)
+			hf := NewHandlerFactory(tt.tmplRepo, nil, nil, bldrInfoFinder)
 			hndlr, err := hf.Build(tt.hndlrCnfg, tt.instsCnfg, nil)
 			if err != nil {
 				t.Fatalf("got err %v\nwant <nil>", err)

--- a/pkg/runtime/handler_test.go
+++ b/pkg/runtime/handler_test.go
@@ -1,0 +1,293 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"istio.io/mixer/pkg/adapter"
+	pb "istio.io/mixer/pkg/config/proto"
+	tmpl "istio.io/mixer/pkg/template"
+)
+
+type fakeTmplRepo struct {
+	infrErr    error
+	cnfgrErr   error
+	cnfgrPanic string
+	typeResult proto.Message
+
+	cnfgMtdCallInfo map[string]map[string]proto.Message // templateName - > map[instName]InferredType (proto.Message)
+}
+
+func (t fakeTmplRepo) GetTemplateInfo(template string) (tmpl.Info, bool) {
+	return tmpl.Info{
+		InferType: func(proto.Message, tmpl.TypeEvalFn) (proto.Message, error) {
+			return t.typeResult, t.infrErr
+		},
+		ConfigureType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+			if t.cnfgrPanic != "" {
+				panic(t.cnfgrPanic)
+			}
+			if t.cnfgMtdCallInfo != nil {
+				t.cnfgMtdCallInfo[template] = types
+			}
+
+			return t.cnfgrErr
+		},
+	}, true
+}
+
+func (t fakeTmplRepo) SupportsTemplate(hndlrBuilder adapter.HandlerBuilder, s string) (bool, string) {
+	// always succeed
+	return true, ""
+}
+
+type fakeHndlrBldr struct {
+	bldPanic string
+	bldErr   error
+}
+type fakeHndlr struct {
+	createdWithCnfg adapter.Config
+}
+
+func (f fakeHndlr) Close() error {
+	return nil
+}
+
+func (f fakeHndlrBldr) Build(cnfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
+	if f.bldPanic != "" {
+		panic(f.bldPanic)
+	}
+
+	return fakeHndlr{createdWithCnfg: cnfg}, f.bldErr
+}
+
+func TestBuild_Error(t *testing.T) {
+	tests := []struct {
+		name string
+
+		instsCnfg []*pb.Instance
+		hndlrCnfg *pb.Handler
+
+		tmplRepo     tmpl.Repository
+		hndlrBuilder adapter.HandlerBuilder
+
+		// want      proto.Message
+		wantError string
+	}{
+		{
+			name:         "ErrorNilCreatedHandlerBuilder",
+			hndlrBuilder: nil,
+			wantError:    "nil HandlerBuilder instantiated for adapter 'a1' in handler config 'h1'",
+
+			hndlrCnfg: &pb.Handler{Name: "h1", Adapter: "a1"},
+		},
+		{
+			name:      "ErrorConfigureXXXX",
+			tmplRepo:  fakeTmplRepo{cnfgrErr: fmt.Errorf("FOOBAR ERROR")},
+			wantError: "for mesh function name 'tpml1': FOOBAR ERROR",
+
+			instsCnfg:    []*pb.Instance{{"inst1", "tpml1", &empty.Empty{}}},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &empty.Empty{}},
+			hndlrBuilder: fakeHndlrBldr{},
+		},
+
+		{
+			name:     "PanicConfigureXXXX",
+			tmplRepo: fakeTmplRepo{cnfgrPanic: "FOOBAR PANIC"},
+			wantError: "handler panicked with 'FOOBAR PANIC' when trying to configure the " +
+				"associated adapter. Please remove the handler or fix the configuration",
+
+			instsCnfg:    []*pb.Instance{{"inst1", "tpml1", &empty.Empty{}}},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1"},
+			hndlrBuilder: fakeHndlrBldr{},
+		},
+
+		{
+			name:         "ErrorAdptBuildXXXX",
+			hndlrBuilder: fakeHndlrBldr{bldErr: fmt.Errorf("FOOBAR ERROR from HandlerBuidler build")},
+			wantError:    "cannot configure adapter 'a1' in handler config 'h1': FOOBAR ERROR from HandlerBuidler build",
+
+			tmplRepo:  fakeTmplRepo{},
+			instsCnfg: []*pb.Instance{{"inst1", "tpml1", &empty.Empty{}}},
+			hndlrCnfg: &pb.Handler{Name: "h1", Adapter: "a1", Params: &empty.Empty{}},
+		},
+
+		{
+			name:         "PanicAdptBuild",
+			hndlrBuilder: fakeHndlrBldr{bldPanic: "FOOBAR ERROR panic from HandlerBuidler build"},
+			wantError: "handler panicked with 'FOOBAR ERROR panic from HandlerBuidler build' when trying to " +
+				"configure the associated adapter",
+
+			tmplRepo:  fakeTmplRepo{},
+			hndlrCnfg: &pb.Handler{Name: "h1", Adapter: "a1", Params: &empty.Empty{}},
+		},
+
+		{
+			name:      "ErrorTypeInferError",
+			tmplRepo:  fakeTmplRepo{infrErr: fmt.Errorf("FOOBAR ERROR")},
+			wantError: "cannot infer type information from params in instance 'inst1': FOOBAR ERROR",
+
+			instsCnfg:    []*pb.Instance{{"inst1", "tpml1", &empty.Empty{}}},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1"},
+			hndlrBuilder: fakeHndlrBldr{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			bldrInfoFinder := func(name string) (*adapter.BuilderInfo, bool) {
+				return &adapter.BuilderInfo{CreateHandlerBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
+			}
+
+			hf := Create(tt.tmplRepo, nil, nil, bldrInfoFinder)
+			_, err := hf.Build(tt.hndlrCnfg, tt.instsCnfg, nil)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Errorf("got error %v\nwant %v", err, tt.wantError)
+			}
+
+		})
+	}
+}
+
+func TestBuild_Valid(t *testing.T) {
+	tests := []struct {
+		name string
+
+		instsCnfg []*pb.Instance
+		hndlrCnfg *pb.Handler
+
+		tmplRepo     fakeTmplRepo
+		hndlrBuilder adapter.HandlerBuilder
+
+		wantCnfgMtdCallInfo map[string]map[string]proto.Message // templateName - > map[instName]InferredType (proto.Message)
+		wantBldMtdCnfgParam proto.Message                       // expected adaper-cnfg passed to the HandlerBuilder in handlerBuilder.Build mtd
+	}{
+		{
+			name:         "SingleInstance",
+			tmplRepo:     fakeTmplRepo{typeResult: &wrappers.Int32Value{Value: 1}, cnfgMtdCallInfo: make(map[string]map[string]proto.Message)},
+			instsCnfg:    []*pb.Instance{{"inst1", "tmpl1", &empty.Empty{}}},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
+			hndlrBuilder: fakeHndlrBldr{},
+
+			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{"tmpl1": {"inst1": &wrappers.Int32Value{Value: 1}}},
+			wantBldMtdCnfgParam: &wrappers.Int32Value{Value: 2},
+		},
+		{
+			name:         "EmptyInstance",
+			tmplRepo:     fakeTmplRepo{cnfgMtdCallInfo: make(map[string]map[string]proto.Message)},
+			instsCnfg:    []*pb.Instance{},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
+			hndlrBuilder: fakeHndlrBldr{},
+
+			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{},
+			wantBldMtdCnfgParam: &wrappers.Int32Value{Value: 2},
+		},
+		{
+			name:     "SingleTmplMultipleInstances",
+			tmplRepo: fakeTmplRepo{typeResult: &wrappers.Int32Value{Value: 1}, cnfgMtdCallInfo: make(map[string]map[string]proto.Message)},
+			instsCnfg: []*pb.Instance{
+				{"inst1", "tmpl1", &empty.Empty{}},
+				{"inst2", "tmpl1", &empty.Empty{}},
+			},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
+			hndlrBuilder: fakeHndlrBldr{},
+
+			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{
+				"tmpl1": {
+					"inst2": &wrappers.Int32Value{Value: 1},
+					"inst1": &wrappers.Int32Value{Value: 1},
+				},
+			},
+			wantBldMtdCnfgParam: &wrappers.Int32Value{Value: 2},
+		},
+		{
+			name:     "DedupeInstances",
+			tmplRepo: fakeTmplRepo{typeResult: &wrappers.Int32Value{Value: 1}, cnfgMtdCallInfo: make(map[string]map[string]proto.Message)},
+			instsCnfg: []*pb.Instance{
+				{"dupe", "tmpl1", &empty.Empty{}},
+				{"dupe", "tmpl1", &empty.Empty{}},
+				{"inst2", "tmpl1", &empty.Empty{}},
+			},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
+			hndlrBuilder: fakeHndlrBldr{},
+
+			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{
+				"tmpl1": {
+					"inst2": &wrappers.Int32Value{Value: 1},
+					"dupe":  &wrappers.Int32Value{Value: 1},
+				},
+			},
+			wantBldMtdCnfgParam: &wrappers.Int32Value{Value: 2},
+		},
+		{
+			name:     "MultipleTmplMultipleInstances",
+			tmplRepo: fakeTmplRepo{typeResult: &wrappers.Int32Value{Value: 1}, cnfgMtdCallInfo: make(map[string]map[string]proto.Message)},
+			instsCnfg: []*pb.Instance{
+				{"inst1", "tmpl1", &empty.Empty{}},
+				{"inst2", "tmpl1", &empty.Empty{}},
+				{"inst3", "tmpl1", &empty.Empty{}},
+
+				{"inst4", "tmpl2", &empty.Empty{}},
+				{"inst5", "tmpl2", &empty.Empty{}},
+				{"inst6", "tmpl2", &empty.Empty{}},
+			},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
+			hndlrBuilder: fakeHndlrBldr{},
+
+			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{
+				"tmpl1": {
+					"inst1": &wrappers.Int32Value{Value: 1},
+					"inst2": &wrappers.Int32Value{Value: 1},
+					"inst3": &wrappers.Int32Value{Value: 1},
+				},
+				"tmpl2": {
+					"inst4": &wrappers.Int32Value{Value: 1},
+					"inst5": &wrappers.Int32Value{Value: 1},
+					"inst6": &wrappers.Int32Value{Value: 1},
+				},
+			},
+			wantBldMtdCnfgParam: &wrappers.Int32Value{Value: 2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			bldrInfoFinder := func(name string) (*adapter.BuilderInfo, bool) {
+				return &adapter.BuilderInfo{CreateHandlerBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
+			}
+
+			hf := Create(tt.tmplRepo, nil, nil, bldrInfoFinder)
+			hndlr, err := hf.Build(tt.hndlrCnfg, tt.instsCnfg, nil)
+			if err != nil {
+				t.Fatalf("got err %v\nwant <nil>", err)
+			}
+			fHndlr := hndlr.(fakeHndlr)
+			if !reflect.DeepEqual(tt.wantCnfgMtdCallInfo, tt.tmplRepo.cnfgMtdCallInfo) {
+				t.Errorf("got %v\nwant %v", tt.tmplRepo.cnfgMtdCallInfo, tt.wantCnfgMtdCallInfo)
+			}
+			if !reflect.DeepEqual(tt.wantBldMtdCnfgParam, fHndlr.createdWithCnfg) {
+				t.Errorf("got %v\nwant %v", fHndlr.createdWithCnfg, tt.wantBldMtdCnfgParam)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented a handler creation factory that is need for handler instantiation on config change.

The HandlerFactory interface exposed by the code is needed by @mandarjog's ConfigCoordinator. Until this code is integrated with ConfigCoordinator, it is pretty much dead code.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1125)
<!-- Reviewable:end -->
