### PR TITLE
Enable timestamp field in the LogEntry template.

### DIFF
--- a/adapter/stdio/stdio.go
+++ b/adapter/stdio/stdio.go
@@ -167,9 +167,7 @@ func (h *handler) HandleLogEntry(_ context.Context, instances []*logentry.Instan
 		entry := zapcore.Entry{
 			LoggerName: instance.Name,
 			Level:      h.mapSeverityLevel(instance.Severity),
-
-			// TODO: disabled in template
-			// Time: instance.Timestemp
+			Time:       instance.Timestamp,
 		}
 
 		for _, varName := range h.logEntryVars[instance.Name] {

--- a/template/logentry/template.proto
+++ b/template/logentry/template.proto
@@ -16,9 +16,7 @@ syntax = "proto3";
 
 package logentry;
 
-// TODO: STUFF THAT IS COMMENTED OUT NEEDS TO BE TURNED ON ONCE CODE GEN IS FIXED
-
-//import "google/protobuf/timestamp.proto";
+import "google/protobuf/timestamp.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 import "pkg/adapter/template/TemplateExtensions.proto";
 
@@ -31,7 +29,7 @@ message Template {
     map<string, istio.mixer.v1.config.descriptor.ValueType> variables = 1;
 
     // Timestamp is the time value for the log entry
-//    google.protobuf.Timestamp timestamp = 2;
+    google.protobuf.Timestamp timestamp = 2;
 
     // Severity indicates the importance of the log entry.
     string severity = 3;


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1157)
<!-- Reviewable:end -->
