### PR TITLE
Implement CRD creation for adapters and mesh functions.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -214,6 +214,14 @@ go_repository(
 )
 
 go_repository(
+    name = "io_k8s_apiextensions_apiserver",
+    build_file_generation = "on",
+    build_file_name = "BUILD.bazel",
+    commit = "c682349b0d1c12975d8e24a9799b66747255d7a5",  #  Jul 18, 2017 (no releases)
+    importpath = "k8s.io/apiextensions-apiserver",
+)
+
+go_repository(
     name = "com_github_ugorji_go",
     commit = "708a42d246822952f38190a8d8c4e6b16a0e600c",  # Mar 12, 2017 (no releases)
     importpath = "github.com/ugorji/go",

--- a/adapter/stackdriver/bufferedClient_test.go
+++ b/adapter/stackdriver/bufferedClient_test.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googleapis/gax-go"
+	gax "github.com/googleapis/gax-go"
 	xcontext "golang.org/x/net/context"
-	"google.golang.org/genproto/googleapis/monitoring/v3"
+	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
 
 	"istio.io/mixer/pkg/adapter/test"
 )

--- a/adapter/stackdriver/merge.go
+++ b/adapter/stackdriver/merge.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
-	"google.golang.org/genproto/googleapis/monitoring/v3"
+	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
 
 	"istio.io/mixer/pkg/adapter"
 )

--- a/adapter/stackdriver/merge_test.go
+++ b/adapter/stackdriver/merge_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
-	"google.golang.org/genproto/googleapis/monitoring/v3"
+	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
 
 	"istio.io/mixer/pkg/adapter/test"
 )

