### PR TITLE
Rename the adapter names to be DNS 1035 compatible

### DIFF
--- a/adapter/denier/denier.go
+++ b/adapter/denier/denier.go
@@ -93,7 +93,7 @@ func (handler) Close() error { return nil }
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:        "istio.io/mixer/adapter/denier",
+		Name:        "istio-io-mixer-adapter-denier",
 		Description: "Rejects any check and quota request with a configurable error",
 		SupportedTemplates: []string{
 			checknothing.TemplateName,

--- a/adapter/list/list.go
+++ b/adapter/list/list.go
@@ -271,7 +271,7 @@ func (h *handler) purgeList() {
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:               "istio.io/mixer/adapter/list",
+		Name:               "istio-io-mixer-adapter-list",
 		Description:        "Checks whether an entry is present in a list",
 		SupportedTemplates: []string{listentry.TemplateName},
 		DefaultConfig: &config.Params{

--- a/adapter/noop2/noop.go
+++ b/adapter/noop2/noop.go
@@ -125,7 +125,7 @@ func (handler) Close() error { return nil }
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:        "istio.io/mixer/adapter/noop",
+		Name:        "istio-io-mixer-adapter-noop",
 		Description: "Does nothing (useful for testing)",
 		SupportedTemplates: []string{
 			checknothing.TemplateName,

--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -58,7 +58,7 @@ var (
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:        "prometheus",
+		Name:        "istio-io-mixer-adapter-prometheus",
 		Description: "Publishes prometheus metrics",
 		SupportedTemplates: []string{
 			metric.TemplateName,

--- a/adapter/stdio/stdio.go
+++ b/adapter/stdio/stdio.go
@@ -229,7 +229,7 @@ func (h *handler) mapSeverityLevel(severity string) zapcore.Level {
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:        "istio.io/mixer/adapter/stdio",
+		Name:        "istio-io-mixer-adapter-stdio",
 		Description: "Writes logs and metrics to a standard I/O stream",
 		SupportedTemplates: []string{
 			logentry.TemplateName,


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1142)
<!-- Reviewable:end -->
