### PR TITLE
Send Check method the result of the preprocessing step.

### DIFF
--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -128,7 +128,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 	if s.dispatcher != nil {
 		// dispatch check2 and set success messages.
 		glog.V(1).Info("Dispatching Check2")
-		cr, err := s.dispatcher.Check(legacyCtx, requestBag)
+		cr, err := s.dispatcher.Check(legacyCtx, preprocResponseBag)
 		if err != nil {
 			out2 = status.WithError(err)
 		}


### PR DESCRIPTION
Check was previously being sent the plain request bag, it should be sent the result of the preprocessing step.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1207)
<!-- Reviewable:end -->
