### PR TITLE
Undo codecov comment for codegen tool.

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -9,7 +9,6 @@ cd $ROOTDIR
 
 echo "Code coverage test"
 echo "" > coverage.txt
-# TODO remove the exclusion of codegen once the codegen tests start working via bazel
 for d in $(go list ./... | grep -v vendor); do
     go test -coverprofile=profile.out $d
     if [ -f profile.out ]; then

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -10,7 +10,7 @@ cd $ROOTDIR
 echo "Code coverage test"
 echo "" > coverage.txt
 # TODO remove the exclusion of codegen once the codegen tests start working via bazel
-for d in $(go list ./... | grep -v vendor | grep -v codegen); do
+for d in $(go list ./... | grep -v vendor); do
     go test -coverprofile=profile.out $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt


### PR DESCRIPTION
Coverage numbers are:
?   	istio.io/mixer/tools/codegen/cmd/mixgenbootstrap	[no test files]
?   	istio.io/mixer/tools/codegen/cmd/mixgeninventory	[no test files]
?   	istio.io/mixer/tools/codegen/cmd/mixgenproc	[no test files]
ok  	istio.io/mixer/tools/codegen/pkg/bootstrapgen	0.078s	coverage: 75.9% of statements
?   	istio.io/mixer/tools/codegen/pkg/bootstrapgen/template	[no test files]
ok  	istio.io/mixer/tools/codegen/pkg/interfacegen	0.067s	coverage: 71.4% of statements
?   	istio.io/mixer/tools/codegen/pkg/interfacegen/template	[no test files]
ok  	istio.io/mixer/tools/codegen/pkg/inventory	0.026s	coverage: 81.8% of statements
ok  	istio.io/mixer/tools/codegen/pkg/modelgen	0.041s	coverage: 90.9% of statements

Not that great. I am glad the modelgen though has reasonally cov since it is the main stuff. Will work in the coming weeks to bumpup the codecov numbers.
cmd dir is the main file so, I think no test there is fine. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1135)
<!-- Reviewable:end -->
