### PR TITLE
Tolerate CRD spec to be nil

### DIFF
--- a/pkg/config/crd/store.go
+++ b/pkg/config/crd/store.go
@@ -172,7 +172,8 @@ func (s *Store) Get(key store.Key) (map[string]interface{}, error) {
 	if !exists {
 		return nil, store.ErrNotFound
 	}
-	return obj.(*unstructured.Unstructured).UnstructuredContent()["spec"].(map[string]interface{}), nil
+	val, _ := obj.(*unstructured.Unstructured).UnstructuredContent()["spec"].(map[string]interface{})
+	return val, nil
 }
 
 // List implements store.Store2Backend interface.
@@ -181,8 +182,9 @@ func (s *Store) List() map[store.Key]map[string]interface{} {
 	for kind, c := range s.caches {
 		for _, obj := range c.List() {
 			uns := obj.(*unstructured.Unstructured)
+			val, _ := uns.UnstructuredContent()["spec"].(map[string]interface{})
 			key := store.Key{Kind: kind, Name: uns.GetName(), Namespace: uns.GetNamespace()}
-			result[key] = uns.UnstructuredContent()["spec"].(map[string]interface{})
+			result[key] = val
 		}
 	}
 	return result
@@ -190,10 +192,11 @@ func (s *Store) List() map[store.Key]map[string]interface{} {
 
 func toEvent(t store.ChangeType, obj interface{}) store.BackendEvent {
 	uns := obj.(*unstructured.Unstructured)
+	val, _ := uns.UnstructuredContent()["spec"].(map[string]interface{})
 	return store.BackendEvent{
 		Type:  t,
 		Key:   store.Key{Kind: uns.GetKind(), Namespace: uns.GetNamespace(), Name: uns.GetName()},
-		Value: uns.UnstructuredContent()["spec"].(map[string]interface{}),
+		Value: val,
 	}
 }
 


### PR DESCRIPTION
fixes
```
/Volumes/Untitled/BAZEL_OUT/external/go1_8_3_darwin_amd64/src/runtime/asm_amd64.s:2197
panic: interface conversion: interface {} is nil, not map[string]interface {} [recovered]
	panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 2150 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	external/io_k8s_apimachinery/pkg/util/runtime/runtime.go:58 +0x126
panic(0x22acc40, 0xc420a07240)
	/Volumes/Untitled/BAZEL_OUT/external/go1_8_3_darwin_amd64/src/runtime/panic.go:489 +0x2cf
istio.io/mixer/pkg/config/crd.toEvent(0x0, 0x245a480, 0xc4209880a0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	pkg/config/crd/store.go:196 +0x1df
istio.io/mixer/pkg/config/crd.(*Store).OnAdd(0xc420250910, 0x245a480, 0xc4209880a0)
	pkg/config/crd/store.go:212 +0x56
k8s.io/client-go/tools/cache.(*processorListener).run(0xc4203edc30, 0x0)
	external/io_k8s_client_go/tools/cache/shared_informer.go:553 +0x2f6
k8s.io/client-go/tools/cache.(*processorListener).(k8s.io/client-go/tools/cache.run)-fm(0x0)
	external/io_k8s_client_go/tools/cache/shared_informer.go:330 +0x34
k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1()
	external/io_k8s_apimachinery/pkg/util/wait/wait.go:54 +0x31
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc4204b00a0, 0xc420a24080)
	external/io_k8s_apimachinery/pkg/util/wait/wait.go:71 +0x4f
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	external/io_k8s_apimachinery/pkg/util/wait/wait.go:72 +0x62
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1162)
<!-- Reviewable:end -->
