### PR TITLE
Add adpater test framework and sample tests

### DIFF
--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     visibility = [
         "//cmd:__subpackages__",
+        "//test/testenv:__subpackages__",
     ],
     deps = [
         "//adapter:go_default_library",

--- a/cmd/server/cmd/test_server.go
+++ b/cmd/server/cmd/test_server.go
@@ -46,11 +46,12 @@ var defaultSeverArgs = serverArgs{
 
 // SetupTestServer sets up a test server environment
 func SetupTestServer(info map[string]template.Info, adapters []adapter.InfoFn, configStoreURL string, configStore2URL string,
-	configDefaultNamespace string, configIdentityAttributeDomain string) *ServerContext {
+	configDefaultNamespace string, configIdentityAttributeDomain string, useAst bool) *ServerContext {
 	sa := defaultSeverArgs
 	sa.configStoreURL = configStoreURL
 	sa.configStore2URL = configStore2URL
 	sa.configDefaultNamespace = configDefaultNamespace
 	sa.configIdentityAttributeDomain = configIdentityAttributeDomain
+	sa.useAst = useAst
 	return setupServer(&sa, info, adapters, shared.Printf, shared.Fatalf)
 }

--- a/test/testenv/BUILD
+++ b/test/testenv/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "testenv.go",
+    ],
+    deps = [
+        "//cmd/server/cmd:go_default_library",
+        "//cmd/shared:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/template:go_default_library",
+        "@com_github_istio_api//:mixer/v1",  # keep
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["testenv_test.go"],
+    data = [
+        "//testdata",
+    ],
+    library = ":go_default_library",
+    deps = [
+        "//adapter/denier:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/attribute:go_default_library",
+        "//template:go_default_library",
+        "//test/testenv:go_default_library",
+        "@com_github_istio_api//:mixer/v1",  # keep
+        "@com_github_pborman_uuid//:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+    ],
+)

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -1,0 +1,84 @@
+package testenv
+
+import (
+	"io"
+	"net"
+
+	"google.golang.org/grpc"
+	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/mixer/cmd/server/cmd"
+	"istio.io/mixer/cmd/shared"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/template"
+)
+
+// TestEnv interface
+type TestEnv interface {
+	io.Closer
+	CreateMixerClient() (mixerpb.MixerClient, *grpc.ClientConn, error)
+}
+
+type testEnv struct {
+	addr         string
+	mixerContext *cmd.ServerContext
+	shutdown     chan struct{}
+}
+
+// Args includes the required args to initialize Mixer server.
+type Args struct {
+	MixerServerAddr               string
+	ConfigStoreURL                string
+	ConfigStore2URL               string
+	ConfigDefaultNamespace        string
+	ConfigIdentityAttributeDomain string
+	UseAstEvaluator               bool
+}
+
+// NewEnv creates a TestEnv instance.
+func NewEnv(args *Args, info map[string]template.Info, adapters []adapter.InfoFn) (TestEnv, error) {
+	lis, err := net.Listen("tcp", args.MixerServerAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	context := cmd.SetupTestServer(info, adapters, args.ConfigStoreURL, args.ConfigStore2URL,
+		args.ConfigDefaultNamespace, args.ConfigIdentityAttributeDomain, args.UseAstEvaluator)
+	shutdown := make(chan struct{})
+
+	go func() {
+		shared.Printf("Start test Mixer on:%v\n", lis.Addr())
+		{
+			defer context.GP.Close()
+			defer context.AdapterGP.Close()
+			if err := context.Server.Serve(lis); err != nil {
+				shared.Printf("Mixer Shutdown: %v\n", err)
+			}
+		}
+		shutdown <- struct{}{}
+	}()
+
+	return &testEnv{
+		addr:         lis.Addr().String(),
+		mixerContext: context,
+		shutdown:     shutdown,
+	}, nil
+}
+
+// CreateMixerClient returns a Mixer Grpc client.
+func (env *testEnv) CreateMixerClient() (mixerpb.MixerClient, *grpc.ClientConn, error) {
+	conn, err := grpc.Dial(env.addr, grpc.WithInsecure())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return mixerpb.NewMixerClient(conn), conn, nil
+}
+
+// Close cleans up TestEnv.
+func (env *testEnv) Close() error {
+	env.mixerContext.Server.GracefulStop()
+	<-env.shutdown
+	close(env.shutdown)
+	env.mixerContext = nil
+	return nil
+}

--- a/test/testenv/testenv_test.go
+++ b/test/testenv/testenv_test.go
@@ -1,0 +1,131 @@
+package testenv
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/pborman/uuid"
+	"golang.org/x/net/context"
+	mixerapi "istio.io/api/mixer/v1"
+	"istio.io/mixer/adapter/denier"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/template"
+)
+
+func closeHelper(c io.Closer) {
+	err := c.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func copyFile(dest, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	defer closeHelper(in)
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer closeHelper(out)
+	_, err = io.Copy(out, in)
+	return err
+
+}
+
+func buildConfigStore(relativePaths []string) (string, error) {
+	currentPath, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	configPath := path.Join(currentPath, uuid.New())
+	if err = os.Mkdir(configPath, os.ModePerm); err != nil {
+		return "", err
+	}
+
+	for _, filePath := range relativePaths {
+		err = copyFile(path.Join(configPath, path.Base(filePath)), path.Join(currentPath, filePath))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return configPath, nil
+}
+
+func getAttrBag(attribs map[string]interface{}) mixerapi.Attributes {
+	requestBag := attribute.GetMutableBag(nil)
+	requestBag.Set("target.service", "svc.cluster.local")
+	for k, v := range attribs {
+		requestBag.Set(k, v)
+	}
+
+	var attrs mixerapi.Attributes
+	requestBag.ToProto(&attrs, nil, 0)
+	return attrs
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	code := m.Run()
+	os.Exit(code)
+}
+
+func TestDenierAdapter(t *testing.T) {
+	configStore, err := buildConfigStore([]string{
+		"../../testdata/config/attributes.yaml",
+		"../../testdata/config/deny.yaml",
+	})
+	if err != nil {
+		t.Fatalf("fail to build test config store: %v", err)
+	}
+
+	defer func() {
+		if removeErr := os.RemoveAll(configStore); removeErr != nil {
+			log.Fatal(removeErr)
+		}
+	}()
+
+	var args = Args{
+		// Start Mixer server on a free port on loop back interface
+		MixerServerAddr:               `127.0.0.1:0`,
+		ConfigStoreURL:                `fs://` + configStore,
+		ConfigStore2URL:               `fs://` + configStore,
+		ConfigDefaultNamespace:        "istio-config-default",
+		ConfigIdentityAttributeDomain: "svc.cluster.local",
+		UseAstEvaluator:               true,
+	}
+
+	env, err := NewEnv(&args, template.SupportedTmplInfo, []adapter.InfoFn{denier.GetInfo})
+	if err != nil {
+		t.Fatalf("fail to create testenv: %v", err)
+	}
+
+	defer closeHelper(env)
+
+	client, conn, err := env.CreateMixerClient()
+	if err != nil {
+		t.Fatalf("fail to create client connection: %v", err)
+	}
+	defer closeHelper(conn)
+
+	attribs := map[string]interface{}{"request.headers": map[string]string{"clnt": "abc"}}
+	bag := getAttrBag(attribs)
+	request := mixerapi.CheckRequest{Attributes: bag}
+	resq, err := client.Check(context.Background(), &request)
+	if err != nil {
+		t.Errorf("fail to send check to Mixer %v", err)
+	}
+	if resq.Precondition.Status.Code != 7 {
+		t.Error(`resq.Precondition.Status.Code != 7`)
+	}
+}

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -14,3 +14,9 @@ pkg_tar(
     tags = ["manual"],
     visibility = ["//docker:__pkg__"],
 )
+
+filegroup(
+    name = "testdata",
+    srcs = glob(["**/*.yml"]) + glob(["**/*.yaml"]),
+    visibility = ["//test/testenv:__subpackages__"],
+)


### PR DESCRIPTION
- Add testenv package which allows adapter developers to instantiate Mixer server and client in test proc for easy test and debug.
- Add a sample test based on denier

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1217)
<!-- Reviewable:end -->
