### PR TITLE
Update prometheus adapter for reload

### DIFF
--- a/adapter/prometheus2/BUILD
+++ b/adapter/prometheus2/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//adapter/prometheus2/config:go_default_library",
         "//pkg/adapter:go_default_library",
         "//template/metric:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",

--- a/adapter/prometheus2/BUILD
+++ b/adapter/prometheus2/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//adapter/prometheus2/config:go_default_library",
         "//pkg/adapter:go_default_library",
         "//template/metric:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",

--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -17,13 +17,17 @@
 package prometheus
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha1"
+	"encoding/gob"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -34,17 +38,24 @@ import (
 )
 
 type (
-	newServerFn func(string) server
+	// cinfo is a collector, its kind and the sha
+	// of config that produced the collector.
+	// sha is used to confirm a cache hit.
+	cinfo struct {
+		c    prometheus.Collector
+		sha  [sha1.Size]byte
+		kind config.Params_MetricInfo_Kind
+	}
 
 	builder struct {
-		newServer newServerFn
-		registry  *prometheus.Registry
+		metrics  map[string]*cinfo
+		registry *prometheus.Registry
+		srv      server
 	}
 
 	handler struct {
 		srv     server
-		metrics map[string]prometheus.Collector
-		kinds   map[string]config.Params_MetricInfo_Kind
+		metrics map[string]*cinfo
 	}
 )
 
@@ -55,8 +66,16 @@ var (
 	_ metric.Handler        = &handler{}
 )
 
