### PR TITLE
Suppress gogo* warnings in bazel

### DIFF
--- a/bazel.rc
+++ b/bazel.rc
@@ -1,5 +1,2 @@
-test --test_output=errors
-test --test_size_filters=-large,-enormous
-
 # Always include the version information in the build
 build --workspace_status_command=./bin/build_stamp.sh --action_env=ISTIO_VERSION --output_filter=^gogo


### PR DESCRIPTION
This PR adds an output filter to the default bazel build configuration to suppress WARNINGs related to codegen stuff.

This is meant to be a short-term workaround until a patch that addresses the need for the `output_to_workspace` option can be developed and fixed.

This PR also moves from the custom `mixer_gen` rule definition to a `native.genrule` for simplicity.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1180)
<!-- Reviewable:end -->
