### PR TITLE
safeDispatch: ensure that an adapter panic does not bring down Mixer

### DIFF
--- a/pkg/runtime/dispatcher_test.go
+++ b/pkg/runtime/dispatcher_test.go
@@ -37,6 +37,40 @@ import (
 	"istio.io/mixer/pkg/template"
 )
 
+func TestDispatcher_safeDispatch(t *testing.T) {
+	//safeDispatch(ctx context.Context, do dispatchFn, op string) (res *result) {
+
+	ctx := context.Background()
+	panicerror := errors.New("panicerror")
+
+	for _, tc := range []struct {
+		desc  string
+		panic bool
+	}{} {
+		t.Run(tc.desc, func(t *testing.T) {
+			want := &result{}
+			if tc.panic {
+				want.err = panicerror
+			}
+
+			res := safeDispatch(ctx, func(context context.Context) *result {
+				if tc.panic {
+					panic(panicerror)
+				}
+				return &result{}
+			}, tc.desc)
+
+			if res == want {
+				return
+			}
+
+			if !strings.Contains(res.err.Error(), want.err.Error()) {
+				t.Fatalf("got %v\nwant %v", res.err, want.err)
+			}
+		})
+	}
+}
+
 func TestReport(t *testing.T) {
 	gp := pool.NewGoroutinePool(1, true)
 	tname := "metric1"


### PR DESCRIPTION
Prometheus testing exposed this bug.
Added safe dispatch to ensure panic in adapter does not bring down mixer.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1168)
<!-- Reviewable:end -->