-// GetBuilderInfo returns the BuilderInfo associated with this adapter implementation.
+// GetBuilderInfo returns the BuilderInfo associated with this adapter.
 func GetBuilderInfo() adapter.BuilderInfo {
+	// prometheus uses a singleton http port, so we make the
+	// builder itself a singleton, when defaultAddr become configurable
+	// srv will be a map[string]server
+	singletonBuilder := &builder{
+		srv:      newServer(defaultAddr),
+		registry: prometheus.NewPedanticRegistry(),
+		metrics:  make(map[string]*cinfo),
+	}
 	return adapter.BuilderInfo{
 		Name:        "prometheus",
 		Impl:        "istio.io/mixer/adapter/prometheus",
@@ -64,72 +83,102 @@ func GetBuilderInfo() adapter.BuilderInfo {
 		SupportedTemplates: []string{
 			metric.TemplateName,
 		},
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &builder{newServer, prometheus.NewPedanticRegistry()} },
-		DefaultConfig:        &config.Params{},
-		ValidateConfig:       func(msg adapter.Config) *adapter.ConfigErrors { return nil },
+		CreateHandlerBuilder: func() adapter.HandlerBuilder {
+			return singletonBuilder
+		},
+		DefaultConfig:  &config.Params{},
+		ValidateConfig: func(msg adapter.Config) *adapter.ConfigErrors { return nil },
 	}
 }
 
 func (b *builder) ConfigureMetricHandler(map[string]*metric.Type) error { return nil }
 
 func (b *builder) Build(c adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	srv := b.newServer(defaultAddr)
-	if err := srv.Start(env, promhttp.HandlerFor(b.registry, promhttp.HandlerOpts{})); err != nil {
-		return nil, err
-	}
 
 	cfg := c.(*config.Params)
 	var metricErr *multierror.Error
-	metricsMap := make(map[string]prometheus.Collector, len(cfg.Metrics))
-	kinds := make(map[string]config.Params_MetricInfo_Kind, len(cfg.Metrics))
+
+	// newMetrics collects new metric configuration
+	newMetrics := make([]*config.Params_MetricInfo, 0, len(cfg.Metrics))
+
+	// check for metric redefinition - if metric is redefined clear
+	// metric state: registry, metric map.
+	// Addition or removal of metrics is ok.
+	var cl *cinfo
 	for _, m := range cfg.Metrics {
+		// metric is not found in the current metric table
+		// should be added.
+		if cl = b.metrics[m.Name]; cl == nil {
+			newMetrics = append(newMetrics, m)
+			continue
+		}
+
+		// metric collector found and sha matches
+		// safe to reuse the existing collector.
+		if cl.sha == computeSha(m) {
+			continue
+		}
+
+		// sha does not match.
+		glog.Warningf("Metric %s redefined. Reloading adapter.", m.Name)
+		b.registry = prometheus.NewPedanticRegistry()
+		newMetrics = cfg.Metrics
+		b.metrics = make(map[string]*cinfo)
+		break
+	}
+
+	if glog.V(4) {
+		glog.Infof("%d new metrics defined", len(newMetrics))
+	}
+
+	var err error
+	for _, m := range newMetrics {
+		ci := &cinfo{kind: m.Kind, sha: computeSha(m)}
 		switch m.Kind {
 		case config.GAUGE:
-			c, err := registerOrGet(b.registry, newGaugeVec(m.Name, m.Description, m.LabelNames))
+			ci.c, err = registerOrGet(b.registry, newGaugeVec(m.Name, m.Description, m.LabelNames))
 			if err != nil {
 				metricErr = multierror.Append(metricErr, fmt.Errorf("could not register metric: %v", err))
 				continue
 			}
-			metricsMap[m.Name] = c
-			kinds[m.Name] = config.GAUGE
+			b.metrics[m.Name] = ci
 		case config.COUNTER:
-			c, err := registerOrGet(b.registry, newCounterVec(m.Name, m.Description, m.LabelNames))
+			ci.c, err = registerOrGet(b.registry, newCounterVec(m.Name, m.Description, m.LabelNames))
 			if err != nil {
 				metricErr = multierror.Append(metricErr, fmt.Errorf("could not register metric: %v", err))
 				continue
 			}
-			metricsMap[m.Name] = c
-			kinds[m.Name] = config.COUNTER
+			b.metrics[m.Name] = ci
 		case config.DISTRIBUTION:
-			c, err := registerOrGet(b.registry, newHistogramVec(m.Name, m.Description, m.LabelNames, m.Buckets))
+			ci.c, err = registerOrGet(b.registry, newHistogramVec(m.Name, m.Description, m.LabelNames, m.Buckets))
 			if err != nil {
 				metricErr = multierror.Append(metricErr, fmt.Errorf("could not register metric: %v", err))
 				continue
 			}
-			metricsMap[m.Name] = c
-			kinds[m.Name] = config.DISTRIBUTION
+			b.metrics[m.Name] = ci
 		default:
 			metricErr = multierror.Append(metricErr, fmt.Errorf("unknown metric kind (%d); could not register metric", m.Kind))
 		}
 	}
-	return &handler{srv, metricsMap, kinds}, metricErr.ErrorOrNil()
+
+	if err := b.srv.Start(env, promhttp.HandlerFor(b.registry, promhttp.HandlerOpts{})); err != nil {
+		return nil, err
+	}
+
+	return &handler{b.srv, b.metrics}, metricErr.ErrorOrNil()
 }
 
 func (h *handler) HandleMetric(_ context.Context, vals []*metric.Instance) error {
 	var result *multierror.Error
 
 	for _, val := range vals {
-		collector, found := h.metrics[val.Name]
+		ci, found := h.metrics[val.Name]
 		if !found {
 			result = multierror.Append(result, fmt.Errorf("could not find metric info from adapter config for %s", val.Name))
 			continue
 		}
-		kind, found := h.kinds[val.Name]
-		if !found {
-			result = multierror.Append(result, fmt.Errorf("could not find kind for metric %s", val.Name))
-			continue
-		}
-		switch kind {
+		collector := ci.c
+		switch ci.kind {
 		case config.GAUGE:
 			vec := collector.(*prometheus.GaugeVec)
 			amt, err := promValue(val.Value)
@@ -233,6 +282,7 @@ func labelNames(m []string) []string {
 // targeted for removal soon(tm). So, we duplicate that functionality here
 // to maintain it long-term, as we have a use case for the convenience.
 func registerOrGet(registry *prometheus.Registry, c prometheus.Collector) (prometheus.Collector, error) {
+
 	if err := registry.Register(c); err != nil {
 		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			return are.ExistingCollector, nil
@@ -274,4 +324,14 @@ func promLabels(l map[string]interface{}) prometheus.Labels {
 		labels[i] = fmt.Sprintf("%v", label)
 	}
 	return labels
+}
+
+func computeSha(m *config.Params_MetricInfo) [sha1.Size]byte {
+	var buff bytes.Buffer
+	enc := gob.NewEncoder(&buff)
+
+	if err := enc.Encode(m); err != nil {
+		glog.Warningf("Unable to encode %v", err)
+	}
+	return sha1.Sum(buff.Bytes())
 }

--- a/adapter/prometheus2/prometheus_test.go
+++ b/adapter/prometheus2/prometheus_test.go
@@ -31,10 +31,10 @@ import (
 )
 
 type testServer struct {
-	server
-
 	errOnStart bool
 }
+
+var _ server = &testServer{}
 
 func (t testServer) Start(adapter.Env, http.Handler) error {
 	if t.errOnStart {

--- a/adapter/prometheus2/prometheus_test.go
+++ b/adapter/prometheus2/prometheus_test.go
@@ -46,7 +46,11 @@ func (t testServer) Start(adapter.Env, http.Handler) error {
 func (testServer) Close() error { return nil }
 
 func newBuilder(s server) *builder {
-	return &builder{newServer: func(string) server { return s }, registry: prometheus.NewPedanticRegistry()}
+	return &builder{
+		srv:      s,
+		registry: prometheus.NewPedanticRegistry(),
+		metrics:  make(map[string]*cinfo),
+	}
 }
 
 var (
@@ -227,11 +231,9 @@ func TestFactory_Build_MetricDefinitionConflicts(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			for i, met := range v.metrics {
-				_, err := f.Build(makeConfig(met), test.NewEnv(t))
-				if i > 0 && err == nil {
-					t.Error("Build() => expected error during metrics registration")
-				}
+			_, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t))
+			if err == nil {
+				t.Error("Build() => expected error during metrics registration")
 			}
 		})
 	}
@@ -280,12 +282,12 @@ func TestProm_Record(t *testing.T) {
 			// Check tautological recording of entries.
 			pr := aspect.(*handler)
 			for _, adapterVal := range v.values {
-				c, ok := pr.metrics[adapterVal.Name]
+				ci, ok := pr.metrics[adapterVal.Name]
 				if !ok {
 					t.Errorf("Record() could not find metric with name %s:", adapterVal.Name)
 					continue
 				}
-
+				c := ci.c
 				m := new(dto.Metric)
 				switch c.(type) {
 				case *prometheus.CounterVec:

--- a/adapter/prometheus2/server.go
+++ b/adapter/prometheus2/server.go
@@ -91,10 +91,10 @@ func (s *serverInst) Start(env adapter.Env, metricsHandler http.Handler) (err er
 	srvMux := http.NewServeMux()
 	s.handler = &metaHandler{delegate: metricsHandler}
 	srvMux.Handle(metricsPath, s.handler)
-	s.srv = &http.Server{Addr: s.addr, Handler: srvMux}
+	srv := &http.Server{Addr: s.addr, Handler: srvMux}
 	env.ScheduleDaemon(func() {
 		env.Logger().Infof("serving prometheus metrics on %s", s.addr)
-		if err := s.srv.Serve(listener.(*net.TCPListener)); err != nil {
+		if err := srv.Serve(listener.(*net.TCPListener)); err != nil {
 			if err == http.ErrServerClosed {
 				env.Logger().Infof("HTTP server stopped")
 			} else {
@@ -102,6 +102,7 @@ func (s *serverInst) Start(env adapter.Env, metricsHandler http.Handler) (err er
 			}
 		}
 	})
+	s.srv = srv
 	s.refCnt++
 
 	return nil

--- a/adapter/prometheus2/server_test.go
+++ b/adapter/prometheus2/server_test.go
@@ -58,3 +58,37 @@ func TestServer(t *testing.T) {
 		t.Errorf("Failed to close server properly: %v", err)
 	}
 }
+
+func TestServerInst_Close(t *testing.T) {
+	testAddr := "127.0.0.1:9992"
+	s := newServer(testAddr)
+	env := test.NewEnv(t)
+
+	if err := s.Start(env, http.HandlerFunc(doesNothing)); err != nil {
+		t.Fatalf("Start() failed unexpectedly: %v", err)
+	}
+
+	if err := s.Start(env, http.HandlerFunc(doesNothing)); err != nil {
+		t.Fatalf("Start() failed unexpectedly: %v", err)
+	}
+
+	if s.srv == nil {
+		t.Fatalf("expected server to be non-nil")
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Failed to close server properly: %v", err)
+	}
+
+	if s.srv == nil {
+		t.Fatalf("expected server to be non-nil")
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Failed to close server properly: %v", err)
+	}
+
+	if s.srv != nil {
+		t.Fatalf("expected server to be nil: %v", s.srv)
+	}
+}

--- a/adapter/prometheus2/server_test.go
+++ b/adapter/prometheus2/server_test.go
@@ -60,7 +60,7 @@ func TestServer(t *testing.T) {
 }
 
 func TestServerInst_Close(t *testing.T) {
-	testAddr := "127.0.0.1:9992"
+	testAddr := "127.0.0.1:0"
 	s := newServer(testAddr)
 	env := test.NewEnv(t)
 


### PR DESCRIPTION
1. Use a singleton builder to ensure port is used correctly.
2. Do smart reloads, counter state is trashed only when a metric
   is redefined.
3. Ensure that builder.Build() does not panic on metric redefinition.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1173)
<!-- Reviewable:end -->
