### PR TITLE
Update the logentry and metric templates with fields for monitored resources

### DIFF
--- a/template/logentry/template.proto
+++ b/template/logentry/template.proto
@@ -34,9 +34,13 @@ message Template {
     // Severity indicates the importance of the log entry.
     string severity = 3;
 
-    // An expression to compute the type of the monitored resource this log entry is being recorded on.
+    // Optional. An expression to compute the type of the monitored resource this log entry is being recorded on.
+    // If the logging backend supports monitored resources, these fields are used to populate that resource.
+    // Otherwise these fields will be ignored by the adapter.
     string monitored_resource_type = 4;
 
-    // A set of expressions that will form the dimensions of the monitored resource this log entry is being recorded on.
+    // Optional. A set of expressions that will form the dimensions of the monitored resource this log entry is being
+    // recorded on. If the logging backend supports monitored resources, these fields are used to populate that resource.
+    // Otherwise these fields will be ignored by the adapter.
     map<string, istio.mixer.v1.config.descriptor.ValueType> monitored_resource_dimensions = 5;
 }

--- a/template/logentry/template.proto
+++ b/template/logentry/template.proto
@@ -33,4 +33,10 @@ message Template {
 
     // Severity indicates the importance of the log entry.
     string severity = 3;
+
+    // An expression to compute the type of the monitored resource this log entry is being recorded on.
+    string monitored_resource_type = 4;
+
+    // A set of expressions that will form the dimensions of the monitored resource this log entry is being recorded on.
+    map<string, istio.mixer.v1.config.descriptor.ValueType> monitored_resource_dimensions = 5;
 }

--- a/template/metric/template.proto
+++ b/template/metric/template.proto
@@ -29,4 +29,10 @@ message Template {
 
     // The unique identity of the particular metric to report.
     map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 2;
+
+    // An expression to compute the type of the monitored resource this metric is being reported on.
+    string monitored_resource_type = 3;
+
+    // A set of expressions that will form the dimensions of the monitored resource this metric is being reported on.
+    map<string, istio.mixer.v1.config.descriptor.ValueType> monitored_resource_dimensions = 4;
 }

--- a/template/metric/template.proto
+++ b/template/metric/template.proto
@@ -30,9 +30,13 @@ message Template {
     // The unique identity of the particular metric to report.
     map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 2;
 
-    // An expression to compute the type of the monitored resource this metric is being reported on.
+    // Optional. An expression to compute the type of the monitored resource this metric is being reported on.
+    // If the metric backend supports monitored resources, these fields are used to populate that resource. Otherwise
+    // these fields will be ignored by the adapter.
     string monitored_resource_type = 3;
 
-    // A set of expressions that will form the dimensions of the monitored resource this metric is being reported on.
+    // Optional. A set of expressions that will form the dimensions of the monitored resource this metric is being reported on.
+    // If the metric backend supports monitored resources, these fields are used to populate that resource. Otherwise
+    // these fields will be ignored by the adapter.
     map<string, istio.mixer.v1.config.descriptor.ValueType> monitored_resource_dimensions = 4;
 }


### PR DESCRIPTION
Should monitored resource type be a string, or a `ValueType`? In Stackdriver it is always a string (as are all the dimensions).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add fields for monitored resources to the metric and log entry templates.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1163)
<!-- Reviewable:end -->
