### PR TITLE
Fix crd test flakeness

### DIFF
--- a/pkg/config/crd/store_test.go
+++ b/pkg/config/crd/store_test.go
@@ -65,6 +65,11 @@ type dummyListerWatcherBuilder struct {
 }
 
 func (d *dummyListerWatcherBuilder) build(res metav1.APIResource) cache.ListerWatcher {
+	w := watch.NewFake()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.watchers[res.Kind] = w
+
 	return &cache.ListWatch{
 		ListFunc: func(metav1.ListOptions) (runtime.Object, error) {
 			d.mu.RLock()
@@ -78,10 +83,6 @@ func (d *dummyListerWatcherBuilder) build(res metav1.APIResource) cache.ListerWa
 			return list, nil
 		},
 		WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
-			d.mu.Lock()
-			defer d.mu.Unlock()
-			w := watch.NewFake()
-			d.watchers[res.Kind] = w
 			return w, nil
 		},
 	}


### PR DESCRIPTION
This should fix the test flakeness and potential timeout for `pkg/config/crd`. At least this should remove
the timeout failure which hides the actual problem if there are.

- similar to #1210, creates the watcher instance earlier, to resolve the race condition between invocation of `WatchFunc` (of creating watcher) and `put` (use of watcher)
- replace `FakeWatcher` by `RaceFreeFakeWatcher`. Otherwise, `put` may be blocked due to write of channel with no listeners.
- restructure `TestCrdsRetryAsynchronously` a bit; make the put/watch/get testing after verifying the store creates the cache. Otherwise, the cache isn't ready yet, and the test can fail.
- minor cleanup to cancel the context for `Init` after the test case finishes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1212)
<!-- Reviewable:end -->
