### PR TITLE
simplify crd gen and add route-rules and attribute-manifests

### DIFF
--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -36,9 +36,6 @@ go_library(
         "@com_github_openzipkin_zipkin_go_opentracing//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
-        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
-        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//grpclog/glogger:go_default_library",
@@ -50,4 +47,8 @@ go_test(
     size = "small",
     srcs = ["crd_test.go"],
     library = ":go_default_library",
+    deps = [
+        "//pkg/adapter:go_default_library",
+        "//pkg/template:go_default_library",
+    ],
 )

--- a/cmd/server/cmd/crd.go
+++ b/cmd/server/cmd/crd.go
@@ -104,7 +104,6 @@ type crdVar struct {
 	Version    string
 }
 
-// newCrdVar get a new crdVar
 func newCrdVar(shrtName, implName, pluralName, label string) *crdVar {
 	return &crdVar{
 		ShrtName:   shrtName,

--- a/cmd/server/cmd/crd.go
+++ b/cmd/server/cmd/crd.go
@@ -15,30 +15,46 @@
 package cmd
 
 import (
+	"bytes"
 	"sort"
+	gotemplate "text/template"
 
-	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/mixer/cmd/shared"
 	pkgAdapter "istio.io/mixer/pkg/adapter"
-	pkgadapter "istio.io/mixer/pkg/adapter"
+	mixerRuntime "istio.io/mixer/pkg/runtime"
 	"istio.io/mixer/pkg/template"
 )
 
-func crdCmd(tmplInfos map[string]template.Info, adapters []pkgAdapter.InfoFn, printf shared.FormatFn) *cobra.Command {
+// Group is the K8s API group.
+const Group = "config.istio.io"
+
+// Version is the K8s API version.
+const Version = "v1alpha2"
+
+func crdCmd(tmplInfos map[string]template.Info, adapters []pkgAdapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	adapterCmd := cobra.Command{
 		Use:   "crd",
 		Short: "CRDs (CustomResourceDefinition) available in Mixer",
 	}
 
 	adapterCmd.AddCommand(&cobra.Command{
+		Use:   "all",
+		Short: "List all CRDs",
+		Run: func(cmd *cobra.Command, args []string) {
+			printCrd(printf, fatalf, mixerRuntime.RulesKind, "istio.io.mixer", mixerRuntime.RulesKind+"s", "core")
+			printCrd(printf, fatalf, mixerRuntime.AttributeManifestKind, "istio.io.mixer", mixerRuntime.AttributeManifestKind+"s", "core")
+			listCrdsAdapters(printf, fatalf, adapters)
+			listCrdsInstances(printf, fatalf, tmplInfos)
+		},
+	})
+
+	adapterCmd.AddCommand(&cobra.Command{
 		Use:   "adapter",
 		Short: "List CRDs for available adapters",
 		Run: func(cmd *cobra.Command, args []string) {
-			listCrdsAdapters(printf, adapters)
+			listCrdsAdapters(printf, fatalf, adapters)
 		},
 	})
 
@@ -46,23 +62,23 @@ func crdCmd(tmplInfos map[string]template.Info, adapters []pkgAdapter.InfoFn, pr
 		Use:   "instance",
 		Short: "List CRDs for available instance kinds (mesh functions)",
 		Run: func(cmd *cobra.Command, args []string) {
-			listCrdsInstances(printf, tmplInfos)
+			listCrdsInstances(printf, fatalf, tmplInfos)
 		},
 	})
 
 	return &adapterCmd
 }
 
-func listCrdsAdapters(printf shared.FormatFn, infoFns []pkgadapter.InfoFn) {
+func listCrdsAdapters(printf, fatalf shared.FormatFn, infoFns []pkgAdapter.InfoFn) {
 	for _, infoFn := range infoFns {
 		info := infoFn()
 		shrtName := info.Name /* TODO make this info.shortName when related PR is in. */
 		// TODO : Use the plural name from the adapter info
-		printCrd(printf, shrtName, info.Name, shrtName+"s", "mixer-adapter")
+		printCrd(printf, fatalf, shrtName, info.Name, shrtName+"s", "mixer-adapter")
 	}
 }
 
-func listCrdsInstances(printf shared.FormatFn, infos map[string]template.Info) {
+func listCrdsInstances(printf, fatalf shared.FormatFn, infos map[string]template.Info) {
 	tmplNames := make([]string, 0, len(infos))
 
 	for name := range infos {
@@ -74,40 +90,56 @@ func listCrdsInstances(printf shared.FormatFn, infos map[string]template.Info) {
 	for _, tmplName := range tmplNames {
 		info := infos[tmplName]
 		// TODO : Use the plural name from the template info
-		printCrd(printf, info.Name, info.Impl, info.Name+"s", "mixer-instance")
+		printCrd(printf, fatalf, info.Name, info.Impl, info.Name+"s", "mixer-instance")
 	}
 }
 
-func printCrd(printf shared.FormatFn, shrtName, implName, pluralName, label string) {
-	group := "config.istio.io"
-	crd := apiextensionsv1beta1.CustomResourceDefinition{
-		TypeMeta: meta_v1.TypeMeta{
-			Kind:       "CustomResourceDefinition",
-			APIVersion: "apiextensions.k8s.io/v1beta1",
-		},
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: pluralName + "." + group,
-			Labels: map[string]string{
-				"impl":  implName,
-				"istio": label,
-			},
-		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   group,
-			Version: "v1alpha2",
-			Scope:   apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   pluralName,
-				Singular: shrtName,
-				Kind:     shrtName,
-			},
-		},
+type crdVar struct {
+	ShrtName   string
+	ImplName   string
+	PluralName string
+	Label      string
+	Name       string
+	Group      string
+	Version    string
+}
+
+// newCrdVar get a new crdVar
+func newCrdVar(shrtName, implName, pluralName, label string) *crdVar {
+	return &crdVar{
+		ShrtName:   shrtName,
+		ImplName:   implName,
+		PluralName: pluralName,
+		Label:      label,
+		Name:       pluralName + "." + Group,
+		Group:      Group,
+		Version:    Version,
 	}
-	out, err := yaml.Marshal(crd)
-	if err != nil {
-		printf("%s", err)
-		return
+}
+
+func printCrd(printf, fatalf shared.FormatFn, shrtName, implName, pluralName, label string) {
+	crdTemplate := `kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: {{.Name}}
+  labels:
+    package: {{.ImplName}}
+    istio: {{.Label}}
+spec:
+  group: {{.Group}}
+  names:
+    kind: {{.ShrtName}}
+    plural: {{.PluralName}}
+    singular: {{.ShrtName}}
+  scope: Namespaced
+  version: {{.Version}}
+---
+`
+	t := gotemplate.New("crd")
+	w := &bytes.Buffer{}
+	t, _ = t.Parse(crdTemplate)
+	if err := t.Execute(w, newCrdVar(shrtName, implName, pluralName, label)); err != nil {
+		fatalf("Could not create CRD " + err.Error())
 	}
-	printf(string(out))
-	printf("---\n")
+	printf(w.String())
 }

--- a/cmd/server/cmd/crd_test.go
+++ b/cmd/server/cmd/crd_test.go
@@ -32,14 +32,13 @@ var exampleAdapters = []pkgadapter.InfoFn{
 	func() adapter.BuilderInfo { return adapter.BuilderInfo{Name: "abcd"} },
 }
 var exampleAdaptersCrd = `
-apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
-  creationTimestamp: null
-  labels:
-    impl: foo-bar
-    istio: mixer-adapter
   name: foo-bars.config.istio.io
+  labels:
+    package: foo-bar
+    istio: mixer-adapter
 spec:
   group: config.istio.io
   names:
@@ -48,20 +47,14 @@ spec:
     singular: foo-bar
   scope: Namespaced
   version: v1alpha2
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
-  creationTimestamp: null
-  labels:
-    impl: abcd
-    istio: mixer-adapter
   name: abcds.config.istio.io
+  labels:
+    package: abcd
+    istio: mixer-adapter
 spec:
   group: config.istio.io
   names:
@@ -70,27 +63,19 @@ spec:
     singular: abcd
   scope: Namespaced
   version: v1alpha2
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
----
-`
+---`
 
 var exampleTmplInfos = map[string]template.Info{
 	"abcd-foo": {Name: "abcd-foo", Impl: "implPathShouldBeDNSCompat"},
 	"abcdBar":  {Name: "abcdBar", Impl: "implPathShouldBeDNSCompat2"},
 }
-var exampleInstanceCrd = `
+var exampleInstanceCrd = `kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
-  labels:
-    impl: implPathShouldBeDNSCompat
-    istio: mixer-instance
   name: abcd-foos.config.istio.io
+  labels:
+    package: implPathShouldBeDNSCompat
+    istio: mixer-instance
 spec:
   group: config.istio.io
   names:
@@ -99,20 +84,14 @@ spec:
     singular: abcd-foo
   scope: Namespaced
   version: v1alpha2
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
-  creationTimestamp: null
-  labels:
-    impl: implPathShouldBeDNSCompat2
-    istio: mixer-instance
   name: abcdBars.config.istio.io
+  labels:
+    package: implPathShouldBeDNSCompat2
+    istio: mixer-instance
 spec:
   group: config.istio.io
   names:
@@ -121,11 +100,6 @@ spec:
     singular: abcdBar
   scope: Namespaced
   version: v1alpha2
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 ---
 `
 
@@ -144,8 +118,9 @@ func TestListCrdsAdapters(t *testing.T) {
 			var printf = func(format string, args ...interface{}) {
 				buffer.WriteString(fmt.Sprintf(format, args...))
 			}
-			listCrdsAdapters(printf, tt.args)
+			listCrdsAdapters(printf, printf, tt.args)
 			gotOut := buffer.String()
+
 			if strings.TrimSpace(gotOut) != strings.TrimSpace(tt.wantOut) {
 				t.Errorf("listCrdsAdapters() = %s, want %s", gotOut, tt.wantOut)
 			}
@@ -168,10 +143,11 @@ func TestListCrdsInstances(t *testing.T) {
 			var printf = func(format string, args ...interface{}) {
 				buffer.WriteString(fmt.Sprintf(format, args...))
 			}
-			listCrdsInstances(printf, tt.args)
+			listCrdsInstances(printf, printf, tt.args)
 			gotOut := buffer.String()
+
 			if strings.TrimSpace(gotOut) != strings.TrimSpace(tt.wantOut) {
-				t.Errorf("listCrdsInstances() = %s, want %s", gotOut, tt.wantOut)
+				t.Errorf("listCrdsInstances() = %v, want %v", gotOut, tt.wantOut)
 			}
 		})
 	}

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -53,7 +53,7 @@ func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter
 	// template.NewRepository(info)
 	rootCmd.AddCommand(adapterCmd(printf))
 	rootCmd.AddCommand(serverCmd(info, adapters, printf, fatalf))
-	rootCmd.AddCommand(crdCmd(info, adapters, printf))
+	rootCmd.AddCommand(crdCmd(info, adapters, printf, fatalf))
 	rootCmd.AddCommand(shared.VersionCmd(printf))
 
 	return rootCmd


### PR DESCRIPTION
1. Adds route-rule and attribute-manifests
2. Removes dep on k8s, (gogland is happy) 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1158)
<!-- Reviewable:end -->
