### PR TITLE
Add TCP attributes to appropriate manifests

### DIFF
--- a/testdata/config/attributes.yaml
+++ b/testdata/config/attributes.yaml
@@ -49,6 +49,24 @@ spec:
         valueType: STRING
       target.uid:
         valueType: STRING
+      connection.id:
+        valueType: STRING
+      connection.received.bytes:
+        valueType: INT64
+      connection.received.bytes_total:
+        valueType: INT64
+      connection.sent.bytes:
+        valueType: INT64
+      connection.sent.bytes_total:
+        valueType: INT64
+      connection.duration:
+        valueType: DURATION
+      connection.protocol:
+        valueType: STRING
+      connection.timestamp:
+        valueType: TIMESTAMP
+      connection.time:
+        valueType: TIMESTAMP
       # DEPRECATED, to be removed. Use request.useragent instead.
       request.user-agent:
         valueType: STRING

--- a/testdata/configroot/scopes/global/descriptors.yml
+++ b/testdata/configroot/scopes/global/descriptors.yml
@@ -75,6 +75,24 @@ manifests:
         valueType: STRING
       target.uid:
         valueType: STRING
+      connection.id:
+        valueType: STRING
+      connection.received.bytes:
+        valueType: INT64
+      connection.received.bytes_total:
+        valueType: INT64
+      connection.sent.bytes:
+        valueType: INT64
+      connection.sent.bytes_total:
+        valueType: INT64
+      connection.duration:
+        valueType: DURATION
+      connection.protocol:
+        valueType: STRING
+      connection.timestamp:
+        valueType: TIMESTAMP
+      connection.time:
+        valueType: TIMESTAMP
       # DEPRECATED, to be removed. Use request.useragent instead.
       request.user-agent:
         valueType: STRING


### PR DESCRIPTION
This PR adds the attributes recently added to the global dictionary list to the manifests (old and new) within mixer.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1200)
<!-- Reviewable:end -->
