### PR TITLE
don't specify resync period for shared informer

### DIFF
--- a/pkg/config/crd/store.go
+++ b/pkg/config/crd/store.go
@@ -38,10 +38,6 @@ const (
 )
 
 const (
-	// defaultResyncPeriod is the resync period for the k8s cache.
-	// TODO: allow customization.
-	defaultResyncPeriod = time.Minute
-
 	// initWaiterInterval is the interval to check if the initial data is ready
 	// in the cache.
 	initWaiterInterval = time.Millisecond
@@ -134,7 +130,7 @@ func (s *Store) Init(ctx context.Context, kinds []string) error {
 			}
 			if _, ok := kindsSet[res.Kind]; ok {
 				cl := lwBuilder.build(res)
-				informer := cache.NewSharedInformer(cl, &unstructured.Unstructured{}, defaultResyncPeriod)
+				informer := cache.NewSharedInformer(cl, &unstructured.Unstructured{}, 0)
 				s.caches[res.Kind] = informer.GetStore()
 				informers[res.Kind] = informer
 				informer.AddEventHandler(s)


### PR DESCRIPTION
I wasn't aware of the process of resync period -- but it actually
emits the update events for existing data for this period.

0 means no resync, which is suitable to our usage.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1166)
<!-- Reviewable:end -->
