### PR TITLE
Increase the verbosity level of memquota to reduce log spam

### DIFF
--- a/adapter/memquota2/dedup.go
+++ b/adapter/memquota2/dedup.go
@@ -105,7 +105,7 @@ func (du *dedupUtil) reapDedup() {
 	du.oldDedup = du.recentDedup
 	du.recentDedup = t
 
-	if du.logger.VerbosityLevel(6) {
+	if len(t) > 0 && du.logger.VerbosityLevel(6) {
 		du.logger.Infof("Running reaper to reclaim %d old deduplication entries", len(t))
 	}
 

--- a/adapter/memquota2/dedup.go
+++ b/adapter/memquota2/dedup.go
@@ -106,7 +106,7 @@ func (du *dedupUtil) reapDedup() {
 	du.recentDedup = t
 
 	if du.logger.VerbosityLevel(6) {
-		du.logger.Infof("Running repear to reclaim %d old deduplication entries", len(t))
+		du.logger.Infof("Running reaper to reclaim %d old deduplication entries", len(t))
 	}
 
 	// TODO: why isn't there a O(1) way to clear a map to the empty state?!

--- a/adapter/memquota2/dedup.go
+++ b/adapter/memquota2/dedup.go
@@ -105,7 +105,7 @@ func (du *dedupUtil) reapDedup() {
 	du.oldDedup = du.recentDedup
 	du.recentDedup = t
 
-	if du.logger.VerbosityLevel(4) {
+	if du.logger.VerbosityLevel(6) {
 		du.logger.Infof("Running repear to reclaim %d old deduplication entries", len(t))
 	}
 


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1224)
<!-- Reviewable:end -->
