### PR TITLE
Fix the concurrency issue in evaluator.IL.

### DIFF
--- a/pkg/il/evaluator/evaluator_test.go
+++ b/pkg/il/evaluator/evaluator_test.go
@@ -119,7 +119,7 @@ func TestEvalPredicate_WrongType(t *testing.T) {
 
 func TestEvalType(t *testing.T) {
 	e := initEvaluator(t, configBool)
-	ty, err := e.EvalType("attr", e.finder)
+	ty, err := e.EvalType("attr", e.getAttrContext().finder)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -130,7 +130,7 @@ func TestEvalType(t *testing.T) {
 
 func TestEvalType_WrongType(t *testing.T) {
 	e := initEvaluator(t, configBool)
-	_, err := e.EvalType("boo", e.finder)
+	_, err := e.EvalType("boo", e.getAttrContext().finder)
 	if err == nil {
 		t.Fatal("Was expecting an error")
 	}
@@ -138,7 +138,7 @@ func TestEvalType_WrongType(t *testing.T) {
 
 func TestAssertType(t *testing.T) {
 	e := initEvaluator(t, configBool)
-	err := e.AssertType("attr", e.finder, pbv.BOOL)
+	err := e.AssertType("attr", e.getAttrContext().finder, pbv.BOOL)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -146,7 +146,7 @@ func TestAssertType(t *testing.T) {
 
 func TestAssertType_WrongType(t *testing.T) {
 	e := initEvaluator(t, configBool)
-	err := e.AssertType("attr", e.finder, pbv.STRING)
+	err := e.AssertType("attr", e.getAttrContext().finder, pbv.STRING)
 	if err == nil {
 		t.Fatal("Was expecting an error")
 	}
@@ -154,7 +154,7 @@ func TestAssertType_WrongType(t *testing.T) {
 
 func TestAssertType_EvaluationError(t *testing.T) {
 	e := initEvaluator(t, configBool)
-	err := e.AssertType("boo", e.finder, pbv.BOOL)
+	err := e.AssertType("boo", e.getAttrContext().finder, pbv.BOOL)
 	if err == nil {
 		t.Fatal("Was expecting an error")
 	}
@@ -172,7 +172,7 @@ func TestConfigChange(t *testing.T) {
 
 	f := descriptor.NewFinder(&configBool)
 	e.ConfigChange(nil, f, nil)
-	if e.finder != f {
+	if e.getAttrContext().finder != f {
 		t.Fatal("Finder is not set correctly")
 	}
 


### PR DESCRIPTION
Mainly fixing two issues:
- The write to the finder pointer is not guaranteed to be atomic.
- Due to pointer capture in a local during the compilation, it was possible
  to add an interpreter to the cache that is based on the old version
  of the metadata.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1169)
<!-- Reviewable:end -->
