### PR TITLE
Remove output_to_workspace flag

### DIFF
--- a/adapter_author_deps.bzl
+++ b/adapter_author_deps.bzl
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 def mixer_adapter_repositories():
     native.git_repository(
         name = "org_pubref_rules_protobuf",
-        commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31, 2017 (gogo* support)
+        commit = "439c57e42dd4edf488644871ee0e0ec3b7c83b6e",  # Sept 1, 2017 (genfiles fix)
         remote = "https://github.com/pubref/rules_protobuf",
     )
 

--- a/tools/codegen/generate.bzl
+++ b/tools/codegen/generate.bzl
@@ -98,7 +98,6 @@ def mixer_proto_library(
       "imports": imports + MIXER_IMPORTS + PROTO_IMPORTS,
       "importmap": dict(dict(MIXER_IMPORT_MAP, **GOGO_IMPORT_MAP), **importmap),
       "inputs": inputs + MIXER_INPUTS + PROTO_INPUTS,
-      "output_to_workspace": True, # TODO: Remove when an appropriate fix/workaround exists.
       "verbose": verbose,
    }
 


### PR DESCRIPTION
This PR updates the pubref dep to include the patch for generating pb.go files from generated proto files, removing the need for the `output_to_workspace` flag in the `generate.bzl` calls to `gogoslick_proto_library`. 

Fixes #949.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1204)
<!-- Reviewable:end -->
