### PR TITLE
Update MixerIL to return "" when lookup from a stringmap fails.

### DIFF
--- a/pkg/il/builder.go
+++ b/pkg/il/builder.go
@@ -202,6 +202,11 @@ func (f *Builder) Lookup() {
 	f.op0(Lookup)
 }
 
+// NLookup appends the "nlookup" instruction to the byte code.
+func (f *Builder) NLookup() {
+	f.op0(NLookup)
+}
+
 // TLookup appends the "tlookup" instruction to the byte code.
 func (f *Builder) TLookup() {
 	f.op0(TLookup)
@@ -210,6 +215,11 @@ func (f *Builder) TLookup() {
 // ALookup appends the "alookup" instruction to the byte code.
 func (f *Builder) ALookup(v string) {
 	f.op1(ALookup, f.id(v))
+}
+
+// ANLookup appends the "anlookup" instruction to the byte code.
+func (f *Builder) ANLookup(v string) {
+	f.op1(ANLookup, f.id(v))
 }
 
 // AllocateLabel allocates a new label value for use within the code.

--- a/pkg/il/builder_test.go
+++ b/pkg/il/builder_test.go
@@ -310,12 +310,31 @@ var builderTests = []builderTest{
 		},
 	},
 	{
+		n: "nlookup",
+		i: func(b *Builder) {
+			b.NLookup()
+		},
+		e: []uint32{
+			uint32(NLookup),
+		},
+	},
+	{
 		n: "alookup",
 		i: func(b *Builder) {
 			b.ALookup("abc")
 		},
 		e: []uint32{
 			uint32(ALookup),
+			1, //str index
+		},
+	},
+	{
+		n: "anlookup",
+		i: func(b *Builder) {
+			b.ANLookup("abc")
+		},
+		e: []uint32{
+			uint32(ANLookup),
 			1, //str index
 		},
 	},

--- a/pkg/il/compiler/compiler.go
+++ b/pkg/il/compiler/compiler.go
@@ -301,10 +301,10 @@ func (g *generator) generateIndex(f *expr.Function, depth int, mode nilMode, val
 
 		if f.Args[1].Const != nil {
 			str := f.Args[1].Const.Value.(string)
-			g.builder.ALookup(str)
+			g.builder.ANLookup(str)
 		} else {
 			g.generate(f.Args[1], depth+1, nmNone, "")
-			g.builder.Lookup()
+			g.builder.NLookup()
 		}
 
 	case nmJmpOnValue:

--- a/pkg/il/compiler/compiler_test.go
+++ b/pkg/il/compiler/compiler_test.go
@@ -379,7 +379,7 @@ end`,
 		code: `
 fn eval() string
   resolve_f "ar"
-  alookup "b"
+  anlookup "b"
   ret
 end
 `,
@@ -402,7 +402,7 @@ fn eval() bool
   ret
 L0:
   resolve_f "ar"
-  alookup "b"
+  anlookup "b"
   aeq_s "c"
   ret
 end`,
@@ -630,7 +630,7 @@ fn eval() string
   jnz L0
   resolve_f "br"
 L0:
-  alookup "foo"
+  anlookup "foo"
   ret
 end`,
 	},
@@ -748,7 +748,7 @@ end`,
 		code: `
 fn eval() string
   resolve_f "sm"
-  alookup "foo"
+  anlookup "foo"
   ret
 end`,
 	},
@@ -763,7 +763,7 @@ end`,
 fn eval() string
   resolve_f "sm"
   resolve_s "as"
-  lookup
+  nlookup
   ret
 end`,
 	},

--- a/pkg/il/interpreter/interpreterRun.go
+++ b/pkg/il/interpreter/interpreterRun.go
@@ -936,6 +936,26 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			opstack[sp] = t3
 			sp++
 
