### PR TITLE
Introduce the memquota2 adapter.

### DIFF
--- a/adapter/denier/denier.go
+++ b/adapter/denier/denier.go
@@ -40,16 +40,16 @@ type (
 
 // ensure our types implement the requisite interfaces
 var _ checknothing.HandlerBuilder = &builder{}
-var _ checknothing.Handler = handler{}
+var _ checknothing.Handler = &handler{}
 var _ listentry.HandlerBuilder = &builder{}
-var _ listentry.Handler = handler{}
+var _ listentry.Handler = &handler{}
 var _ quota.HandlerBuilder = &builder{}
-var _ quota.Handler = handler{}
+var _ quota.Handler = &handler{}
 
 ///////////////// Configuration Methods ///////////////
 
 func (*builder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	return handler{status: cfg.(*config.Params).Status}, nil
+	return &handler{status: cfg.(*config.Params).Status}, nil
 }
 
 func (*builder) ConfigureCheckNothingHandler(map[string]*checknothing.Type) error {
@@ -66,7 +66,7 @@ func (*builder) ConfigureQuotaHandler(map[string]*quota.Type) error {
 
 ////////////////// Runtime Methods //////////////////////////
 
-func (h handler) HandleCheckNothing(context.Context, *checknothing.Instance) (adapter.CheckResult, error) {
+func (h *handler) HandleCheckNothing(context.Context, *checknothing.Instance) (adapter.CheckResult, error) {
 	return adapter.CheckResult{
 		Status:        h.status,
 		ValidDuration: 1000 * time.Second,
@@ -74,7 +74,7 @@ func (h handler) HandleCheckNothing(context.Context, *checknothing.Instance) (ad
 	}, nil
 }
 
-func (h handler) HandleListEntry(context.Context, *listentry.Instance) (adapter.CheckResult, error) {
+func (h *handler) HandleListEntry(context.Context, *listentry.Instance) (adapter.CheckResult, error) {
 	return adapter.CheckResult{
 		Status:        h.status,
 		ValidDuration: 1000 * time.Second,
@@ -82,11 +82,11 @@ func (h handler) HandleListEntry(context.Context, *listentry.Instance) (adapter.
 	}, nil
 }
 
-func (handler) HandleQuota(context.Context, *quota.Instance, adapter.QuotaRequestArgs) (adapter.QuotaResult2, error) {
+func (*handler) HandleQuota(context.Context, *quota.Instance, adapter.QuotaRequestArgs) (adapter.QuotaResult2, error) {
 	return adapter.QuotaResult2{}, nil
 }
 
-func (handler) Close() error { return nil }
+func (*handler) Close() error { return nil }
 
 ////////////////// Bootstrap //////////////////////////
 

--- a/adapter/memquota2/BUILD
+++ b/adapter/memquota2/BUILD
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "dedup.go",
+        "keys.go",
+        "memquota.go",
+        "rollingWindow.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//adapter/memquota2/config:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/pool:go_default_library",
+        "//pkg/status:go_default_library",
+        "//template/quota:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "memquota_test.go",
+        "rollingWindow_test.go",
+    ],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/adapter/test:go_default_library",
+    ],
+)

--- a/adapter/memquota2/config/BUILD
+++ b/adapter/memquota2/config/BUILD
@@ -1,0 +1,27 @@
+load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogoslick_proto_library")
+
+gogoslick_proto_library(
+    name = "go_default_library",
+    importmap = {
+        "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
+        "gogoproto/gogo.proto": "github.com/gogo/protobuf/gogoproto",
+    },
+    imports = [
+        "external/com_github_gogo_protobuf",
+        "external/com_github_google_protobuf/src",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_gogo_protobuf//gogoproto:go_default_library_protos",
+    ],
+    protos = [
+        "config.proto",
+    ],
+    verbose = 0,
+    visibility = ["//adapter/memquota2:__pkg__"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto:go_default_library",
+        "@com_github_gogo_protobuf//sortkeys:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+    ],
+)

--- a/adapter/memquota2/config/config.proto
+++ b/adapter/memquota2/config/config.proto
@@ -1,0 +1,46 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package adapter.memquota.config;
+
+import "google/protobuf/duration.proto";
+import "gogoproto/gogo.proto";
+
+option go_package="config";
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
+
+message Params {
+	message Quota {
+		// The name of the quota
+		string name = 1;
+
+		// The upper limit for this quota.
+		int64 max_amount = 2;
+
+		// The amount of time allocated quota remains valid before it is
+		// automatically released. This is only meaningful for rate limit
+		// quotas, otherwise the value must be zero.
+		google.protobuf.Duration valid_duration = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+	}
+
+	// The set of known quotas.
+	repeated Quota quotas = 1 [(gogoproto.nullable) = false];
+
+	// Minimum number of seconds that deduplication is possible for a given operation.
+	google.protobuf.Duration min_deduplication_duration = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+}

--- a/adapter/memquota2/dedup.go
+++ b/adapter/memquota2/dedup.go
@@ -1,0 +1,116 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memquota
+
+import (
+	"sync"
+	"time"
+
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/template/quota"
+)
+
+type (
+	// dedupUtil stores common information for in-memory and redis quota adapters
+	dedupUtil struct {
+		sync.Mutex
+
+		// two ping-ponging maps of active dedup ids
+		recentDedup map[string]dedupState
+		oldDedup    map[string]dedupState
+
+		// used for reaping dedup ids
+		ticker *time.Ticker
+
+		// indirection to support fast deterministic tests
+		getTime func() time.Time
+
+		logger adapter.Logger
+	}
+
+	// dedupState maintains a dedup state
+	dedupState struct {
+		amount int64
+		exp    time.Time
+	}
+
+	quotaFunc func(key string, currentTime time.Time, currentTick int64) (int64, time.Time, time.Duration)
+)
+
+const (
+	// ticksPerSecond determines the number of quantized time intervals in 1 second.
+	ticksPerSecond = 10
+
+	// nanosPerTick is equal to ns/tick
+	nanosPerTick = int64(time.Second / ticksPerSecond)
+)
+
+// handleDedup is a wrapper function that handles dedupping semantics.
+func (du *dedupUtil) handleDedup(instance *quota.Instance, args adapter.QuotaRequestArgs, qf quotaFunc) (int64, time.Duration, error) {
+	key := makeKey(instance.Name, instance.Dimensions)
+
+	du.Lock()
+
+	currentTime := du.getTime()
+	currentTick := currentTime.UnixNano() / nanosPerTick
+
+	var amount int64
+	var t time.Time
+	var exp time.Duration
+
+	result, dup := du.recentDedup[args.DeduplicationID]
+	if !dup {
+		result, dup = du.oldDedup[args.DeduplicationID]
+	}
+
+	if dup {
+		amount = result.amount
+		exp = result.exp.Sub(currentTime)
+		if exp < 0 {
+			exp = 0
+		}
+	} else {
+		amount, t, exp = qf(key, currentTime, currentTick)
+		du.recentDedup[args.DeduplicationID] = dedupState{amount: amount, exp: t}
+	}
+
+	du.Unlock()
+
+	if dup {
+		du.logger.Infof("Quota operation satisfied through deduplication: dedupID %v, amount %v", args.DeduplicationID, result.amount)
+	}
+
+	return amount, exp, nil
+}
+
+// reapDedup cleans up dedup entries from the oldDedup map and moves all entries from
+// the recentDedup map into the oldDedup map, making those next in line for deletion.
+//
+// This is normally called on a regular basis via a go routine. It's also used directly
+// from tests to inject specific behaviors.
+func (du *dedupUtil) reapDedup() {
+	t := du.oldDedup
+	du.oldDedup = du.recentDedup
+	du.recentDedup = t
+
+	if du.logger.VerbosityLevel(4) {
+		du.logger.Infof("Running repear to reclaim %d old deduplication entries", len(t))
+	}
+
+	// TODO: why isn't there a O(1) way to clear a map to the empty state?!
+	for k := range t {
+		delete(t, k)
+	}
+}

--- a/adapter/memquota2/keys.go
+++ b/adapter/memquota2/keys.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memquota
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+
+	"istio.io/mixer/pkg/pool"
+)
+
+// we maintain a pool of these for use by the makeKey function
+type keyWorkspace struct {
+	keys []string
+}
+
+// pool of reusable keyWorkspace structs
+var keyWorkspacePool = sync.Pool{New: func() interface{} { return &keyWorkspace{} }}
+
+// makeKey produces a unique key representing the given labels.
+func makeKey(name string, labels map[string]interface{}) string {
+	ws := keyWorkspacePool.Get().(*keyWorkspace)
+	keys := ws.keys
+	buf := pool.GetBuffer()
+
+	// ensure stable order
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf.WriteString(name) // nolint: gas
+	for _, k := range keys {
+		buf.WriteString(";") // nolint: gas
+		buf.WriteString(k)   // nolint: gas
+		buf.WriteString("=") // nolint: gas
+
+		switch v := labels[k].(type) {
+		case string:
+			buf.WriteString(v) // nolint: gas
+		case int64:
+			var bytes [32]byte
+			buf.Write(strconv.AppendInt(bytes[:], v, 16)) // nolint: gas
+		case float64:
+			var bytes [32]byte
+			buf.Write(strconv.AppendFloat(bytes[:], v, 'b', -1, 64)) // nolint: gas
+		case bool:
+			var bytes [32]byte
+			buf.Write(strconv.AppendBool(bytes[:], v)) // nolint: gas
+		case []byte:
+			buf.Write(v) // nolint: gas
+		case map[string]string:
+			ws := keyWorkspacePool.Get().(*keyWorkspace)
+			mk := ws.keys
+
+			// ensure stable order
+			for k2 := range v {
+				mk = append(mk, k2)
+			}
+			sort.Strings(mk)
+
+			for _, k2 := range mk {
+				buf.WriteString(k2)    // nolint: gas
+				buf.WriteString(v[k2]) // nolint: gas
+			}
+
+			ws.keys = keys[:0]
+			keyWorkspacePool.Put(ws)
+		default:
+			buf.WriteString(v.(fmt.Stringer).String()) // nolint: gas
+		}
+	}
+
+	result := buf.String()
+	pool.PutBuffer(buf)
+
+	ws.keys = keys[:0]
+	keyWorkspacePool.Put(ws)
+
+	return result
+}

--- a/adapter/memquota2/memquota.go
+++ b/adapter/memquota2/memquota.go
@@ -1,0 +1,246 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package memquota provides a simple in-memory quota implementation. It's
+// trivial to set up, but it has various limitations:
+//
+// - Obviously, the data set must be able to fit in memory.
+//
+// - When Mixer crashes/restarts, all quota values are erased.
+// This means this isn't good for allocation quotas although
+// it works well enough for rate limits quotas.
+//
+// - Since the data is all memory-resident and there isn't any cross-node
+// synchronization, this adapter can't be used in an Istio mixer where
+// a single service can be handled by different mixer instances.
+package memquota
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"istio.io/mixer/adapter/memquota2/config"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/status"
+	"istio.io/mixer/template/quota"
+)
+
+type builder struct {
+	types map[string]*quota.Type
+}
+
+type handler struct {
+	// common info among different quota adapters
+	common dedupUtil
+
+	// the counters we track for non-expiring quotas, protected by lock
+	cells map[string]int64
+
+	// the rolling windows we track for expiring quotas, protected by lock
+	windows map[string]*rollingWindow
+
+	// the limits we know about
+	limits map[string]config.Params_Quota
+}
+
+// ensure our types implement the requisite interfaces
+var _ quota.HandlerBuilder = &builder{}
+var _ quota.Handler = &handler{}
+
+///////////////// Configuration Methods ///////////////
+
+func (b *builder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
+	c := cfg.(*config.Params)
+	return b.buildWithDedup(c, env, time.NewTicker(c.MinDeduplicationDuration))
+}
+
+func (b *builder) buildWithDedup(c *config.Params, env adapter.Env, ticker *time.Ticker) (*handler, error) {
+	limits := make(map[string]config.Params_Quota, len(c.Quotas))
+	for _, l := range c.Quotas {
+		limits[l.Name] = l
+	}
+
+	for k := range b.types {
+		if _, ok := limits[k]; !ok {
+			return nil, fmt.Errorf("did not find limit defined for quota %s", k)
+		}
+	}
+
+	h := &handler{
+		common: dedupUtil{
+			recentDedup: make(map[string]dedupState),
+			oldDedup:    make(map[string]dedupState),
+			ticker:      ticker,
+			getTime:     time.Now,
+			logger:      env.Logger(),
+		},
+		cells:   make(map[string]int64),
+		windows: make(map[string]*rollingWindow),
+		limits:  limits,
+	}
+
+	env.ScheduleDaemon(func() {
+		for range h.common.ticker.C {
+			h.common.Lock()
+			h.common.reapDedup()
+			h.common.Unlock()
+		}
+	})
+
+	return h, nil
+}
+
+func (b *builder) ConfigureQuotaHandler(types map[string]*quota.Type) error {
+	b.types = types
+	return nil
+}
+
+////////////////// Runtime Methods //////////////////////////
+
+func (h *handler) HandleQuota(context context.Context, instance *quota.Instance, args adapter.QuotaRequestArgs) (adapter.QuotaResult2, error) {
+	q := h.limits[instance.Name]
+
+	if args.QuotaAmount > 0 {
+		return h.alloc(instance, args, q)
+	} else if args.QuotaAmount < 0 {
+		args.QuotaAmount = -args.QuotaAmount
+		return h.free(instance, args, q)
+	}
+	return adapter.QuotaResult2{}, nil
+}
+
+func (h *handler) alloc(instance *quota.Instance, args adapter.QuotaRequestArgs, q config.Params_Quota) (adapter.QuotaResult2, error) {
+	amount, exp, err := h.common.handleDedup(instance, args, func(key string, currentTime time.Time, currentTick int64) (int64, time.Time,
+		time.Duration) {
+		result := args.QuotaAmount
+
+		// we optimize storage for non-expiring quotas
+		if q.ValidDuration == 0 {
+			inUse := h.cells[key]
+
+			if result > q.MaxAmount-inUse {
+				if !args.BestEffort {
+					return 0, time.Time{}, 0
+				}
+
+				// grab as much as we can
+				result = q.MaxAmount - inUse
+			}
+			h.cells[key] = inUse + result
+			return result, time.Time{}, 0
+		}
+
+		window, ok := h.windows[key]
+		if !ok {
+			seconds := int32((q.ValidDuration + time.Second - 1) / time.Second)
+			window = newRollingWindow(q.MaxAmount, int64(seconds)*ticksPerSecond)
+			h.windows[key] = window
+		}
+
+		if !window.alloc(result, currentTick) {
+			if !args.BestEffort {
+				return 0, time.Time{}, 0
+			}
+
+			// grab as much as we can
+			result = window.available()
+			_ = window.alloc(result, currentTick)
+		}
+
+		return result, currentTime.Add(q.ValidDuration), q.ValidDuration
+	})
+
+	return adapter.QuotaResult2{
+		Status:        status.OK,
+		Amount:        amount,
+		ValidDuration: exp,
+	}, err
+}
+
+func (h *handler) free(instance *quota.Instance, args adapter.QuotaRequestArgs, q config.Params_Quota) (adapter.QuotaResult2, error) {
+	amount, _, err := h.common.handleDedup(instance, args, func(key string, currentTime time.Time, currentTick int64) (int64, time.Time,
+		time.Duration) {
+		result := args.QuotaAmount
+
+		if q.ValidDuration == 0 {
+			inUse := h.cells[key]
+
+			if result >= inUse {
+				// delete the cell since it contains no useful state
+				delete(h.cells, key)
+				return inUse, time.Time{}, 0
+			}
+
+			h.cells[key] = inUse - result
+			return result, time.Time{}, 0
+		}
+
+		// WARNING: Releasing quota in the case of rate limits is
+		//          inherently racy. A release can easily end up
+		//          freeing quota in the wrong window.
+
+		window, ok := h.windows[key]
+		if !ok {
+			return 0, time.Time{}, 0
+		}
+
+		result = window.release(result, currentTick)
+
+		if window.available() == q.MaxAmount {
+			// delete the cell since it contains no useful state
+			delete(h.windows, key)
+		}
+
+		return result, time.Time{}, 0
+	})
+
+	return adapter.QuotaResult2{
+		Status: status.OK,
+		Amount: amount,
+	}, err
+}
+
+func (h *handler) Close() error {
+	h.common.ticker.Stop()
+	return nil
+}
+
+////////////////// Bootstrap //////////////////////////
+
+// GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
+func GetBuilderInfo() adapter.BuilderInfo {
+	return adapter.BuilderInfo{
+		Name:        "memquota",
+		Impl:        "istio.io/mixer/adapter/memquota",
+		Description: "Volatile memory-based quota tracking",
+		SupportedTemplates: []string{
+			quota.TemplateName,
+		},
+		DefaultConfig: &config.Params{
+			MinDeduplicationDuration: 1 * time.Second,
+		},
+		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &builder{} },
+		ValidateConfig:       validateConfig,
+	}
+}
+
+func validateConfig(cfg adapter.Config) (ce *adapter.ConfigErrors) {
+	c := cfg.(*config.Params)
+
+	if c.MinDeduplicationDuration <= 0 {
+		ce = ce.Appendf("minDeduplicationDuration", "deduplication window of %v is invalid, must be > 0", c.MinDeduplicationDuration)
+	}
+	return
+}

--- a/adapter/memquota2/memquota_test.go
+++ b/adapter/memquota2/memquota_test.go
@@ -1,0 +1,370 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memquota
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"istio.io/mixer/adapter/memquota2/config"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/adapter/test"
+	"istio.io/mixer/template/quota"
+)
+
+func TestBasic(t *testing.T) {
+	info := GetBuilderInfo()
+
+	if !containsQuotaTemplate(info.SupportedTemplates) {
+		t.Error("Didn't find all expected supported templates")
+	}
+
+	builder := info.CreateHandlerBuilder()
+	cfg := info.DefaultConfig
+
+	if err := info.ValidateConfig(cfg); err != nil {
+		t.Errorf("Got error %v, expecting success", err)
+	}
+
+	quotaBuilder := builder.(quota.HandlerBuilder)
+	if err := quotaBuilder.ConfigureQuotaHandler(nil); err != nil {
+		t.Errorf("Got error %v, expecting success", err)
+	}
+
+	handler, err := builder.Build(cfg, test.NewEnv(t))
+	if err != nil {
+		t.Errorf("Got error %v, expecting success", err)
+	}
+
+	if err = handler.Close(); err != nil {
+		t.Errorf("Got error %v, expecting success", err)
+	}
+}
+
+func containsQuotaTemplate(s []string) bool {
+	for _, a := range s {
+		if a == quota.TemplateName {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAllocAndRelease(t *testing.T) {
+	limits := []config.Params_Quota{
+		{
+			Name:          "Q1",
+			MaxAmount:     10,
+			ValidDuration: 0,
+		},
+
+		{
+			Name:          "Q2",
+			MaxAmount:     10,
+			ValidDuration: time.Second,
+		},
+
+		{
+			Name:          "Q3",
+			MaxAmount:     10,
+			ValidDuration: time.Second * 60,
+		},
+	}
+
+	info := GetBuilderInfo()
+	builder := info.CreateHandlerBuilder()
+	cfg := config.Params{
+		MinDeduplicationDuration: 3600 * time.Second,
+		Quotas: limits,
+	}
+
+	hndlr, err := builder.Build(&cfg, test.NewEnv(t))
+	if err != nil {
+		t.Fatalf("Got error %v, expecting success", err)
+	}
+
+	h := hndlr.(*handler)
+
+	cases := []struct {
+		name            string
+		dedup           string
+		allocAmount     int64
+		allocResult     int64
+		allocBestEffort bool
+		exp             time.Duration
+		seconds         int64
+		releaseAmount   int64
+		releaseResult   int64
+	}{
+		{"Q1", "0", 2, 2, false, 0, 0, 0, 0},
+		{"Q1", "0", 2, 2, false, 0, 0, 0, 0}, // should be a nop due to dedup
+		{"Q1", "1", 6, 6, false, 0, 0, 0, 0},
+		{"Q1", "2", 2, 2, false, 0, 0, 0, 0},
+		{"Q1", "3", 2, 0, false, 0, 0, 0, 0},
+		{"Q1", "4", 1, 0, true, 0, 0, 0, 0},
+		{"Q1", "5", 0, 0, true, 0, 0, 0, 0},
+		{"Q1", "5b", 0, 0, false, 0, 0, 5, 5},
+		{"Q1", "5b", 0, 0, false, 0, 0, 5, 5},
+		{"Q1", "5c", 0, 0, false, 0, 0, 15, 5},
+
+		{"Q3", "6", 10, 10, false, time.Second * 60, 1, 0, 0},
+		{"Q3", "7", 10, 0, false, 0, 2, 0, 0},
+
+		{"Q3", "8", 10, 0, false, 0, 60, 0, 0},
+		{"Q3", "9", 10, 10, false, time.Second * 60, 61, 0, 0},
+
+		{"Q3", "10", 100, 10, true, time.Second * 60, 121, 0, 0},
+		{"Q3", "11", 100, 0, false, 0, 122, 10, 10},
+		{"Q3", "12", 0, 0, false, 0, 123, 1000, 0},
+		{"Q3", "12", 0, 0, false, 0, 124, 1000, 0},
+	}
+
+	dims := make(map[string]interface{})
+	dims["L1"] = "string"
+	dims["L2"] = int64(2)
+	dims["L3"] = float64(3.0)
+	dims["L4"] = true
+	dims["L5"] = time.Now()
+	dims["L6"] = []byte{0, 1}
+	dims["L7"] = map[string]string{"Foo": "Bar"}
+
+	now := time.Now()
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			qa := adapter.QuotaRequestArgs{
+				DeduplicationID: "A" + c.dedup,
+				QuotaAmount:     c.allocAmount,
+				BestEffort:      c.allocBestEffort,
+			}
+
+			instance := quota.Instance{
+				Name:       c.name,
+				Dimensions: dims,
+			}
+
+			h.common.getTime = func() time.Time {
+				return now.Add(time.Duration(c.seconds) * time.Second)
+			}
+
+			var qr adapter.QuotaResult2
+			var err error
+
+			qr, err = h.HandleQuota(context.Background(), &instance, qa)
+
+			if err != nil {
+				t.Errorf("Expecting success, got %v", err)
+			}
+
+			if qr.Amount != c.allocResult {
+				t.Errorf("Expecting %d, got %d", c.allocResult, qr.Amount)
+			}
+
+			if qr.ValidDuration != c.exp {
+				t.Errorf("Expecting %v, got %v", c.exp, qr.ValidDuration)
+			}
+
+			qa = adapter.QuotaRequestArgs{
+				DeduplicationID: "R" + c.dedup,
+				QuotaAmount:     -c.releaseAmount,
+			}
+
+			qr, err = h.HandleQuota(context.Background(), &instance, qa)
+			if err != nil {
+				t.Errorf("Expecting success, got %v", err)
+			}
+
+			if qr.Amount != c.releaseResult {
+				t.Errorf("Expecting %d, got %d", c.releaseResult, qr.Amount)
+			}
+		})
+	}
+
+	if err := h.Close(); err != nil {
+		t.Errorf("Unable to close handler: %v", err)
+	}
+}
+
+func TestBadConfig(t *testing.T) {
+	info := GetBuilderInfo()
+	c := info.DefaultConfig.(*config.Params)
+
+	c.MinDeduplicationDuration = 0
+	if err := info.ValidateConfig(c); err == nil {
+		t.Error("Expecting failure, got success")
+	}
+
+	c.MinDeduplicationDuration = -1
+	if err := info.ValidateConfig(c); err == nil {
+		t.Error("Expecting failure, got success")
+	}
+
+	c.MinDeduplicationDuration = 1 * time.Second
+
+	builder := info.CreateHandlerBuilder().(*builder)
+
+	types := map[string]*quota.Type{
+		"Foo": {},
+	}
+
+	if err := builder.ConfigureQuotaHandler(types); err != nil {
+		t.Errorf("Expecting success, got %v", err)
+	}
+
+	_, err := builder.Build(c, test.NewEnv(t))
+	if err == nil {
+		t.Error("Expecting failure, got success")
+	}
+}
+
+func TestReaper(t *testing.T) {
+	limits := []config.Params_Quota{
+		{
+			Name:          "Q1",
+			MaxAmount:     10,
+			ValidDuration: 0,
+		},
+	}
+
+	info := GetBuilderInfo()
+	builder := info.CreateHandlerBuilder()
+	cfg := config.Params{
+		MinDeduplicationDuration: 3600 * time.Second,
+		Quotas: limits,
+	}
+
+	hndlr, err := builder.Build(&cfg, test.NewEnv(t))
+	if err != nil {
+		t.Errorf("Unable to create handler: %v", err)
+	}
+
+	h := hndlr.(*handler)
+
+	now := time.Now()
+	h.common.getTime = func() time.Time {
+		return now
+	}
+
+	qa := adapter.QuotaRequestArgs{
+		QuotaAmount: 10,
+	}
+
+	instance := quota.Instance{
+		Name: "Q1",
+	}
+
+	qa.DeduplicationID = "0"
+	qr, _ := h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 10 {
+		t.Errorf("Alloc(): expecting 10, got %d", qr.Amount)
+	}
+
+	qr, _ = h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 10 {
+		t.Errorf("Alloc(): expecting 10, got %d", qr.Amount)
+	}
+
+	qa.DeduplicationID = "1"
+	qr, _ = h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 0 {
+		t.Errorf("Alloc(): expecting 0, got %d", qr.Amount)
+	}
+
+	// move current dedup state into old dedup state
+	h.common.reapDedup()
+
+	qa.DeduplicationID = "2"
+	qr, _ = h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 0 {
+		t.Errorf("Alloc(): expecting 0, got %d", qr.Amount)
+	}
+
+	// retire original dedup state
+	h.common.reapDedup()
+
+	qa.DeduplicationID = "0"
+	qr, _ = h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 0 {
+		t.Errorf("Alloc(): expecting 0, got %d", qr.Amount)
+	}
+
+	if err := h.Close(); err != nil {
+		t.Errorf("Unable to close handler: %v", err)
+	}
+}
+
+func TestReaperTicker(t *testing.T) {
+	limits := []config.Params_Quota{
+		{
+			Name:          "Q1",
+			MaxAmount:     10,
+			ValidDuration: 0,
+		},
+	}
+
+	testChan := make(chan time.Time)
+	testTicker := &time.Ticker{C: testChan}
+
+	info := GetBuilderInfo()
+	builder := info.CreateHandlerBuilder().(*builder)
+	cfg := info.DefaultConfig.(*config.Params)
+	cfg.Quotas = limits
+
+	h, err := builder.buildWithDedup(cfg, test.NewEnv(t), testTicker)
+	if err != nil {
+		t.Errorf("Unable to create handler: %v", err)
+	}
+
+	qa := adapter.QuotaRequestArgs{
+		QuotaAmount:     10,
+		DeduplicationID: "0",
+	}
+
+	instance := quota.Instance{
+		Name: "Q1",
+	}
+
+	qr, _ := h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 10 {
+		t.Errorf("Alloc(): expecting 10, got %d", qr.Amount)
+	}
+
+	qr, _ = h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 10 {
+		t.Errorf("Alloc(): expecting 10, got %d", qr.Amount)
+	}
+
+	// Advance 3 ticks, ensuring clearing of the de-dup cache
+	testChan <- time.Now()
+	testChan <- time.Now()
+	testChan <- time.Now()
+
+	qa.DeduplicationID = "1"
+	qr, _ = h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 0 {
+		t.Errorf("Alloc(): expecting 0, got %d", qr.Amount)
+	}
+
+	qa.DeduplicationID = "0"
+	qr, _ = h.HandleQuota(context.Background(), &instance, qa)
+	if qr.Amount != 0 {
+		t.Errorf("Alloc(): expecting 0, got %d", qr.Amount)
+	}
+
+	if err := h.Close(); err != nil {
+		t.Errorf("Unable to close handler: %v", err)
+	}
+}

--- a/adapter/memquota2/rollingWindow.go
+++ b/adapter/memquota2/rollingWindow.go
@@ -1,0 +1,114 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memquota
+
+// Implements a rolling window that allows N units to be allocated per rolling time interval.
+// Time is abstracted in terms of ticks, provided by the caller, decoupling the
+// implementation from real-time, enabling much easier testing and more flexibility.
+type rollingWindow struct {
+	// one slot per tick in the window, tracking consumption for that tick
+	slots []int64
+
+	// slot where consumption for the currentSlotTick is recorded
+	currentSlot int
+
+	// the tick count associated with the current slot
+	currentSlotTick int64
+
+	// the total # of units currently available in the window
+	avail int64
+}
+
+// Creates a new rolling window tracker used to implement rate limiting.
+//
+// The limit parameter determines the maximum amount that can be allocated within the
+// window.
+//
+// The ticksPerWindow parameter determines the number of quantized time intervals within the window.
+// When quota is allocated, it belongs to the current tick. As time marches on,
+// the quota associated with older ticks is reclaimed.
+func newRollingWindow(limit int64, ticksInWindow int64) *rollingWindow {
+	return &rollingWindow{
+		avail: limit,
+		slots: make([]int64, ticksInWindow),
+	}
+}
+
+func (w *rollingWindow) alloc(amount int64, currentTick int64) bool {
+	w.roll(currentTick)
+
+	if amount > w.avail {
+		// not enough room
+		return false
+	}
+
+	// now record the units being allocated
+	w.slots[w.currentSlot] += amount
+	w.avail -= amount
+
+	return true
+}
+
+func (w *rollingWindow) release(amount int64, currentTick int64) int64 {
+	w.roll(currentTick)
+
+	// we release from the leading edge of the window moving back in time
+	// until we've released enough or released everything, whichever is first...
+	var total int64
+	index := w.currentSlot
+	for range w.slots {
+		avail := w.slots[index]
+
+		if avail >= amount {
+			w.slots[index] -= amount
+			total += amount
+			break
+		}
+
+		w.slots[index] = 0
+		total += avail
+		amount -= avail
+
+		index--
+		if index < 0 {
+			index = len(w.slots) - 1
+		}
+	}
+
+	w.avail += total
+	return total
+}
+
+func (w *rollingWindow) roll(currentTick int64) {
+	// how many ticks has the window moved since we were last here?
+	behind := int(currentTick - w.currentSlotTick)
+	if behind > len(w.slots) {
+		behind = len(w.slots)
+	}
+
+	// reclaim any units that are now outside of the window
+	for i := 0; i < behind; i++ {
+		index := (w.currentSlot + 1 + i) % len(w.slots)
+		w.avail += w.slots[index]
+		w.slots[index] = 0
+	}
+
+	w.currentSlot = (w.currentSlot + behind) % len(w.slots)
+	w.currentSlotTick = currentTick
+}
+
+func (w *rollingWindow) available() int64 {
+	return w.avail
+}

--- a/adapter/memquota2/rollingWindow_test.go
+++ b/adapter/memquota2/rollingWindow_test.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memquota
+
+import (
+	"testing"
+)
+
+func TestAlloc(t *testing.T) {
+	cases := []struct {
+		amount int64
+		tick   int64
+		avail  int64
+		result bool
+	}{
+		{6, 1, 5, false},
+		{1, 1, 4, true},
+		{2, 1, 2, true},
+		{2, 1, 0, true},
+		{1, 1, 0, false},
+		{2, 1, 0, false},
+		{1, 2, 0, false},
+		{1, 3, 0, false},
+		{1, 4, 4, true},
+		{4, 5, 0, true},
+		{1, 5, 0, false},
+		{1, 7, 0, true},
+		{1, 7, 0, false},
+		{1, 8, 3, true},
+		{5, 11, 0, true},
+	}
+
+	w := newRollingWindow(5, 3)
+
+	for i, c := range cases {
+		if ok := w.alloc(c.amount, c.tick); ok != c.result {
+			t.Errorf("Expecting %v got %v, case %d", c.result, ok, i)
+		}
+
+		if w.available() != c.avail {
+			t.Errorf("Expecting %d available, got %d, case %d", c.avail, w.available(), i)
+		}
+	}
+}
+
+func TestRelease(t *testing.T) {
+	cases := []struct {
+		allocAmount   int64
+		allocTick     int64
+		releaseAmount int64
+		releaseTick   int64
+		releaseResult int64
+		avail         int64
+	}{
+		{4, 0, 4, 0, 4, 5},
+		{4, 0, 4, 1, 4, 5},
+		{4, 0, 4, 4, 0, 5},
+
+		{2, 10, 0, 10, 0, 3},
+		{2, 11, 0, 11, 0, 1},
+		{0, 13, 4, 13, 2, 5},
+		{5, 13, 5, 13, 5, 5},
+	}
+
+	w := newRollingWindow(5, 3)
+
+	for i, c := range cases {
+		if ok := w.alloc(c.allocAmount, c.allocTick); !ok {
+			t.Errorf("Expecting to succeed, case %d", i)
+		}
+
+		result := w.release(c.releaseAmount, c.releaseTick)
+		if result != c.releaseResult {
+			t.Errorf("Expecting %d, got %d, case %d", c.releaseResult, result, i)
+		}
+
+		if w.available() != c.avail {
+			t.Errorf("Expecting %d available, got %d, case %d", c.avail, w.available(), i)
+		}
+	}
+}

--- a/adapter/noop2/noop.go
+++ b/adapter/noop2/noop.go
@@ -40,22 +40,22 @@ type (
 
 // ensure our types implement the requisite interfaces
 var _ checknothing.HandlerBuilder = &builder{}
-var _ checknothing.Handler = handler{}
+var _ checknothing.Handler = &handler{}
 var _ reportnothing.HandlerBuilder = &builder{}
-var _ reportnothing.Handler = handler{}
+var _ reportnothing.Handler = &handler{}
 var _ listentry.HandlerBuilder = &builder{}
-var _ listentry.Handler = handler{}
+var _ listentry.Handler = &handler{}
 var _ logentry.HandlerBuilder = &builder{}
-var _ logentry.Handler = handler{}
+var _ logentry.Handler = &handler{}
 var _ metric.HandlerBuilder = &builder{}
-var _ metric.Handler = handler{}
+var _ metric.Handler = &handler{}
 var _ quota.HandlerBuilder = &builder{}
-var _ quota.Handler = handler{}
+var _ quota.Handler = &handler{}
 
 ///////////////// Configuration Methods ///////////////
 
 func (*builder) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
-	return handler{}, nil
+	return &handler{}, nil
 }
 
 func (*builder) ConfigureCheckNothingHandler(map[string]*checknothing.Type) error {
@@ -90,27 +90,27 @@ var checkResult = adapter.CheckResult{
 	ValidUseCount: 1000000000,
 }
 
-func (handler) HandleCheckNothing(context.Context, *checknothing.Instance) (adapter.CheckResult, error) {
+func (*handler) HandleCheckNothing(context.Context, *checknothing.Instance) (adapter.CheckResult, error) {
 	return checkResult, nil
 }
 
-func (handler) HandleReportNothing(context.Context, []*reportnothing.Instance) error {
+func (*handler) HandleReportNothing(context.Context, []*reportnothing.Instance) error {
 	return nil
 }
 
-func (handler) HandleListEntry(context.Context, *listentry.Instance) (adapter.CheckResult, error) {
+func (*handler) HandleListEntry(context.Context, *listentry.Instance) (adapter.CheckResult, error) {
 	return checkResult, nil
 }
 
-func (handler) HandleLogEntry(context.Context, []*logentry.Instance) error {
+func (*handler) HandleLogEntry(context.Context, []*logentry.Instance) error {
 	return nil
 }
 
-func (handler) HandleMetric(context.Context, []*metric.Instance) error {
+func (*handler) HandleMetric(context.Context, []*metric.Instance) error {
 	return nil
 }
 
-func (handler) HandleQuota(ctx context.Context, _ *quota.Instance, args adapter.QuotaRequestArgs) (adapter.QuotaResult2, error) {
+func (*handler) HandleQuota(ctx context.Context, _ *quota.Instance, args adapter.QuotaRequestArgs) (adapter.QuotaResult2, error) {
 	return adapter.QuotaResult2{
 			ValidDuration: 1000000000 * time.Second,
 			Amount:        args.QuotaAmount,
@@ -118,7 +118,7 @@ func (handler) HandleQuota(ctx context.Context, _ *quota.Instance, args adapter.
 		nil
 }
 
-func (handler) Close() error { return nil }
+func (*handler) Close() error { return nil }
 
 ////////////////// Bootstrap //////////////////////////
 

--- a/codecov.requirement
+++ b/codecov.requirement
@@ -2,6 +2,7 @@ Requirements of code coverage percentage for packages
 Use this format: "Package name \t Required percentage"
 istio.io/mixer/adapter/denier	100
 istio.io/mixer/adapter/list 100
+istio.io/mixer/adapter/memquota2	100
 istio.io/mixer/adapter/noop2	100
 istio.io/mixer/adapter/stdio	100
 istio.io/mixer/pkg/api  100


### PR DESCRIPTION
This is a cut-and-paste of the original memory-based quota adapter. The core quota logic is unchanged, it's just the glue with the rest of the system that is new.

100% code coverage.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1156)
<!-- Reviewable:end -->
