### PR TITLE
fix the test flake on queue_test

### DIFF
--- a/pkg/config/store/fsstore2_test.go
+++ b/pkg/config/store/fsstore2_test.go
@@ -158,7 +158,9 @@ spec:
 			if err != nil {
 				tt.Fatal(err)
 			}
-			if err := s.Init(context.Background(), []string{"Kind"}); err != nil {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := s.Init(ctx, []string{"Kind"}); err != nil {
 				tt.Fatal(err.Error())
 			}
 			if lst := s.List(); len(lst) != 1 {
@@ -255,7 +257,9 @@ func TestFSStore2MissingRoot(t *testing.T) {
 	if err := os.RemoveAll(fsroot); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Init(context.Background(), []string{"Kind"}); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Init(ctx, []string{"Kind"}); err != nil {
 		t.Errorf("Got %v, Want nil", err)
 	}
 	if lst := s.List(); len(lst) != 0 {
@@ -319,7 +323,9 @@ spec:
 			if err := c.prepare(fsroot); err != nil {
 				tt.Fatalf("Failed to prepare precondition: %v", err)
 			}
-			if err := s.Init(context.Background(), []string{"Handler"}); err != nil {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := s.Init(ctx, []string{"Handler"}); err != nil {
 				tt.Fatalf("Init failed: %v", err)
 			}
 			want := map[Key]map[string]interface{}{k: data}


### PR DESCRIPTION
TestQueueCancel could be flaky because the timing of context's
timeout isn't very reliable. It could be delayed, and a bit more
events can be emitted unexpectedly.

Instead, this PR simplifies the test case; the core part of this
test case is that the outgoing channel is closed when the context
is done, the number of events or writing isn't relevant.

This PR also fixes passing context for some fsstore2 test cases.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1179)
<!-- Reviewable:end -->
