### PR TITLE
Don't use encoding/gob to compute SHAs of config

### DIFF
--- a/pkg/runtime/handlerTable.go
+++ b/pkg/runtime/handlerTable.go
@@ -153,14 +153,14 @@ func encode(buf *bytes.Buffer, v interface{}) {
 			glog.Warningf("Failed to write %v to a buffer: %v", t, err)
 		}
 	case proto.Message:
-		if b, err := proto.Marshal(proto.Message(t)); err != nil {
+		if b, err := proto.Marshal(t); err != nil {
 			glog.Warningf("Failed to marshall %v into a proto: %v", t, err)
 		} else if _, err := buf.Write(b); err != nil {
 			glog.Warningf("Failed to write %v to buffer: %v", b, err)
 		}
 	default:
 		glog.Warningf("Fell into default case for v.(type): %#v; falling back to fmt.Fprintf()", t)
-		if _, err := fmt.Fprintf(buf, "%v", t); err != nil {
+		if _, err := fmt.Fprintf(buf, "%+v", t); err != nil {
 			glog.Warningf("Failed to write %v to buffer: %v", t, err)
 		}
 	}

--- a/pkg/runtime/handlerTable.go
+++ b/pkg/runtime/handlerTable.go
@@ -17,9 +17,10 @@ package runtime
 import (
 	"bytes"
 	"crypto/sha1"
-	"encoding/gob"
+	"fmt"
 	"sort"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/glog"
 
 	"istio.io/mixer/pkg/adapter"
@@ -145,20 +146,34 @@ func (t *handlerTable) initHandler(he *HandlerEntry) {
 	he.Handler, he.HandlerCreateError = t.buildHandler(hc, insts)
 }
 
-func encode(enc *gob.Encoder, e interface{}) {
-	if err := enc.Encode(e); err != nil {
-		glog.Warningf("Unable to encode %v", e)
+func encode(buf *bytes.Buffer, v interface{}) {
+	switch t := v.(type) {
+	case string:
+		if _, err := buf.Write([]byte(t)); err != nil {
+			glog.Warningf("Failed to write %v to a buffer: %v", t, err)
+		}
+	case proto.Message:
+		b, err := proto.Marshal(proto.Message(t))
+		if err != nil {
+			glog.Warningf("Failed to marshall %v into a proto: %v", t, err)
+		} else if _, err := buf.Write(b); err != nil {
+			glog.Warningf("Failed to write %v to buffer: %v", b, err)
+		}
+	default:
+		glog.Warningf("Fell into default case for v.(type): %#v; falling back to fmt.Fprintf()", t)
+		if _, err := fmt.Fprintf(buf, "%v", t); err != nil {
+			glog.Warningf("Failed to write %v to buffer: %v", t, err)
+		}
 	}
 }
 
 // computeSha for individual handler entries
 func (t *handlerTable) computeSha() {
-	var buff bytes.Buffer
-	enc := gob.NewEncoder(&buff)
+	buf := new(bytes.Buffer)
 	for _, nh := range t.table {
 		h := t.handlerConfig[nh.Name]
-		encode(enc, h.Adapter)
-		encode(enc, h.Params)
+		encode(buf, h.Adapter)
+		encode(buf, h.Params)
 
 		// instances in alphabetical order
 		// TODO add instance details only if the handler cares about it.
@@ -169,10 +184,10 @@ func (t *handlerTable) computeSha() {
 		sort.Strings(insts)
 		for _, iname := range insts {
 			inst := t.instanceConfig[iname]
-			encode(enc, inst.Template)
-			encode(enc, inst.Params)
+			encode(buf, inst.Template)
+			encode(buf, inst.Params)
 		}
-		nh.sha = sha1.Sum(buff.Bytes())
-		buff.Reset()
+		nh.sha = sha1.Sum(buf.Bytes())
+		buf.Reset()
 	}
 }

--- a/pkg/runtime/handlerTable.go
+++ b/pkg/runtime/handlerTable.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
+	"io"
 	"sort"
 
 	"github.com/gogo/protobuf/proto"
@@ -146,21 +147,21 @@ func (t *handlerTable) initHandler(he *HandlerEntry) {
 	he.Handler, he.HandlerCreateError = t.buildHandler(hc, insts)
 }
 
-func encode(buf *bytes.Buffer, v interface{}) {
+func encode(w io.Writer, v interface{}) {
 	switch t := v.(type) {
 	case string:
-		if _, err := buf.Write([]byte(t)); err != nil {
+		if _, err := w.Write([]byte(t)); err != nil {
 			glog.Warningf("Failed to write %v to a buffer: %v", t, err)
 		}
 	case proto.Message:
 		if b, err := proto.Marshal(t); err != nil {
 			glog.Warningf("Failed to marshall %v into a proto: %v", t, err)
-		} else if _, err := buf.Write(b); err != nil {
+		} else if _, err := w.Write(b); err != nil {
 			glog.Warningf("Failed to write %v to buffer: %v", b, err)
 		}
 	default:
 		glog.Warningf("Fell into default case for v.(type): %#v; falling back to fmt.Fprintf()", t)
-		if _, err := fmt.Fprintf(buf, "%+v", t); err != nil {
+		if _, err := fmt.Fprintf(w, "%+v", t); err != nil {
 			glog.Warningf("Failed to write %v to buffer: %v", t, err)
 		}
 	}

--- a/pkg/runtime/handlerTable.go
+++ b/pkg/runtime/handlerTable.go
@@ -153,8 +153,7 @@ func encode(buf *bytes.Buffer, v interface{}) {
 			glog.Warningf("Failed to write %v to a buffer: %v", t, err)
 		}
 	case proto.Message:
-		b, err := proto.Marshal(proto.Message(t))
-		if err != nil {
+		if b, err := proto.Marshal(proto.Message(t)); err != nil {
 			glog.Warningf("Failed to marshall %v into a proto: %v", t, err)
 		} else if _, err := buf.Write(b); err != nil {
 			glog.Warningf("Failed to write %v to buffer: %v", b, err)


### PR DESCRIPTION
Gob was barfing attempting to encode some nested protos due to requiring registration of types up front. For this usecase we just need SHAs of strings and proto fields, so we implement this directly for strings and use proto.Marshal to get a []byte from the protos

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1197)
<!-- Reviewable:end -->
