### PR TITLE
create fake watchers earlier for CRD tests

### DIFF
--- a/pkg/config/crd/store_test.go
+++ b/pkg/config/crd/store_test.go
@@ -65,6 +65,11 @@ type dummyListerWatcherBuilder struct {
 }
 
 func (d *dummyListerWatcherBuilder) build(res metav1.APIResource) cache.ListerWatcher {
+	w := watch.NewFake()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.watchers[res.Kind] = w
+
 	return &cache.ListWatch{
 		ListFunc: func(metav1.ListOptions) (runtime.Object, error) {
 			d.mu.RLock()
@@ -78,10 +83,6 @@ func (d *dummyListerWatcherBuilder) build(res metav1.APIResource) cache.ListerWa
 			return list, nil
 		},
 		WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
-			d.mu.Lock()
-			defer d.mu.Unlock()
-			w := watch.NewFake()
-			d.watchers[res.Kind] = w
 			return w, nil
 		},
 	}


### PR DESCRIPTION
Maybe there's a race between the invocation of `WatchFunc` and
the `put` method which injects the test data. If `put` comes
earlier, that event never comes to the watching channel (because
the watcher isn't there yet), therefore `waitFor` will fail to
receive the expected event.

For #1209

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1210)
<!-- Reviewable:end -->
