### PR TITLE
pluralize kind names per k8s spec

### DIFF
--- a/cmd/server/cmd/crd_test.go
+++ b/cmd/server/cmd/crd_test.go
@@ -66,8 +66,11 @@ spec:
 ---`
 
 var exampleTmplInfos = map[string]template.Info{
-	"abcd-foo": {Name: "abcd-foo", Impl: "implPathShouldBeDNSCompat"},
-	"abcdBar":  {Name: "abcdBar", Impl: "implPathShouldBeDNSCompat2"},
+	"abcd-foo":   {Name: "abcd-foo", Impl: "implPathShouldBeDNSCompat"},
+	"abcdBar":    {Name: "abcdBar", Impl: "implPathShouldBeDNSCompat2"},
+	"entry":      {Name: "entry", Impl: "implPathShouldBeDNSCompat2"},      // unusual plural
+	"prometheus": {Name: "prometheus", Impl: "implPathShouldBeDNSCompat2"}, // unusual plural
+	"box":        {Name: "box", Impl: "implPathShouldBeDNSCompat2"},        // unusual plural
 }
 var exampleInstanceCrd = `kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -98,6 +101,54 @@ spec:
     kind: abcdBar
     plural: abcdBars
     singular: abcdBar
+  scope: Namespaced
+  version: v1alpha2
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: boxes.config.istio.io
+  labels:
+    package: implPathShouldBeDNSCompat2
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: box
+    plural: boxes
+    singular: box
+  scope: Namespaced
+  version: v1alpha2
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: entries.config.istio.io
+  labels:
+    package: implPathShouldBeDNSCompat2
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: entry
+    plural: entries
+    singular: entry
+  scope: Namespaced
+  version: v1alpha2
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: prometheuses.config.istio.io
+  labels:
+    package: implPathShouldBeDNSCompat2
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: prometheus
+    plural: prometheuses
+    singular: prometheus
   scope: Namespaced
   version: v1alpha2
 ---


### PR DESCRIPTION
K8s expects kind names to be pluralized per k8s spec (i.e. correctly :-) )
This reuses their pluralize code.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1167)
<!-- Reviewable:end -->