--- a/adapter/stackdriver/stackdriver.go
+++ b/adapter/stackdriver/stackdriver.go
@@ -22,7 +22,7 @@ import (
 
 	monitoring "cloud.google.com/go/monitoring/apiv3"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/googleapis/gax-go"
+	gax "github.com/googleapis/gax-go"
 	xcontext "golang.org/x/net/context"
 	gapiopts "google.golang.org/api/option"
 	labelpb "google.golang.org/genproto/googleapis/api/label"

--- a/cmd/collateral/cmd/root.go
+++ b/cmd/collateral/cmd/root.go
@@ -55,7 +55,7 @@ func GetRootCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 func work(printf, fatalf shared.FormatFn, outputDir string) {
 	roots := []*cobra.Command{
 		mixc.GetRootCmd(nil, nil, nil),
-		mixs.GetRootCmd(nil, nil, nil, nil),
+		mixs.GetRootCmd(nil, nil, nil, nil, nil),
 	}
 
 	printf("Outputting Mixer CLI collateral files to %s", outputDir)

--- a/cmd/server/BUILD
+++ b/cmd/server/BUILD
@@ -11,8 +11,10 @@ go_binary(
     linkstamp = "istio.io/mixer/pkg/version",
     visibility = ["//visibility:public"],
     deps = [
+        "//adapter:go_default_library",
         "//cmd/server/cmd:go_default_library",
         "//cmd/shared:go_default_library",
+        "//pkg/adapter:go_default_library",
         "//pkg/template:go_default_library",
         "//template:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -1,10 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
+        "crd.go",
         "inventory.go",
         "root.go",
         "server.go",
@@ -34,8 +35,18 @@ go_library(
         "@com_github_openzipkin_zipkin_go_opentracing//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//grpclog/glogger:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["crd_test.go"],
+    library = ":go_default_library",
 )

--- a/cmd/server/cmd/crd.go
+++ b/cmd/server/cmd/crd.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"sort"
+
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -59,7 +61,16 @@ func listCrdsAdapters(printf shared.FormatFn, infoFns []pkgadapter.InfoFn) {
 }
 
 func listCrdsInstances(printf shared.FormatFn, tmplInfos map[string]template.Info) {
-	for _, info := range tmplInfos {
+	tmplNames := make([]string, 0, len(tmplInfos))
+
+	for name := range tmplInfos {
+		tmplNames = append(tmplNames, name)
+	}
+
+	sort.Strings(tmplNames)
+
+	for _, tmplName := range tmplNames {
+		info := tmplInfos[tmplName]
 		printCrd(printf, info.Name, info.HndlrInterfaceName, "mixer-instance")
 	}
 }

--- a/cmd/server/cmd/crd.go
+++ b/cmd/server/cmd/crd.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/mixer/cmd/shared"
+	pkgAdapter "istio.io/mixer/pkg/adapter"
+	pkgadapter "istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/template"
+)
+
+func crdCmd(tmplInfos map[string]template.Info, adapters []pkgAdapter.InfoFn, printf shared.FormatFn) *cobra.Command {
+	adapterCmd := cobra.Command{
+		Use:   "crd",
+		Short: "CRDs (CustomResourceDefinition) available in Mixer",
+	}
+
+	adapterCmd.AddCommand(&cobra.Command{
+		Use:   "adapter",
+		Short: "List CRDs for available adapters",
+		Run: func(cmd *cobra.Command, args []string) {
+			listCrdsAdapters(printf, adapters)
+		},
+	})
+
+	adapterCmd.AddCommand(&cobra.Command{
+		Use:   "instance",
+		Short: "List CRDs for available instance kinds (mesh functions)",
+		Run: func(cmd *cobra.Command, args []string) {
+			listCrdsInstances(printf, tmplInfos)
+		},
+	})
+
+	return &adapterCmd
+}
+
+func listCrdsAdapters(printf shared.FormatFn, infoFns []pkgadapter.InfoFn) {
+	for _, infoFn := range infoFns {
+		info := infoFn()
+		printCrd(printf, info.Name /* TODO make this info.shortName when related PR is in. */, info.Name, "mixer-adapter")
+	}
+}
+
+func listCrdsInstances(printf shared.FormatFn, tmplInfos map[string]template.Info) {
+	for _, info := range tmplInfos {
+		printCrd(printf, info.Name, info.HndlrInterfaceName, "mixer-instance")
+	}
+}
+
+func printCrd(printf shared.FormatFn, shrtName string, implName string, istioLabel string) {
+	crd := apiextensionsv1beta1.CustomResourceDefinition{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind: "CustomResourceDefinition",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: shrtName + ".config.istio.io",
+			Labels: map[string]string{
+				"impl":  implName,
+				"istio": istioLabel,
+			},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "config.istio.io",
+			Version: "v1alpha2",
+			Scope:   apiextensionsv1beta1.NamespaceScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   shrtName + "s",
+				Singular: shrtName,
+				Kind:     shrtName,
+			},
+		},
+	}
+	out, err := yaml.Marshal(crd)
+	if err != nil {
+		printf("%s", err)
+		return
+	}
+	printf(string(out))
+	printf("---\n")
+}

--- a/cmd/server/cmd/crd.go
+++ b/cmd/server/cmd/crd.go
@@ -79,20 +79,21 @@ func listCrdsInstances(printf shared.FormatFn, infos map[string]template.Info) {
 }
 
 func printCrd(printf shared.FormatFn, shrtName, implName, pluralName, label string) {
+	group := "config.istio.io"
 	crd := apiextensionsv1beta1.CustomResourceDefinition{
 		TypeMeta: meta_v1.TypeMeta{
 			Kind:       "CustomResourceDefinition",
 			APIVersion: "apiextensions.k8s.io/v1beta1",
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: shrtName + ".config.istio.io",
+			Name: pluralName + "." + group,
 			Labels: map[string]string{
 				"impl":  implName,
 				"istio": label,
 			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "config.istio.io",
+			Group:   group,
 			Version: "v1alpha2",
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{

--- a/cmd/server/cmd/crd.go
+++ b/cmd/server/cmd/crd.go
@@ -60,22 +60,22 @@ func listCrdsAdapters(printf shared.FormatFn, infoFns []pkgadapter.InfoFn) {
 	}
 }
 
-func listCrdsInstances(printf shared.FormatFn, tmplInfos map[string]template.Info) {
-	tmplNames := make([]string, 0, len(tmplInfos))
+func listCrdsInstances(printf shared.FormatFn, infos map[string]template.Info) {
+	tmplNames := make([]string, 0, len(infos))
 
-	for name := range tmplInfos {
+	for name := range infos {
 		tmplNames = append(tmplNames, name)
 	}
 
 	sort.Strings(tmplNames)
 
 	for _, tmplName := range tmplNames {
-		info := tmplInfos[tmplName]
+		info := infos[tmplName]
 		printCrd(printf, info.Name, info.HndlrInterfaceName, "mixer-instance")
 	}
 }
 
-func printCrd(printf shared.FormatFn, shrtName string, implName string, istioLabel string) {
+func printCrd(printf shared.FormatFn, shrtName, implName, label string) {
 	crd := apiextensionsv1beta1.CustomResourceDefinition{
 		TypeMeta: meta_v1.TypeMeta{
 			Kind: "CustomResourceDefinition",
@@ -84,7 +84,7 @@ func printCrd(printf shared.FormatFn, shrtName string, implName string, istioLab
 			Name: shrtName + ".config.istio.io",
 			Labels: map[string]string{
 				"impl":  implName,
-				"istio": istioLabel,
+				"istio": label,
 			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{

--- a/cmd/server/cmd/crd.go
+++ b/cmd/server/cmd/crd.go
@@ -56,7 +56,9 @@ func crdCmd(tmplInfos map[string]template.Info, adapters []pkgAdapter.InfoFn, pr
 func listCrdsAdapters(printf shared.FormatFn, infoFns []pkgadapter.InfoFn) {
 	for _, infoFn := range infoFns {
 		info := infoFn()
-		printCrd(printf, info.Name /* TODO make this info.shortName when related PR is in. */, info.Name, "mixer-adapter")
+		shrtName := info.Name /* TODO make this info.shortName when related PR is in. */
+		// TODO : Use the plural name from the adapter info
+		printCrd(printf, shrtName, info.Name, shrtName+"s", "mixer-adapter")
 	}
 }
 
@@ -71,14 +73,16 @@ func listCrdsInstances(printf shared.FormatFn, infos map[string]template.Info) {
 
 	for _, tmplName := range tmplNames {
 		info := infos[tmplName]
-		printCrd(printf, info.Name, info.HndlrInterfaceName, "mixer-instance")
+		// TODO : Use the plural name from the template info
+		printCrd(printf, info.Name, info.HndlrInterfaceName, info.Name+"s", "mixer-instance")
 	}
 }
 
-func printCrd(printf shared.FormatFn, shrtName, implName, label string) {
+func printCrd(printf shared.FormatFn, shrtName, implName, pluralName, label string) {
 	crd := apiextensionsv1beta1.CustomResourceDefinition{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind: "CustomResourceDefinition",
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1beta1",
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: shrtName + ".config.istio.io",
@@ -92,7 +96,7 @@ func printCrd(printf shared.FormatFn, shrtName, implName, label string) {
 			Version: "v1alpha2",
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   shrtName + "s",
+				Plural:   pluralName,
 				Singular: shrtName,
 				Kind:     shrtName,
 			},

--- a/cmd/server/cmd/crd_test.go
+++ b/cmd/server/cmd/crd_test.go
@@ -39,7 +39,7 @@ metadata:
   labels:
     impl: foo-bar
     istio: mixer-adapter
-  name: foo-bar.config.istio.io
+  name: foo-bars.config.istio.io
 spec:
   group: config.istio.io
   names:
@@ -61,7 +61,7 @@ metadata:
   labels:
     impl: abcd
     istio: mixer-adapter
-  name: abcd.config.istio.io
+  name: abcds.config.istio.io
 spec:
   group: config.istio.io
   names:
@@ -90,7 +90,7 @@ metadata:
   labels:
     impl: ""
     istio: mixer-instance
-  name: abcd-foo.config.istio.io
+  name: abcd-foos.config.istio.io
 spec:
   group: config.istio.io
   names:
@@ -112,7 +112,7 @@ metadata:
   labels:
     impl: ""
     istio: mixer-instance
-  name: abcdBar.config.istio.io
+  name: abcdBars.config.istio.io
 spec:
   group: config.istio.io
   names:

--- a/cmd/server/cmd/crd_test.go
+++ b/cmd/server/cmd/crd_test.go
@@ -1,0 +1,174 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"istio.io/mixer/pkg/adapter"
+	pkgadapter "istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/template"
+)
+
+var empty = ``
+
+var exampleAdapters = []pkgadapter.InfoFn{
+	func() adapter.BuilderInfo { return adapter.BuilderInfo{Name: "foo-bar"} },
+	func() adapter.BuilderInfo { return adapter.BuilderInfo{Name: "abcd"} },
+}
+var exampleAdaptersCrd = `
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    impl: foo-bar
+    istio: mixer-adapter
+  name: foo-bar.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    kind: foo-bar
+    plural: foo-bars
+    singular: foo-bar
+  scope: Namespaced
+  version: v1alpha2
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+---
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    impl: abcd
+    istio: mixer-adapter
+  name: abcd.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    kind: abcd
+    plural: abcds
+    singular: abcd
+  scope: Namespaced
+  version: v1alpha2
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+---
+`
+
+var exampleTmplInfos = map[string]template.Info{
+	"abcd-foo": {Name: "abcd-foo"},
+	"abcdBar":  {Name: "abcdBar"},
+}
+var exampleInstanceCrd = `
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    impl: ""
+    istio: mixer-instance
+  name: abcd-foo.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    kind: abcd-foo
+    plural: abcd-foos
+    singular: abcd-foo
+  scope: Namespaced
+  version: v1alpha2
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+---
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    impl: ""
+    istio: mixer-instance
+  name: abcdBar.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    kind: abcdBar
+    plural: abcdBars
+    singular: abcdBar
+  scope: Namespaced
+  version: v1alpha2
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+---
+`
+
+func TestListCrdsAdapters(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []pkgadapter.InfoFn
+		wantOut string
+	}{
+		{"empty", []pkgadapter.InfoFn{}, empty},
+		{"example", exampleAdapters, exampleAdaptersCrd},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			var printf = func(format string, args ...interface{}) {
+				buffer.WriteString(fmt.Sprintf(format, args...))
+			}
+			listCrdsAdapters(printf, tt.args)
+			gotOut := buffer.String()
+			if strings.TrimSpace(gotOut) != strings.TrimSpace(tt.wantOut) {
+				t.Errorf("listCrdsAdapters() = %s, want %s", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestListCrdsInstances(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]template.Info
+		wantOut string
+	}{
+		{"empty", map[string]template.Info{}, empty},
+		{"example", exampleTmplInfos, exampleInstanceCrd},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			var printf = func(format string, args ...interface{}) {
+				buffer.WriteString(fmt.Sprintf(format, args...))
+			}
+			listCrdsInstances(printf, tt.args)
+			gotOut := buffer.String()
+			if strings.TrimSpace(gotOut) != strings.TrimSpace(tt.wantOut) {
+				t.Errorf("listCrdsInstances() = %s, want %s", gotOut, tt.wantOut)
+			}
+		})
+	}
+}

--- a/cmd/server/cmd/crd_test.go
+++ b/cmd/server/cmd/crd_test.go
@@ -32,6 +32,7 @@ var exampleAdapters = []pkgadapter.InfoFn{
 	func() adapter.BuilderInfo { return adapter.BuilderInfo{Name: "abcd"} },
 }
 var exampleAdaptersCrd = `
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -53,6 +54,7 @@ status:
     plural: ""
   conditions: null
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -81,6 +83,7 @@ var exampleTmplInfos = map[string]template.Info{
 	"abcdBar":  {Name: "abcdBar"},
 }
 var exampleInstanceCrd = `
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -102,6 +105,7 @@ status:
     plural: ""
   conditions: null
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -22,11 +22,12 @@ import (
 	_ "google.golang.org/grpc/grpclog/glogger" // needed to initialize glog
 
 	"istio.io/mixer/cmd/shared"
+	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/template"
 )
 
 // GetRootCmd returns the root of the cobra command-tree.
-func GetRootCmd(args []string, tmplRepo template.Repository, printf, fatalf shared.FormatFn) *cobra.Command {
+func GetRootCmd(args []string, tmplInfos map[string]template.Info, adapters []adapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "mixs",
 		Short: "Mixer is Istio's abstraction on top of infrastructure backends.",
@@ -50,7 +51,8 @@ func GetRootCmd(args []string, tmplRepo template.Repository, printf, fatalf shar
 	flag.CommandLine = fs
 
 	rootCmd.AddCommand(adapterCmd(printf))
-	rootCmd.AddCommand(serverCmd(tmplRepo, printf, fatalf))
+	rootCmd.AddCommand(serverCmd(template.NewRepository(tmplInfos), adapters, printf, fatalf))
+	rootCmd.AddCommand(crdCmd(tmplInfos, adapters, printf))
 	rootCmd.AddCommand(shared.VersionCmd(printf))
 
 	return rootCmd

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -27,7 +27,7 @@ import (
 )
 
 // GetRootCmd returns the root of the cobra command-tree.
-func GetRootCmd(args []string, tmplInfos map[string]template.Info, adapters []adapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
+func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "mixs",
 		Short: "Mixer is Istio's abstraction on top of infrastructure backends.",
@@ -51,8 +51,8 @@ func GetRootCmd(args []string, tmplInfos map[string]template.Info, adapters []ad
 	flag.CommandLine = fs
 
 	rootCmd.AddCommand(adapterCmd(printf))
-	rootCmd.AddCommand(serverCmd(template.NewRepository(tmplInfos), adapters, printf, fatalf))
-	rootCmd.AddCommand(crdCmd(tmplInfos, adapters, printf))
+	rootCmd.AddCommand(serverCmd(template.NewRepository(info), adapters, printf, fatalf))
+	rootCmd.AddCommand(crdCmd(info, adapters, printf))
 	rootCmd.AddCommand(shared.VersionCmd(printf))
 
 	return rootCmd

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -40,6 +40,7 @@ import (
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/mixer/adapter"
 	"istio.io/mixer/cmd/shared"
+	pkgAdapter "istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/adapterManager"
 	"istio.io/mixer/pkg/api"
 	"istio.io/mixer/pkg/aspect"
@@ -85,7 +86,7 @@ type serverArgs struct {
 	globalConfigFile string
 }
 
-func serverCmd(tmplRepo template.Repository, printf, fatalf shared.FormatFn) *cobra.Command {
+func serverCmd(tmplRepo template.Repository, adapters []pkgAdapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	sa := &serverArgs{}
 	serverCmd := cobra.Command{
 		Use:   "server",
@@ -102,7 +103,7 @@ func serverCmd(tmplRepo template.Repository, printf, fatalf shared.FormatFn) *co
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			runServer(sa, tmplRepo, printf, fatalf)
+			runServer(sa, tmplRepo, adapters, printf, fatalf)
 		},
 	}
 
@@ -186,7 +187,7 @@ func configStore(url, serviceConfigFile, globalConfigFile string, printf, fatalf
 	return s
 }
 
-func runServer(sa *serverArgs, tmplRepo template.Repository, printf, fatalf shared.FormatFn) {
+func runServer(sa *serverArgs, tmplRepo template.Repository, adapters []pkgAdapter.InfoFn, printf, fatalf shared.FormatFn) {
 	printf("Mixer started with args: %#v", sa)
 
 	var err error
@@ -219,7 +220,7 @@ func runServer(sa *serverArgs, tmplRepo template.Repository, printf, fatalf shar
 	}
 	store := configStore(sa.configStoreURL, sa.serviceConfigFile, sa.globalConfigFile, printf, fatalf)
 	adapterMgr := adapterManager.NewManager(adapter.Inventory(), aspect.Inventory(), eval, gp, adapterGP)
-	configManager := config.NewManager(eval, adapterMgr.AspectValidatorFinder, adapterMgr.BuilderValidatorFinder, adapter.Inventory2(),
+	configManager := config.NewManager(eval, adapterMgr.AspectValidatorFinder, adapterMgr.BuilderValidatorFinder, adapters,
 		adapterMgr.SupportedKinds,
 		tmplRepo, store, time.Second*time.Duration(sa.configFetchIntervalSec),
 		sa.configIdentityAttribute,

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -86,7 +86,7 @@ type serverArgs struct {
 	globalConfigFile string
 }
 
-func serverCmd(tmplRepo template.Repository, adapters []pkgAdapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
+func serverCmd(repo template.Repository, adapters []pkgAdapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	sa := &serverArgs{}
 	serverCmd := cobra.Command{
 		Use:   "server",
@@ -103,7 +103,7 @@ func serverCmd(tmplRepo template.Repository, adapters []pkgAdapter.InfoFn, print
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			runServer(sa, tmplRepo, adapters, printf, fatalf)
+			runServer(sa, repo, adapters, printf, fatalf)
 		},
 	}
 
@@ -187,7 +187,7 @@ func configStore(url, serviceConfigFile, globalConfigFile string, printf, fatalf
 	return s
 }
 
-func runServer(sa *serverArgs, tmplRepo template.Repository, adapters []pkgAdapter.InfoFn, printf, fatalf shared.FormatFn) {
+func runServer(sa *serverArgs, repo template.Repository, adapters []pkgAdapter.InfoFn, printf, fatalf shared.FormatFn) {
 	printf("Mixer started with args: %#v", sa)
 
 	var err error
@@ -222,13 +222,13 @@ func runServer(sa *serverArgs, tmplRepo template.Repository, adapters []pkgAdapt
 	adapterMgr := adapterManager.NewManager(adapter.Inventory(), aspect.Inventory(), eval, gp, adapterGP)
 	configManager := config.NewManager(eval, adapterMgr.AspectValidatorFinder, adapterMgr.BuilderValidatorFinder, adapters,
 		adapterMgr.SupportedKinds,
-		tmplRepo, store, time.Second*time.Duration(sa.configFetchIntervalSec),
+		repo, store, time.Second*time.Duration(sa.configFetchIntervalSec),
 		sa.configIdentityAttribute,
 		sa.configIdentityAttributeDomain)
 
 	configAPIServer := config.NewAPI("v1", sa.configAPIPort, eval,
 		adapterMgr.AspectValidatorFinder, adapterMgr.BuilderValidatorFinder, adapter.Inventory2(),
-		adapterMgr.SupportedKinds, store, tmplRepo)
+		adapterMgr.SupportedKinds, store, repo)
 
 	var serverCert *tls.Certificate
 	var clientCerts *x509.CertPool

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,16 +25,16 @@ import (
 	generatedTmplRepo "istio.io/mixer/template"
 )
 
-func getSupportedTemplateInfos() map[string]template.Info {
+func supportedTemplates() map[string]template.Info {
 	return generatedTmplRepo.SupportedTmplInfo
 }
 
-func getSupportedAdapters() []pkgAdapter.InfoFn {
+func supportedAdapters() []pkgAdapter.InfoFn {
 	return adapter.Inventory2()
 }
 
 func main() {
-	rootCmd := cmd.GetRootCmd(os.Args[1:], getSupportedTemplateInfos(), getSupportedAdapters(), shared.Printf, shared.Fatalf)
+	rootCmd := cmd.GetRootCmd(os.Args[1:], supportedTemplates(), supportedAdapters(), shared.Printf, shared.Fatalf)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,18 +17,24 @@ package main
 import (
 	"os"
 
+	adapter "istio.io/mixer/adapter"
 	"istio.io/mixer/cmd/server/cmd"
 	"istio.io/mixer/cmd/shared"
+	pkgAdapter "istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/template"
 	generatedTmplRepo "istio.io/mixer/template"
 )
 
-func getSupportedTemplateInfos() template.Repository {
-	return template.NewRepository(generatedTmplRepo.SupportedTmplInfo)
+func getSupportedTemplateInfos() map[string]template.Info {
+	return generatedTmplRepo.SupportedTmplInfo
+}
+
+func getSupportedAdapters() []pkgAdapter.InfoFn {
+	return adapter.Inventory2()
 }
 
 func main() {
-	rootCmd := cmd.GetRootCmd(os.Args[1:], getSupportedTemplateInfos(), shared.Printf, shared.Fatalf)
+	rootCmd := cmd.GetRootCmd(os.Args[1:], getSupportedTemplateInfos(), getSupportedAdapters(), shared.Printf, shared.Fatalf)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)


### PR DESCRIPTION
Create CRD from the available mesh functions + available adapters.

Also made the inventory as a parameter from the main.go
(this is needed to make mocking easy + since we are autogenreating the inventory, it can live anywhere and it is nice if only the main function knows about it.)

Signed-off-by: guptasu <guptasu@google.com>

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1129)
<!-- Reviewable:end -->