+		case il.NLookup:
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			t1 = opstack[sp-1]
+			t2 = opstack[sp-2]
+			sp = sp - 2
+			tStr = strings.GetString(t1)
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tVal = heap[t2]
+			tStr, tFound = tVal.(map[string]string)[tStr]
+			if !tFound {
+				tStr = ""
+			}
+			t3 = strings.GetID(tStr)
+			opstack[sp] = t3
+			sp++
+
 		case il.ALookup:
 			if sp < 1 {
 				goto STACK_UNDERFLOW
@@ -953,6 +973,27 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			if !tFound {
 				tErr = fmt.Errorf("member lookup failed: '%v'", strings.GetString(t1))
 				goto RETURN_ERR
+			}
+			t3 = strings.GetID(tStr)
+			opstack[sp] = t3
+			sp++
+
+		case il.ANLookup:
+			if sp < 1 {
+				goto STACK_UNDERFLOW
+			}
+			t1 = body[ip]
+			ip++
+			tStr = strings.GetString(t1)
+			sp--
+			t2 = opstack[sp]
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tVal = heap[t2]
+			tStr, tFound = tVal.(map[string]string)[tStr]
+			if !tFound {
+				tStr = ""
 			}
 			t3 = strings.GetID(tStr)
 			opstack[sp] = t3

--- a/pkg/il/interpreter/interpreterRun.got
+++ b/pkg/il/interpreter/interpreterRun.got
@@ -720,6 +720,18 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			t3 = strings.GetID(tStr)
 			STACK_PUSH(t3)
 
+		case il.NLookup:
+			STACK_UNDERFLOW_GUARD(2)
+			STACK_POP2(t1, t2)
+			tStr = strings.GetString(t1)
+			GET_HEAP_VALUE(t2, tVal)
+			tStr, tFound = tVal.(map[string]string)[tStr]
+			if !tFound {
+				tStr = ""
+			}
+			t3 = strings.GetID(tStr)
+			STACK_PUSH(t3)
+
 		case il.ALookup:
 			STACK_UNDERFLOW_GUARD(1)
 			LOAD_OP_CODE(t1)
@@ -729,6 +741,19 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tStr, tFound = tVal.(map[string]string)[tStr]
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
+			}
+			t3 = strings.GetID(tStr)
+			STACK_PUSH(t3)
+
+		case il.ANLookup:
+			STACK_UNDERFLOW_GUARD(1)
+			LOAD_OP_CODE(t1)
+			tStr = strings.GetString(t1)
+			STACK_POP(t2)
+			GET_HEAP_VALUE(t2, tVal)
+			tStr, tFound = tVal.(map[string]string)[tStr]
+			if !tFound {
+				tStr = ""
 			}
 			t3 = strings.GetID(tStr)
 			STACK_PUSH(t3)

--- a/pkg/il/interpreter/interpreter_test.go
+++ b/pkg/il/interpreter/interpreter_test.go
@@ -1141,6 +1141,32 @@ func TestInterpreter_Eval(t *testing.T) {
 			},
 			err: "member lookup failed: 'q'",
 		},
