### PR TITLE
Move prometheus adapter to Builder2 model

### DIFF
--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -50,7 +50,7 @@ type (
 		metrics  map[string]*cinfo
 		registry *prometheus.Registry
 		srv      server
-		cnfg     *config.Params
+		cfg      *config.Params
 	}
 
 	handler struct {
@@ -98,11 +98,11 @@ func (b *builder) clearState() {
 }
 
 func (b *builder) SetMetricTypes(map[string]*metric.Type) {}
-func (b *builder) SetAdapterConfig(cnfg adapter.Config)   { b.cnfg = cnfg.(*config.Params) }
+func (b *builder) SetAdapterConfig(cfg adapter.Config)    { b.cfg = cfg.(*config.Params) }
 func (b *builder) Validate() *adapter.ConfigErrors        { return nil }
 func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 
-	cfg := b.cnfg
+	cfg := b.cfg
 	var metricErr *multierror.Error
 
 	// newMetrics collects new metric configuration

--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -50,6 +50,7 @@ type (
 		metrics  map[string]*cinfo
 		registry *prometheus.Registry
 		srv      server
+		cnfg     *config.Params
 	}
 
 	handler struct {
@@ -61,7 +62,7 @@ type (
 var (
 	charReplacer = strings.NewReplacer("/", "_", ".", "_", " ", "_", "-", "")
 
-	_ metric.HandlerBuilder = &builder{}
+	_ metric.HandlerBuilder = &obuilder{}
 	_ metric.Handler        = &handler{}
 )
 
@@ -81,11 +82,13 @@ func GetInfo() pkgHndlr.Info {
 		SupportedTemplates: []string{
 			metric.TemplateName,
 		},
-		CreateHandlerBuilder: func() adapter.HandlerBuilder {
-			return singletonBuilder
-		},
+		NewBuilder: func() adapter.Builder2 { return singletonBuilder },
+		// to be deleted
 		DefaultConfig:  &config.Params{},
 		ValidateConfig: func(msg adapter.Config) *adapter.ConfigErrors { return nil },
+		CreateHandlerBuilder: func() adapter.HandlerBuilder {
+			return &obuilder{b: singletonBuilder}
+		},
 	}
 }
 
@@ -94,11 +97,12 @@ func (b *builder) clearState() {
 	b.metrics = make(map[string]*cinfo)
 }
 
-func (b *builder) ConfigureMetricHandler(map[string]*metric.Type) error { return nil }
+func (b *builder) SetMetricTypes(map[string]*metric.Type) {}
+func (b *builder) SetAdapterConfig(cnfg adapter.Config)   { b.cnfg = cnfg.(*config.Params) }
+func (b *builder) Validate() *adapter.ConfigErrors        { return nil }
+func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 
-func (b *builder) Build(c adapter.Config, env adapter.Env) (adapter.Handler, error) {
-
-	cfg := c.(*config.Params)
+	cfg := b.cnfg
 	var metricErr *multierror.Error
 
 	// newMetrics collects new metric configuration
@@ -340,4 +344,19 @@ func computeSha(m *config.Params_MetricInfo, log adapter.Logger) [sha1.Size]byte
 		log.Warningf("Unable to encode %v", err)
 	}
 	return sha1.Sum(ba)
+}
+
+type obuilder struct {
+	b *builder
+}
+
+func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
+	o.b.SetAdapterConfig(cfg)
+	return o.b.Build(context.Background(), env)
+}
+
+// ConfigureMetricHandler is to be deleted
+func (o *obuilder) ConfigureMetricHandler(types map[string]*metric.Type) error {
+	o.b.SetMetricTypes(types)
+	return nil
 }

--- a/adapter/prometheus2/prometheus_test.go
+++ b/adapter/prometheus2/prometheus_test.go
@@ -165,7 +165,8 @@ func TestFactory_NewMetricsAspect(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			if _, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t)); err != nil {
+			f.SetAdapterConfig(makeConfig(v.metrics...))
+			if _, err := f.Build(context.Background(), test.NewEnv(t)); err != nil {
 				t.Errorf("NewMetricsAspect() => unexpected error: %v", err)
 			}
 		})
@@ -174,7 +175,8 @@ func TestFactory_NewMetricsAspect(t *testing.T) {
 
 func TestFactory_BuildServerFail(t *testing.T) {
 	f := newBuilder(&testServer{errOnStart: true})
-	if _, err := f.Build(makeConfig(), test.NewEnv(t)); err == nil {
+	f.SetAdapterConfig(makeConfig())
+	if _, err := f.Build(context.Background(), test.NewEnv(t)); err == nil {
 		t.Error("NewMetricsAspect() => expected error on server startup")
 	}
 }
@@ -189,7 +191,8 @@ func TestBuild_MetricDefinitionErrors(t *testing.T) {
 	}
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			if _, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t)); err == nil {
+			f.SetAdapterConfig(makeConfig(v.metrics...))
+			if _, err := f.Build(context.Background(), test.NewEnv(t)); err == nil {
 				t.Errorf("Expected error for Build(%#v)", v.metrics)
 			}
 		})
@@ -231,7 +234,8 @@ func TestFactory_Build_MetricDefinitionConflicts(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			_, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t))
+			f.SetAdapterConfig(makeConfig(v.metrics...))
+			_, err := f.Build(context.Background(), test.NewEnv(t))
 			if err == nil {
 				t.Error("Build() => expected error during metrics registration")
 			}
@@ -241,7 +245,8 @@ func TestFactory_Build_MetricDefinitionConflicts(t *testing.T) {
 
 func TestProm_Close(t *testing.T) {
 	f := newBuilder(&testServer{})
-	prom, _ := f.Build(&config.Params{}, test.NewEnv(t))
+	f.SetAdapterConfig(&config.Params{})
+	prom, _ := f.Build(context.Background(), test.NewEnv(t))
 	if err := prom.Close(); err != nil {
 		t.Errorf("Close() should not have returned an error: %v", err)
 	}
@@ -269,7 +274,8 @@ func TestProm_Record(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			a, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t))
+			f.SetAdapterConfig(makeConfig(v.metrics...))
+			a, err := f.Build(context.Background(), test.NewEnv(t))
 			if err != nil {
 				t.Errorf("Build() => unexpected error: %v", err)
 			}
@@ -336,7 +342,8 @@ func TestProm_RecordFailures(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			a, err := f.Build(makeConfig(v.metrics...), test.NewEnv(t))
+			f.SetAdapterConfig(makeConfig(v.metrics...))
+			a, err := f.Build(context.Background(), test.NewEnv(t))
 			if err != nil {
 				t.Errorf("Build() => unexpected error: %v", err)
 			}


### PR DESCRIPTION
Changed the builder to builder2 interface
Moved the existing builder code as oBuilder, will delete it very soon.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1215)
<!-- Reviewable:end -->
