### PR TITLE
Add newer version of service control adapter based on new adapter fra…

### DIFF
--- a/adapter/svcctrl/BUILD
+++ b/adapter/svcctrl/BUILD
@@ -1,0 +1,36 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "client.go",
+        "svcctrl.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//adapter/svcctrl/config:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//template/metric:go_default_library",
+        "//template/quota:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_pborman_uuid//:go_default_library",
+        "@org_golang_google_api//servicecontrol/v1:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["svcctrl_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//template/metric:go_default_library",
+        "@com_github_davecgh_go_spew//spew:go_default_library",
+    ],
+)

--- a/adapter/svcctrl/client.go
+++ b/adapter/svcctrl/client.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package svcctrl
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	sc "google.golang.org/api/servicecontrol/v1"
+
+	"istio.io/mixer/pkg/adapter"
+)
+
+type createClientFn func(adapter.Logger) (*sc.Service, error)
+
+// Creates a service control client. The client is authenticated with service control with Oauth2.
+func createClient(logger adapter.Logger) (*sc.Service, error) {
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: http.DefaultTransport})
+
+	client, err := google.DefaultClient(ctx, sc.CloudPlatformScope, sc.ServicecontrolScope)
+	if err != nil {
+		return nil, logger.Errorf("unable to create http client %v", err.Error())
+	}
+
+	serviceControl, err := sc.New(client)
+	if err != nil {
+		return nil, logger.Errorf("unable to create service control client %v", err.Error())
+	}
+	logger.Infof("created service control client\n")
+	return serviceControl, nil
+}

--- a/adapter/svcctrl/config/BUILD
+++ b/adapter/svcctrl/config/BUILD
@@ -1,0 +1,24 @@
+load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogoslick_proto_library")
+
+gogoslick_proto_library(
+    name = "go_default_library",
+    importmap = {
+        "gogoproto/gogo.proto": "github.com/gogo/protobuf/gogoproto",
+    },
+    imports = [
+        "external/com_github_gogo_protobuf",
+        "external/com_github_google_protobuf/src",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_gogo_protobuf//gogoproto:go_default_library_protos",
+    ],
+    protos = [
+        "config.proto",
+    ],
+    verbose = 0,
+    visibility = ["//adapter/svcctrl:__pkg__"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto:go_default_library",
+    ],
+)

--- a/adapter/svcctrl/config/config.proto
+++ b/adapter/svcctrl/config/config.proto
@@ -1,0 +1,29 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package adapter.svcctrl.config;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "config";
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
+
+message Params {
+    // Fully qualified GCP service name.
+    string service_name = 1;
+}

--- a/adapter/svcctrl/svcctrl.go
+++ b/adapter/svcctrl/svcctrl.go
@@ -1,0 +1,128 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package svcctrl
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/pborman/uuid"
+	sc "google.golang.org/api/servicecontrol/v1"
+
+	"istio.io/mixer/adapter/svcctrl/config"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/template/metric"
+)
+
+type builder struct {
+	createClientFn
+}
+
+type handler struct {
+	serviceControlClient *sc.Service
+	env                  adapter.Env
+	configParams         *config.Params
+}
+
+func (b *builder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
+	client, err := b.createClientFn(env.Logger())
+	if err != nil {
+		return nil, err
+	}
+
+	return &handler{
+		serviceControlClient: client,
+		env:                  env,
+		configParams:         cfg.(*config.Params),
+	}, nil
+}
+
+func (b *builder) ConfigureMetricHandler(instanceTypes map[string]*metric.Type) error {
+	return nil
+}
+
+func (h *handler) HandleMetric(ctx context.Context, instances []*metric.Instance) error {
+	buf := bytes.NewBufferString("mixer-metric-report-id-")
+	_, err := buf.WriteString(uuid.New())
+	if err != nil {
+		return err
+	}
+
+	opID := buf.String()
+	reportReq, err := handleMetric(time.Now().Format(time.RFC3339Nano), opID)
+	if err != nil {
+		return err
+	}
+	_, err = h.serviceControlClient.Services.Report(h.configParams.ServiceName, reportReq).Do()
+	return err
+}
+
+func handleMetric(timeNow, opID string) (*sc.ReportRequest, error) {
+	op := &sc.Operation{
+		OperationId:   opID,
+		OperationName: "reportMetrics",
+		StartTime:     timeNow,
+		EndTime:       timeNow,
+		Labels: map[string]string{
+			"cloud.googleapis.com/location": "global",
+		},
+	}
+
+	value := int64(1)
+	metricValue := sc.MetricValue{
+		StartTime:  timeNow,
+		EndTime:    timeNow,
+		Int64Value: &value,
+	}
+
+	op.MetricValueSets = []*sc.MetricValueSet{
+		{
+			MetricName:   "serviceruntime.googleapis.com/api/producer/request_count",
+			MetricValues: []*sc.MetricValue{&metricValue},
+		},
+	}
+
+	reportReq := &sc.ReportRequest{
+		Operations: []*sc.Operation{op},
+	}
+	return reportReq, nil
+}
+
+func (h *handler) Close() error {
+	h.serviceControlClient = nil
+	return nil
+}
+
+// GetBuilderInfo registers Adapter with Mixer.
+func GetBuilderInfo() adapter.BuilderInfo {
+	return adapter.BuilderInfo{
+		Name:        "svcctrl",
+		Impl:        "istio.io/mixer/adapter/svcctrl",
+		Description: "Interface to Google Service Control",
+		SupportedTemplates: []string{
+			metric.TemplateName,
+		},
+		CreateHandlerBuilder: func() adapter.HandlerBuilder {
+			return &builder{
+				createClientFn: createClient,
+			}
+		},
+		DefaultConfig: &config.Params{
+			ServiceName: "library-example.sandbox.googleapis.com",
+		},
+		ValidateConfig: func(msg adapter.Config) *adapter.ConfigErrors { return nil },
+	}
+}

--- a/adapter/svcctrl/svcctrl_test.go
+++ b/adapter/svcctrl/svcctrl_test.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package svcctrl
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	sc "google.golang.org/api/servicecontrol/v1"
+)
+
+func TestHandleMetric(t *testing.T) {
+	timeNow := time.Now().Format(time.RFC3339Nano)
+	request, err := handleMetric(timeNow, "")
+
+	if err != nil {
+		t.Fatalf("handleMetric() failed with:%v", err)
+	}
+
+	metricValue := int64(1)
+	expected := &sc.ReportRequest{
+		Operations: []*sc.Operation{
+			{
+				OperationName: "reportMetrics",
+				StartTime:     timeNow,
+				EndTime:       timeNow,
+				Labels: map[string]string{
+					"cloud.googleapis.com/location": "global",
+				},
+				MetricValueSets: []*sc.MetricValueSet{
+					{
+						MetricName: "serviceruntime.googleapis.com/api/producer/request_count",
+						MetricValues: []*sc.MetricValue{
+							{
+								StartTime:  timeNow,
+								EndTime:    timeNow,
+								Int64Value: &metricValue,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := spew.NewDefaultConfig()
+	cfg.DisablePointerAddresses = true
+	if !reflect.DeepEqual(*expected, *request) {
+		t.Errorf("expect op1 == op2, but op1 = %v, op2 = %v", cfg.Sdump(*expected), cfg.Sdump(*request))
+	}
+}


### PR DESCRIPTION
…mework

The adapter doesn't do much at this point except sending a hardcoded metric to Google Service Control backend.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1141)
<!-- Reviewable:end -->