+		"nlookup/success": {
+			code: `
+		fn main () string
+			resolve_f "a"
+			apush_s "b"
+			nlookup
+			ret
+		end`,
+			input: map[string]interface{}{
+				"a": map[string]string{"b": "c"},
+			},
+			expected: "c",
+		},
+		"nlookup/not found": {
+			code: `
+		fn main () string
+			resolve_f "a"
+			apush_s "q"
+			nlookup
+			ret
+		end`,
+			input: map[string]interface{}{
+				"a": map[string]string{"b": "c"},
+			},
+			expected: nil,
+		},
 		"alookup/success": {
 			code: `
 		fn main () string
@@ -1164,6 +1190,30 @@ func TestInterpreter_Eval(t *testing.T) {
 				"a": map[string]string{"b": "c"},
 			},
 			err: "member lookup failed: 'q'",
+		},
+		"anlookup/success": {
+			code: `
+		fn main () string
+			resolve_f "a"
+			anlookup "b"
+			ret
+		end`,
+			input: map[string]interface{}{
+				"a": map[string]string{"b": "c"},
+			},
+			expected: "c",
+		},
+		"alookup/not found": {
+			code: `
+		fn main () string
+			resolve_f "a"
+			anlookup "q"
+			ret
+		end`,
+			input: map[string]interface{}{
+				"a": map[string]string{"b": "c"},
+			},
+			expected: nil,
 		},
 		"tlookup/success": {
 			code: `
@@ -1951,11 +2001,28 @@ fn main () void
 end`,
 			err: "invalid heap access",
 		},
+		"nlookup/invalid heap access": {
+			code: `
+fn main () void
+	apush_b true // Prime the operand stack with "1"
+	apush_s "foo"
+	nlookup
+end`,
+			err: "invalid heap access",
+		},
 		"alookup/invalid heap access": {
 			code: `
 fn main () void
 	apush_b true // Prime the operand stack with "1"
 	alookup "foo"
+end`,
+			err: "invalid heap access",
+		},
+		"anlookup/invalid heap access": {
+			code: `
+fn main () void
+	apush_b true // Prime the operand stack with "1"
+	anlookup "foo"
 end`,
 			err: "invalid heap access",
 		},
@@ -2121,11 +2188,17 @@ L0:
 		"lookup": {
 			code: `lookup`,
 		},
+		"nlookup": {
+			code: `nlookup`,
+		},
 		"tlookup": {
 			code: `tlookup`,
 		},
 		"alookup": {
 			code: `alookup "a"`,
+		},
+		"anlookup": {
+			code: `anlookup "a"`,
 		},
 	}
 

--- a/pkg/il/opcode.go
+++ b/pkg/il/opcode.go
@@ -296,6 +296,16 @@ const (
 	// parameter as the name. If a value is found, then the value is pushed into the stack
 	// Otherwise raises an error.
 	ALookup Opcode = 212
+
+	// NLookup pops a string, then a stringmap from the stack and perform a lookup on the stringmap
+	// using the string as the name. If a value is found, then the value is pushed into the
+	// stack.  Otherwise empty string is pushed onto the stack.
+	NLookup Opcode = 213
+
+	// ANLookup pops a stringmap from the stack and perform a lookup on the stringmap using the string
+	// parameter as the name. If a value is found, then the value is pushed into the stack
+	// Otherwise empty string is pushed onto the stack.
+	ANLookup Opcode = 214
 )
 
 const (
@@ -727,6 +737,11 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 	// stack.  Otherwise raises an error.
 	Lookup: {name: "Lookup", keyword: "lookup"},
 
+	// NLookup pops a string, then a stringmap from the stack and perform a lookup on the stringmap
+	// using the string as the name. If a value is found, then the value is pushed into the
+	// stack.  Otherwise empty string is pushed ono the stack.
+	NLookup: {name: "NLookup", keyword: "nlookup"},
+
 	// TLookup pops a string, then a stringmap from the stack and perform a lookup on the stringmap
 	// using the string as the name. If a value is found, then the value is pushed into the
 	// stack, then 1.  Otherwise 0 is pushed to into the stack.
@@ -736,6 +751,14 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 	// parameter as the name. If a value is found, then the value is pushed into the stack
 	// Otherwise raises an error.
 	ALookup: {name: "ALookup", keyword: "alookup", args: []OpcodeArg{
+		// The name of the attribute.
+		OpcodeArgString,
+	}},
+
+	// ANLookup pops a stringmap from the stack and perform a lookup on the stringmap using the string
+	// parameter as the name. If a value is found, then the value is pushed into the stack
+	// Otherwise empty string is pushed onto the stack.
+	ANLookup: {name: "ANLookup", keyword: "anlookup", args: []OpcodeArg{
 		// The name of the attribute.
 		OpcodeArgString,
 	}},


### PR DESCRIPTION
- Introduce new opcodes, NLookup, ANLookup that returns default value
when the lookup fails.
- Update the compiler to use these new opcodes when generating code.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1221)
<!-- Reviewable:end -->
