### PR TITLE
Use int32 consistently for check result's ValidUseCount field.

### DIFF
--- a/adapter/list/config/config.proto
+++ b/adapter/list/config/config.proto
@@ -44,7 +44,7 @@ message Params {
 
     // Indicates the number of times a caller of this adapter can use a cached answer
     // before it should ask the adapter again.
-    int64 caching_use_count = 5;
+    int32 caching_use_count = 5;
 
     // List entries that are consulted first, before the list from the server
     repeated string overrides = 6;

--- a/pkg/adapter/check.go
+++ b/pkg/adapter/check.go
@@ -29,7 +29,7 @@ type CheckResult struct {
 	// ValidDuration represents amount of time for which this result can be considered valid.
 	ValidDuration time.Duration
 	// ValidUseCount represents the number of uses for which this result can be considered valid.
-	ValidUseCount int64
+	ValidUseCount int32
 }
 
 // GetStatus gets status embedded in the result.

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -120,8 +120,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 			out2 = status.WithError(err)
 		} else {
 			resp.Precondition.ValidDuration = cr.ValidDuration
-			// FIXME cr.ValidUseCount should be int32
-			resp.Precondition.ValidUseCount = int32(cr.ValidUseCount)
+			resp.Precondition.ValidUseCount = cr.ValidUseCount
 		}
 	}
 


### PR DESCRIPTION
Addresses issue #1133 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1154)
<!-- Reviewable:end -->
