### PR TITLE
remove dashes from crd names and update configs

### DIFF
--- a/adapter/list/list.go
+++ b/adapter/list/list.go
@@ -236,7 +236,7 @@ func (h *handler) purgeList() {
 // GetInfo returns the Info associated with this adapter implementation.
 func GetInfo() pkgHndlr.Info {
 	return pkgHndlr.Info{
-		Name:               "list-checker",
+		Name:               "listchecker",
 		Impl:               "istio.io/mixer/adapter/list",
 		Description:        "Checks whether an entry is present in a list",
 		SupportedTemplates: []string{listentry.TemplateName},

--- a/pkg/runtime/controller.go
+++ b/pkg/runtime/controller.go
@@ -84,10 +84,10 @@ type Controller struct {
 }
 
 // RulesKind defines the config kind name of mixer rules.
-const RulesKind = "mixer-rule"
+const RulesKind = "rule"
 
 // AttributeManifestKind define the config kind name of attribute manifests.
-const AttributeManifestKind = "attribute-manifest"
+const AttributeManifestKind = "attribute"
 
 // ResolverChangeListener is notified when a new resolver is created due to config change.
 type ResolverChangeListener interface {

--- a/pkg/runtime/controller.go
+++ b/pkg/runtime/controller.go
@@ -87,7 +87,7 @@ type Controller struct {
 const RulesKind = "rule"
 
 // AttributeManifestKind define the config kind name of attribute manifests.
-const AttributeManifestKind = "attribute"
+const AttributeManifestKind = "attributemanifest"
 
 // ResolverChangeListener is notified when a new resolver is created due to config change.
 type ResolverChangeListener interface {

--- a/testdata/config/attributes.yaml
+++ b/testdata/config/attributes.yaml
@@ -1,5 +1,5 @@
 apiVersion: "config.istio.io/v1alpha2"
-kind: attribute-manifest
+kind: attributemanifest
 metadata:
   name: istio-proxy
   namespace: istio-config-default
@@ -54,7 +54,7 @@ spec:
         valueType: STRING
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: attribute-manifest
+kind: attributemanifest
 metadata:
   name: kubernetes
   namespace: istio-config-default

--- a/testdata/config/deny.yaml
+++ b/testdata/config/deny.yaml
@@ -17,7 +17,7 @@ spec:
  
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: mixer-rule
+kind: rule
 metadata:
   name: mixerdenysome
   namespace: istio-config-default

--- a/testdata/config/metrics.yaml
+++ b/testdata/config/metrics.yaml
@@ -45,7 +45,7 @@ spec:
     response_code: response.code | 200
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: mixer-rule
+kind: rule
 metadata:
   name: prommetrics
   namespace: istio-config-default

--- a/testdata/config/metrics.yaml
+++ b/testdata/config/metrics.yaml
@@ -8,11 +8,32 @@ spec:
   - name: request_count
     instance_name: requestcount.metric.istio-config-default
     kind: COUNTER
-    label_names: [ source, target, service, method, version,  response_code ]
+    label_names: [ source, target, service, method, version, response_code ]
   - name: request_duration
     instance_name: requestduration.metric.istio-config-default
-    kind: COUNTER
-    label_names: [ source, target, service, method, version,  response_code ]
+    kind: DISTRIBUTION
+    label_names: [ source, target, service, method, version, response_code ]
+    buckets:
+      explicit_buckets:
+        bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+  - name: request_size
+    instance_name: requestsize.metric.istio-config-default
+    kind: DISTRIBUTION
+    label_names: [ source, target, service, method, version, response_code ]
+    buckets:
+      exponentialBuckets:
+        numFiniteBuckets: 8
+        scale: 1
+        growthFactor: 10
+  - name: response_size
+    instance_name: responsesize.metric.istio-config-default
+    kind: DISTRIBUTION
+    label_names: [ source, target, service, method, version, response_code ]
+    buckets:
+      exponentialBuckets:
+        numFiniteBuckets: 8
+        scale: 1
+        growthFactor: 10
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -45,6 +66,36 @@ spec:
     response_code: response.code | 200
 ---
 apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: requestsize
+  namespace: istio-config-default
+spec:
+  value: request.size | 0
+  dimensions:
+    source: source.labels["app"] | "unknown"
+    target: target.service | "unknown"
+    service: target.labels["app"] | "unknown"
+    method: request.path | "unknown"
+    version: target.labels["version"] | "unknown"
+    response_code: response.code | 200
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: responsesize
+  namespace: istio-config-default
+spec:
+  value: response.size | 0
+  dimensions:
+    source: source.labels["app"] | "unknown"
+    target: target.service | "unknown"
+    service: target.labels["app"] | "unknown"
+    method: request.path | "unknown"
+    version: target.labels["version"] | "unknown"
+    response_code: response.code | 200
+---
+apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: prommetrics
@@ -56,3 +107,5 @@ spec:
     instances:
     - requestcount.metric.istio-config-default
     - requestduration.metric.istio-config-default
+    - requestsize.metric.istio-config-default
+    - responsesize.metric.istio-config-default

--- a/testdata/config/quota.yaml
+++ b/testdata/config/quota.yaml
@@ -20,7 +20,7 @@ spec:
     target: target.service | "unknown"
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: mixer-rule
+kind: rule
 metadata:
   name: quota
   namespace: istio-config-default


### PR DESCRIPTION
Remove dashes from all crd names.

We should add validation that rejects template and adapter names with dashes in a subsequent PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1203)
<!-- Reviewable:end -->
