### PR TITLE
Updates to support 3rd party adapters in other repos

### DIFF
--- a/pkg/adapter/template/BUILD
+++ b/pkg/adapter/template/BUILD
@@ -8,6 +8,7 @@ gogoslick_proto_library(
         "google/protobuf/descriptor.proto": "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     },
     imports = [
+        "../../external/com_github_google_protobuf/src",
         "external/com_github_google_protobuf/src",
     ],
     inputs = [
@@ -17,6 +18,7 @@ gogoslick_proto_library(
     verbose = 0,
     with_grpc = False,
     deps = [
+        "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor:go_default_library",
         "@com_github_gogo_protobuf//sortkeys:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",

--- a/tools/codegen/generate.bzl
+++ b/tools/codegen/generate.bzl
@@ -8,14 +8,14 @@ MIXER_DEPS = [
     "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
 ]
 MIXER_INPUTS = [
-    "//pkg/adapter/template:protos",
+    "@com_github_istio_mixer//pkg/adapter/template:protos",
     "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
 ]
 MIXER_IMPORT_MAP = {
     "mixer/v1/config/descriptor/value_type.proto": "istio.io/api/mixer/v1/config/descriptor",
     "pkg/adapter/template/TemplateExtensions.proto": "istio.io/mixer/pkg/adapter/template",
 }
-MIXER_IMPORTS = [ "external/com_github_istio_api" ]
+MIXER_IMPORTS = [ "external/com_github_istio_api", "../../external/com_github_istio_api", "external/com_github_istio_mixer" ]
 
 # TODO: fill in with complete set of GOGO DEPS and IMPORT MAPPING
 GOGO_DEPS = [
@@ -28,7 +28,7 @@ GOGO_IMPORT_MAP = {
     "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
 }
 
-PROTO_IMPORTS = ["external/com_github_google_protobuf/src"]
+PROTO_IMPORTS = [ "external/com_github_google_protobuf/src", "../../external/com_github_google_protobuf/src" ]
 PROTO_INPUTS = [ "@com_github_google_protobuf//:well_known_protos" ]
 
 def _gen_template_and_handler(name, importmap = {}):   


### PR DESCRIPTION
This PR makes the changes that are needed to support building with an adapter from a different repo.  These changes are informed by the example PR in https://github.com/istio/mixer/pull/1108.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
```
