### PR TITLE
Make adapter names short and descriptive, Add Impl field to info

### DIFF
--- a/adapter/denier/denier.go
+++ b/adapter/denier/denier.go
@@ -93,7 +93,8 @@ func (handler) Close() error { return nil }
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:        "istio.io/mixer/adapter/denier",
+		Name:        "denier",
+		Impl:        "istio.io/mixer/adapter/denier",
 		Description: "Rejects any check and quota request with a configurable error",
 		SupportedTemplates: []string{
 			checknothing.TemplateName,

--- a/adapter/list/list.go
+++ b/adapter/list/list.go
@@ -271,7 +271,8 @@ func (h *handler) purgeList() {
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:               "istio.io/mixer/adapter/list",
+		Name:               "list-checker",
+		Impl:               "istio.io/mixer/adapter/list",
 		Description:        "Checks whether an entry is present in a list",
 		SupportedTemplates: []string{listentry.TemplateName},
 		DefaultConfig: &config.Params{

--- a/adapter/noop2/noop.go
+++ b/adapter/noop2/noop.go
@@ -125,7 +125,8 @@ func (handler) Close() error { return nil }
 // GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:        "istio.io/mixer/adapter/noop",
+		Name:        "noop",
+		Impl:        "istio.io/mixer/adapter/noop",
 		Description: "Does nothing (useful for testing)",
 		SupportedTemplates: []string{
 			checknothing.TemplateName,

--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -59,6 +59,7 @@ var (
 func GetBuilderInfo() adapter.BuilderInfo {
 	return adapter.BuilderInfo{
 		Name:        "prometheus",
+		Impl:        "istio.io/mixer/adapter/prometheus",
 		Description: "Publishes prometheus metrics",
 		SupportedTemplates: []string{
 			metric.TemplateName,

--- a/pkg/adapter/info.go
+++ b/pkg/adapter/info.go
@@ -21,8 +21,16 @@ import (
 // BuilderInfo describes the Adapter and provides a function to a Handler Builder method.
 // TODO change this to Info when we delete the ApplicationLog.Info enum.
 type BuilderInfo struct {
-	// Name returns the official name of the adapter.
+	// Name returns the official name of the adapter, it must be RFC 1035 compatible DNS label.
+	// Regex: "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+	// Name is used in Istio configuration, therefore it should be descriptive but short.
+	// example: denier
+	// Vendor adapters should use a vendor prefix.
+	// example: mycompany-denier
 	Name string
+	// Impl is the package implementing the adapter.
+	// example: "istio.io/mixer/adapter/denier"
+	Impl string
 	// Description returns a user-friendly description of the adapter.
 	Description string
 	// CreateHandlerBuilder is a function that creates a HandlerBuilder which implements Builders associated


### PR DESCRIPTION
Adapter names are now short and descriptive.
Added Impl field for the implementing package.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1145)
<!-- Reviewable:end -->
