### PR TITLE
Switch Mixer to new Builder2 (with SetXXXX mtd + Validate mtd) interface

### DIFF
--- a/adapter/denier/denier.go
+++ b/adapter/denier/denier.go
@@ -75,11 +75,7 @@ func GetInfo() adapter.BuilderInfo {
 			Status: rpc.Status{Code: int32(rpc.FAILED_PRECONDITION)},
 		},
 
-		NewBuilder: func() adapter.Builder2 { return &builder{} },
-
-		// TO BE DELETED
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &obuilder{&builder{}} },
-		ValidateConfig:       func(cfg adapter.Config) *adapter.ConfigErrors { return nil },
+		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -95,31 +91,4 @@ func (*builder) Validate() (ce *adapter.ConfigErrors)               { return }
 
 func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handler, error) {
 	return &handler{status: b.adapterConfig.Status}, nil
-}
-
-// EVERYTHING BELOW IS TO BE DELETED
-
-type obuilder struct {
-	b *builder
-}
-
-// Build is to be deleted
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	o.b.SetAdapterConfig(cfg)
-	return o.b.Build(context.Background(), env)
-}
-
-// SetCheckNothingTypes is to be deleted
-func (*obuilder) SetCheckNothingTypes(map[string]*checknothing.Type) error {
-	return nil
-}
-
-// SetListEntryTypes is to be deleted
-func (*obuilder) SetListEntryTypes(map[string]*listentry.Type) error {
-	return nil
-}
-
-// SetQuotaTypes is to be deleted
-func (*obuilder) SetQuotaTypes(map[string]*quota.Type) error {
-	return nil
 }

--- a/adapter/list/list.go
+++ b/adapter/list/list.go
@@ -249,11 +249,7 @@ func GetInfo() adapter.BuilderInfo {
 			Blacklist:       false,
 		},
 
-		NewBuilder: func() adapter.Builder2 { return &builder{} },
-
-		// TO BE DELETED
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &obuilder{&builder{}} },
-		ValidateConfig:       func(cfg adapter.Config) *adapter.ConfigErrors { return nil },
+		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -333,21 +329,4 @@ func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handl
 	}
 
 	return h, nil
-}
-
-// EVERYTHING BELOW IS TO BE DELETED
-
-type obuilder struct {
-	b *builder
-}
-
-// Build is to be deleted
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	o.b.SetAdapterConfig(cfg)
-	return o.b.Build(context.Background(), env)
-}
-
-// SetListEntryTypes is to be deleted
-func (*obuilder) SetListEntryTypes(map[string]*listentry.Type) error {
-	return nil
 }

--- a/adapter/memquota2/memquota.go
+++ b/adapter/memquota2/memquota.go
@@ -174,11 +174,7 @@ func GetInfo() adapter.BuilderInfo {
 			MinDeduplicationDuration: 1 * time.Second,
 		},
 
-		NewBuilder: func() adapter.Builder2 { return &builder{} },
-
-		// TO BE DELETED
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &obuilder{&builder{}} },
-		ValidateConfig:       func(cfg adapter.Config) *adapter.ConfigErrors { return nil },
+		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -240,22 +236,4 @@ func (b *builder) buildWithDedup(_ context.Context, env adapter.Env, ticker *tim
 	})
 
 	return h, nil
-}
-
-// EVERYTHING BELOW IS TO BE DELETED
-
-type obuilder struct {
-	b *builder
-}
-
-// Build is to be deleted
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	o.b.SetAdapterConfig(cfg)
-	return o.b.Build(context.Background(), env)
-}
-
-// SetQuotaTypes is to be deleted
-func (o *obuilder) SetQuotaTypes(types map[string]*quota.Type) error {
-	o.b.SetQuotaTypes(types)
-	return nil
 }

--- a/adapter/noop2/noop.go
+++ b/adapter/noop2/noop.go
@@ -89,11 +89,7 @@ func GetInfo() adapter.BuilderInfo {
 		},
 		DefaultConfig: &types.Empty{},
 
-		NewBuilder: func() adapter.Builder2 { return &builder{} },
-
-		// TO BE DELETED
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &obuilder{&builder{}} },
-		ValidateConfig:       func(cfg adapter.Config) *adapter.ConfigErrors { return nil },
+		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -110,44 +106,4 @@ func (*builder) Validate() (ce *adapter.ConfigErrors)                 { return }
 
 func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handler, error) {
 	return &handler{}, nil
-}
-
-// EVERYTHING BELOW IS TO BE DELETED
-
-type obuilder struct {
-	b *builder
-}
-
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	return o.b.Build(context.Background(), env)
-}
-
-// SetCheckNothingTypes is to be deleted
-func (*obuilder) SetCheckNothingTypes(map[string]*checknothing.Type) error {
-	return nil
-}
-
-// ConfigureReportNothingHandler is to be deleted
-func (*obuilder) SetReportNothingTypes(map[string]*reportnothing.Type) error {
-	return nil
-}
-
-// SetListEntryTypes is to be deleted
-func (*obuilder) SetListEntryTypes(map[string]*listentry.Type) error {
-	return nil
-}
-
-// SetLogEntryTypes is to be deleted
-func (*obuilder) SetLogEntryTypes(map[string]*logentry.Type) error {
-	return nil
-}
-
-// SetMetricTypes is to be deleted
-func (*obuilder) SetMetricTypes(map[string]*metric.Type) error {
-	return nil
-}
-
-// SetQuotaTypes is to be deleted
-func (*obuilder) SetQuotaTypes(map[string]*quota.Type) error {
-	return nil
 }

--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -81,8 +81,7 @@ func GetInfo() adapter.BuilderInfo {
 		SupportedTemplates: []string{
 			metric.TemplateName,
 		},
-		NewBuilder: func() adapter.HandlerBuilder { return singletonBuilder },
-		// to be deleted
+		NewBuilder:    func() adapter.HandlerBuilder { return singletonBuilder },
 		DefaultConfig: &config.Params{},
 	}
 }

--- a/adapter/prometheus2/prometheus.go
+++ b/adapter/prometheus2/prometheus.go
@@ -61,7 +61,7 @@ type (
 var (
 	charReplacer = strings.NewReplacer("/", "_", ".", "_", " ", "_", "-", "")
 
-	_ metric.HandlerBuilder = &obuilder{}
+	_ metric.HandlerBuilder = &builder{}
 	_ metric.Handler        = &handler{}
 )
 
@@ -81,13 +81,9 @@ func GetInfo() adapter.BuilderInfo {
 		SupportedTemplates: []string{
 			metric.TemplateName,
 		},
-		NewBuilder: func() adapter.Builder2 { return singletonBuilder },
+		NewBuilder: func() adapter.HandlerBuilder { return singletonBuilder },
 		// to be deleted
-		DefaultConfig:  &config.Params{},
-		ValidateConfig: func(msg adapter.Config) *adapter.ConfigErrors { return nil },
-		CreateHandlerBuilder: func() adapter.HandlerBuilder {
-			return &obuilder{b: singletonBuilder}
-		},
+		DefaultConfig: &config.Params{},
 	}
 }
 
@@ -344,19 +340,4 @@ func computeSha(m *config.Params_MetricInfo, log adapter.Logger) [sha1.Size]byte
 		log.Warningf("Unable to encode %v", err)
 	}
 	return sha1.Sum(ba)
-}
-
-type obuilder struct {
-	b *builder
-}
-
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	o.b.SetAdapterConfig(cfg)
-	return o.b.Build(context.Background(), env)
-}
-
-// SetMetricTypes is to be deleted
-func (o *obuilder) SetMetricTypes(types map[string]*metric.Type) error {
-	o.b.SetMetricTypes(types)
-	return nil
 }

--- a/adapter/stackdriver/log/log.go
+++ b/adapter/stackdriver/log/log.go
@@ -42,6 +42,7 @@ type (
 	builder struct {
 		makeClient makeClientFn
 		types      map[string]*logentry.Type
+		cfg        *config.Params
 	}
 
 	info struct {
@@ -71,14 +72,19 @@ func NewBuilder() logentry.HandlerBuilder {
 	return &builder{makeClient: logging.NewClient}
 }
 
-func (b *builder) SetLogEntryTypes(types map[string]*logentry.Type) error {
+func (b *builder) SetLogEntryTypes(types map[string]*logentry.Type) {
 	b.types = types
+}
+func (b *builder) SetAdapterConfig(cfg adapter.Config) {
+	b.cfg = cfg.(*config.Params)
+}
+func (b *builder) Validate() *adapter.ConfigErrors {
 	return nil
 }
 
-func (b *builder) Build(c adapter.Config, env adapter.Env) (adapter.Handler, error) {
+func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 	logger := env.Logger()
-	cfg := c.(*config.Params)
+	cfg := b.cfg
 	client, err := b.makeClient(context.Background(), cfg.ProjectId, helper.ToOpts(cfg)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stackdriver logging client: %v", err)

--- a/adapter/stackdriver/log/log_test.go
+++ b/adapter/stackdriver/log/log_test.go
@@ -38,8 +38,9 @@ func TestBuild(t *testing.T) {
 	b := &builder{makeClient: func(context.Context, string, ...option.ClientOption) (*logging.Client, error) {
 		return nil, errors.New("expected")
 	}}
-	_ = b.SetLogEntryTypes(map[string]*logentry.Type{})
-	if _, err := b.Build(&config.Params{}, test.NewEnv(t)); err == nil {
+	b.SetLogEntryTypes(map[string]*logentry.Type{})
+	b.SetAdapterConfig(&config.Params{})
+	if _, err := b.Build(context.Background(), test.NewEnv(t)); err == nil {
 		t.Error("Expected error, got none.")
 	}
 
@@ -71,8 +72,9 @@ func TestBuild(t *testing.T) {
 			b := &builder{makeClient: func(context.Context, string, ...option.ClientOption) (*logging.Client, error) {
 				return &logging.Client{}, nil
 			}}
-			_ = b.SetLogEntryTypes(tt.types)
-			if _, err := b.Build(tt.cfg, env); err != nil {
+			b.SetLogEntryTypes(tt.types)
+			b.SetAdapterConfig(tt.cfg)
+			if _, err := b.Build(context.Background(), env); err != nil {
 				t.Fatalf("Unexpected error building the handler: %v", err)
 			}
 

--- a/adapter/stackdriver/metric/metric.go
+++ b/adapter/stackdriver/metric/metric.go
@@ -55,6 +55,7 @@ type (
 	builder struct {
 		createClient createClientFunc
 		metrics      map[string]*metric.Type
+		cfg          *config.Params
 	}
 
 	info struct {
@@ -112,14 +113,20 @@ func createClient(cfg *config.Params) (*monitoring.MetricClient, error) {
 	return monitoring.NewMetricClient(context.Background(), helper.ToOpts(cfg)...)
 }
 
-func (b *builder) SetMetricTypes(metrics map[string]*metric.Type) error {
+func (b *builder) SetMetricTypes(metrics map[string]*metric.Type) {
 	b.metrics = metrics
+}
+
+func (b *builder) SetAdapterConfig(cfg adapter.Config) {
+	b.cfg = cfg.(*config.Params)
+}
+func (b *builder) Validate() *adapter.ConfigErrors {
 	return nil
 }
 
 // NewMetricsAspect provides an implementation for adapter.MetricsBuilder.
-func (b *builder) Build(c adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	cfg := c.(*config.Params)
+func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
+	cfg := b.cfg
 	types := make(map[string]info, len(b.metrics))
 	for name, t := range b.metrics {
 		i, found := cfg.MetricInfo[name]

--- a/adapter/stackdriver/metric/metric_test.go
+++ b/adapter/stackdriver/metric/metric_test.go
@@ -77,8 +77,9 @@ func TestFactory_NewMetricsAspect(t *testing.T) {
 			}
 			env := test.NewEnv(t)
 			b := &builder{createClient: clientFunc(nil)}
-			_ = b.SetMetricTypes(metrics)
-			_, err := b.Build(tt.cfg, env)
+			b.SetMetricTypes(metrics)
+			b.SetAdapterConfig(tt.cfg)
+			_, err := b.Build(context.Background(), env)
 			if err != nil || tt.err != "" {
 				if tt.err == "" {
 					t.Fatalf("factory{}.NewMetricsAspect(test.NewEnv(t), nil, nil) = '%s', wanted no err", err.Error())
@@ -111,7 +112,8 @@ func TestFactory_NewMetricsAspect(t *testing.T) {
 func TestFactory_NewMetricsAspect_Errs(t *testing.T) {
 	err := fmt.Errorf("expected")
 	b := &builder{createClient: clientFunc(err)}
-	res, e := b.Build(&config.Params{}, test.NewEnv(t))
+	b.SetAdapterConfig(&config.Params{})
+	res, e := b.Build(context.Background(), test.NewEnv(t))
 	if e != nil && !strings.Contains(e.Error(), err.Error()) {
 		t.Fatalf("Expected error from factory.createClient to be propagated, got %v, %v", res, e)
 	} else if e == nil {

--- a/adapter/stackdriver/stackdriver_test.go
+++ b/adapter/stackdriver/stackdriver_test.go
@@ -98,7 +98,7 @@ func TestDispatchConfigureAndBuild(t *testing.T) {
 		t.Error("Expected m.calledAdptCfg to be called, wasn't.")
 	}
 
-	b.Validate()
+	_ = b.Validate()
 	if !l.calledValidate {
 		t.Error("Expected l.calledValidate to be called, wasn't.")
 	}
@@ -109,7 +109,7 @@ func TestDispatchConfigureAndBuild(t *testing.T) {
 	if l.calledBuild || m.calledBuild {
 		t.Fatalf("Build called on builders before calling b.Build")
 	}
-	if _, err := b.Build(nil, test.NewEnv(t)); err != nil {
+	if _, err := b.Build(context.Background(), test.NewEnv(t)); err != nil {
 		t.Errorf("Exepected err calling builder.Build: %v", err)
 	}
 	if !m.calledBuild {
@@ -127,7 +127,7 @@ func TestDispatchHandleAndClose(t *testing.T) {
 	mb := &fakeBuilder{instance: ma}
 	b := &builder{mb, lb}
 
-	superHandler, err := b.Build(nil, test.NewEnv(t))
+	superHandler, err := b.Build(context.Background(), test.NewEnv(t))
 	if err != nil {
 		t.Fatalf("Unexpected error calling builder.Build: %v", err)
 	}

--- a/adapter/stackdriver/stackdriver_test.go
+++ b/adapter/stackdriver/stackdriver_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"istio.io/mixer/adapter/stackdriver/config"
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/adapter/test"
 	"istio.io/mixer/template/logentry"
@@ -28,6 +29,8 @@ type (
 	fakeBuilder struct {
 		calledConfigure bool
 		calledBuild     bool
+		calledValidate  bool
+		calledAdptCfg   bool
 		instance        *fakeAspect
 	}
 
@@ -37,19 +40,25 @@ type (
 	}
 )
 
-func (f *fakeBuilder) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (f *fakeBuilder) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	f.calledBuild = true
 	return f.instance, nil
 }
 
-func (f *fakeBuilder) SetMetricTypes(metrics map[string]*metric.Type) error {
+func (f *fakeBuilder) SetMetricTypes(metrics map[string]*metric.Type) {
 	f.calledConfigure = true
+}
+
+func (f *fakeBuilder) SetLogEntryTypes(entries map[string]*logentry.Type) {
+	f.calledConfigure = true
+}
+func (f *fakeBuilder) Validate() *adapter.ConfigErrors {
+	f.calledValidate = true
 	return nil
 }
 
-func (f *fakeBuilder) SetLogEntryTypes(entries map[string]*logentry.Type) error {
-	f.calledConfigure = true
-	return nil
+func (f *fakeBuilder) SetAdapterConfig(cfg adapter.Config) {
+	f.calledAdptCfg = true
 }
 
 func (f *fakeAspect) Close() error {
@@ -71,17 +80,30 @@ func TestDispatchConfigureAndBuild(t *testing.T) {
 	m := &fakeBuilder{}
 	l := &fakeBuilder{}
 	b := &builder{m, l}
-	if err := b.SetMetricTypes(make(map[string]*metric.Type)); err != nil {
-		t.Errorf("Unexpected error configuring metric handler: %v", err)
-	}
+	b.SetMetricTypes(make(map[string]*metric.Type))
+
 	if !m.calledConfigure {
 		t.Error("Expected m.SetMetricTypes to be called, wasn't.")
 	}
-	if err := b.SetLogEntryTypes(make(map[string]*logentry.Type)); err != nil {
-		t.Errorf("Unexpected error configuring log handler: %v", err)
-	}
+	b.SetLogEntryTypes(make(map[string]*logentry.Type))
 	if !l.calledConfigure {
 		t.Error("Expected l.SetLogEntryTypes to be called, wasn't.")
+	}
+
+	b.SetAdapterConfig(&config.Params{})
+	if !l.calledAdptCfg {
+		t.Error("Expected l.calledAdptCfg to be called, wasn't.")
+	}
+	if !m.calledAdptCfg {
+		t.Error("Expected m.calledAdptCfg to be called, wasn't.")
+	}
+
+	b.Validate()
+	if !l.calledValidate {
+		t.Error("Expected l.calledValidate to be called, wasn't.")
+	}
+	if !m.calledValidate {
+		t.Error("Expected m.calledValidate to be called, wasn't.")
 	}
 
 	if l.calledBuild || m.calledBuild {

--- a/adapter/statsd2/statsd.go
+++ b/adapter/statsd2/statsd.go
@@ -125,11 +125,7 @@ func GetInfo() adapter.BuilderInfo {
 			SamplingRate:  1.0,
 		},
 
-		NewBuilder: func() adapter.Builder2 { return &builder{} },
-
-		// TO BE DELETED
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &obuilder{&builder{}} },
-		ValidateConfig:       func(cfg adapter.Config) *adapter.ConfigErrors { return nil },
+		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -193,21 +189,4 @@ func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handl
 		templates[metricName] = info{mtype: s.Type, tmpl: t}
 	}
 	return &handler{ac.SamplingRate, client, templates}, nil
-}
-
-// EVERYTHING BELOW IS TO BE DELETED
-
-type obuilder struct {
-	b *builder
-}
-
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	o.b.SetAdapterConfig(cfg)
-	return o.b.Build(context.Background(), env)
-}
-
-// SetMetricTypes is to be deleted
-func (o *obuilder) SetMetricTypes(types map[string]*metric.Type) error {
-	o.b.SetMetricTypes(types)
-	return nil
 }

--- a/adapter/stdio/stdio.go
+++ b/adapter/stdio/stdio.go
@@ -125,11 +125,7 @@ func GetInfo() adapter.BuilderInfo {
 			OutputAsJson: false,
 		},
 
-		NewBuilder: func() adapter.Builder2 { return &builder{} },
-
-		// TO BE DELETED
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &obuilder{&builder{}} },
-		ValidateConfig:       func(cfg adapter.Config) *adapter.ConfigErrors { return nil },
+		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -235,28 +231,4 @@ func newZapLogger(outputPath string, encoding string) (*zap.Logger, error) {
 	zapConfig.Encoding = encoding
 
 	return zapConfig.Build()
-}
-
-// EVERYTHING BELOW IS TO BE DELETED
-
-type obuilder struct {
-	b *builder
-}
-
-// Build is to be deleted
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	o.b.SetAdapterConfig(cfg)
-	return o.b.Build(context.Background(), env)
-}
-
-// ConfigureLogEntryHandler is to be deleted
-func (o *obuilder) SetLogEntryTypes(types map[string]*logentry.Type) error {
-	o.b.SetLogEntryTypes(types)
-	return nil
-}
-
-// ConfigureMetricHandler is to be deleted
-func (o *obuilder) SetMetricTypes(types map[string]*metric.Type) error {
-	o.b.SetMetricTypes(types)
-	return nil
 }

--- a/adapter/svcctrl/svcctrl.go
+++ b/adapter/svcctrl/svcctrl.go
@@ -100,11 +100,7 @@ func GetInfo() adapter.BuilderInfo {
 			ServiceName: "library-example.sandbox.googleapis.com",
 		},
 
-		NewBuilder: func() adapter.Builder2 { return &builder{} },
-
-		// TO BE DELETED
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return &obuilder{&builder{}} },
-		ValidateConfig:       func(cfg adapter.Config) *adapter.ConfigErrors { return nil },
+		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -127,20 +123,4 @@ func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handl
 		env:                  env,
 		configParams:         b.adapterConfig,
 	}, nil
-}
-
-// EVERYTHING BELOW IS TO BE DELETED
-
-type obuilder struct {
-	b *builder
-}
-
-func (o *obuilder) Build(cfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
-	o.b.SetAdapterConfig(cfg)
-	return o.b.Build(context.Background(), env)
-}
-
-// ConfigureMetricHandler is to be deleted
-func (*obuilder) SetMetricTypes(map[string]*metric.Type) error {
-	return nil
 }

--- a/pkg/adapter/handler.go
+++ b/pkg/adapter/handler.go
@@ -28,27 +28,10 @@ type (
 	// HandlerBuilder represents a factory of handlers. Adapters register builders with Mixer
 	// in order to allow Mixer to instantiate handlers on demand.
 	//
-	// For a given builder, Mixer calls the various template-specific configuration methods
-	// on the handler, and once done then Mixer calls the Build method, passing a block
-	// of adapter-specific configuration data as argument. The Build method returns a handler,
-	// which Mixer invokes during request processing.
-	HandlerBuilder interface {
-		// Build must return a handler that implements all the template-specific runtime request serving
-		// interfaces that the Builder was configured for.
-		// This means the Handler returned by the Build method must implement all the runtime interfaces for all the
-		// template the Adapter was registered for in the adapter.RegisterFn2 method.
-		// If the returned Handler fails to implement the required interface that builder was registered for, mixer will
-		// report an error and stop serving runtime traffic to the particular Handler.
-		Build(config Config, env Env) (Handler, error)
-	}
-
-	// Builder2 represents a factory of handlers. Adapters register builders with Mixer
-	// in order to allow Mixer to instantiate handlers on demand.
-	//
 	// For a given builder, Mixer calls the various template-specific SetXXX methods,
 	// the SetAdapterConfig method, and once done then Mixer calls the Validate followed by the Build method. The Build method
 	// returns a handler, which Mixer invokes during request processing.
-	Builder2 interface {
+	HandlerBuilder interface {
 		// SetAdapterConfig gives the builder the adapter-level configuration state.
 		SetAdapterConfig(Config)
 

--- a/pkg/adapter/info.go
+++ b/pkg/adapter/info.go
@@ -33,9 +33,6 @@ type BuilderInfo struct {
 	Impl string
 	// Description returns a user-friendly description of the adapter.
 	Description string
-	// CreateHandlerBuilder is a function that creates a HandlerBuilder which implements Builders associated
-	// with the SupportedTemplates.
-	CreateHandlerBuilder CreateHandlerBuilderFn // DEPRECATED
 	// NewBuilder is a function that creates a Builder which implements Builders associated
 	// with the SupportedTemplates.
 	NewBuilder NewBuilderFn
@@ -45,20 +42,10 @@ type BuilderInfo struct {
 	// adapter. This will be used by the configuration system to establish
 	// the shape of the block of configuration state passed to the HandlerBuilder.Build method.
 	DefaultConfig proto.Message
-	// ValidateConfig is a function that determines whether the given handler configuration meets all
-	// correctness requirements.
-	ValidateConfig ValidateConfigFn
 }
 
-// CreateHandlerBuilderFn is a function that creates a HandlerBuilder.
-type CreateHandlerBuilderFn func() HandlerBuilder
-
 // NewBuilderFn is a function that creates a Builder.
-type NewBuilderFn func() Builder2
-
-// ValidateConfigFn is a function that determines whether the given handler configuration meets all
-// correctness requirements.
-type ValidateConfigFn func(Config) *ConfigErrors
+type NewBuilderFn func() HandlerBuilder
 
 // InfoFn returns an AdapterInfo object that Mixer will use to create HandlerBuilder
 type InfoFn func() BuilderInfo

--- a/pkg/adapterManager/e2e_configuration_test.go
+++ b/pkg/adapterManager/e2e_configuration_test.go
@@ -40,21 +40,9 @@ import (
 var globalActualHandlerCallInfoToValidate map[string]interface{}
 
 type (
-	fakeHndlr        struct{}
-	fakeHndlrBldrOld struct{}
-	fakeHndlrBldr    struct{}
+	fakeHndlr     struct{}
+	fakeHndlrBldr struct{}
 )
-
-func (fakeHndlrBldrOld) Build(cnfg adapter.Config, _ adapter.Env) (adapter.Handler, error) {
-	globalActualHandlerCallInfoToValidate["SetAdapterConfig"] = cnfg
-	fakeHndlrObj := fakeHndlr{}
-	return fakeHndlrObj, nil
-}
-
-func (fakeHndlrBldrOld) SetSampleTypes(typeParams map[string]*sample_report.Type) error {
-	globalActualHandlerCallInfoToValidate["SetSampleTypes"] = typeParams
-	return nil
-}
 
 func (fakeHndlrBldr) Build(_ context.Context, _ adapter.Env) (adapter.Handler, error) {
 	fakeHndlrObj := fakeHndlr{}
@@ -207,8 +195,8 @@ func testConfigFlow(t *testing.T, declarativeSrvcCnfgFilePath string, declaredGl
 		t.Errorf("got call count %d\nwant %d", len(globalActualHandlerCallInfoToValidate), 2)
 	}
 
-	if globalActualHandlerCallInfoToValidate["SetSampleTypes"] == nil || globalActualHandlerCallInfoToValidate["SetSampleTypes"] == nil {
-		t.Errorf("got call info as : %v. \nwant calls %s and %s to have been called", globalActualHandlerCallInfoToValidate, "SetSampleTypes", "SetSampleTypes")
+	if globalActualHandlerCallInfoToValidate["SetSampleTypes"] == nil || globalActualHandlerCallInfoToValidate["SetAdapterConfig"] == nil {
+		t.Errorf("got call info as : %v. \nwant calls %s and %s to have been called", globalActualHandlerCallInfoToValidate, "SetSampleTypes", "SetAdapterConfig")
 	}
 }
 

--- a/pkg/config/adapterInfoRegistry.go
+++ b/pkg/config/adapterInfoRegistry.go
@@ -33,7 +33,7 @@ type handlerBuilderValidator func(hndlrBuilder adapter.HandlerBuilder, t string)
 func newRegistry2(infos []adapter.InfoFn, hndlrBldrValidator handlerBuilderValidator) *adapterInfoRegistry {
 	r := &adapterInfoRegistry{make(map[string]*adapter.BuilderInfo)}
 	for idx, info := range infos {
-		glog.V(3).Infof("Registering [%d] %#v", idx, info)
+		glog.V(3).Infof("registering [%d] %#v", idx, info)
 		adptInfo := info()
 		if a, ok := r.adapterInfosByName[adptInfo.Name]; ok {
 			// panic only if 2 different adapter.BuilderInfo objects are trying to identify by the
@@ -44,19 +44,19 @@ func newRegistry2(infos []adapter.InfoFn, hndlrBldrValidator handlerBuilderValid
 		} else {
 			if adptInfo.NewBuilder == nil {
 				// panic if adapter has not provided the NewBuilder func.
-				msg := fmt.Errorf("Adapter info %v from adapter %s has nil NewBuilder", adptInfo, adptInfo.Name)
+				msg := fmt.Errorf("adapter info %v from adapter %s has nil NewBuilder", adptInfo, adptInfo.Name)
 				glog.Error(msg)
 				panic(msg)
 			}
 			if adptInfo.DefaultConfig == nil {
 				// panic if adapter has not provided the DefaultConfig func.
-				msg := fmt.Errorf("Adapter info %v from adapter %s has nil DefaultConfig", adptInfo, adptInfo.Name)
+				msg := fmt.Errorf("adapter info %v from adapter %s has nil DefaultConfig", adptInfo, adptInfo.Name)
 				glog.Error(msg)
 				panic(msg)
 			}
 			if ok, errMsg := doesBuilderSupportsTemplates(adptInfo, hndlrBldrValidator); !ok {
 				// panic if an Adapter's HandlerBuilder does not implement interfaces that it says it wants to support.
-				msg := fmt.Errorf("HandlerBuilder from adapter %s does not implement the required interfaces"+
+				msg := fmt.Errorf("handlerBuilder from adapter %s does not implement the required interfaces"+
 					" for the templates it supports: %s", adptInfo.Name, errMsg)
 				glog.Error(msg)
 				panic(msg)

--- a/pkg/config/adapterInfoRegistry.go
+++ b/pkg/config/adapterInfoRegistry.go
@@ -42,17 +42,15 @@ func newRegistry2(infos []adapter.InfoFn, hndlrBldrValidator handlerBuilderValid
 			glog.Error(msg)
 			panic(msg)
 		} else {
-			if adptInfo.ValidateConfig == nil {
-				// panic if adapter has not provided the ValidateConfig func.
-				msg := fmt.Errorf("Adapter info %v from adapter %s does not contain value for ValidateConfig"+
-					" function field.", adptInfo, adptInfo.Name)
+			if adptInfo.NewBuilder == nil {
+				// panic if adapter has not provided the NewBuilder func.
+				msg := fmt.Errorf("Adapter info %v from adapter %s has nil NewBuilder", adptInfo, adptInfo.Name)
 				glog.Error(msg)
 				panic(msg)
 			}
 			if adptInfo.DefaultConfig == nil {
 				// panic if adapter has not provided the DefaultConfig func.
-				msg := fmt.Errorf("Adapter info %v from adapter %s does not contain value for DefaultConfig "+
-					"field.", adptInfo, adptInfo.Name)
+				msg := fmt.Errorf("Adapter info %v from adapter %s has nil DefaultConfig", adptInfo, adptInfo.Name)
 				glog.Error(msg)
 				panic(msg)
 			}
@@ -86,7 +84,7 @@ func (r *adapterInfoRegistry) FindAdapterInfo(name string) (b *adapter.BuilderIn
 }
 
 func doesBuilderSupportsTemplates(info adapter.BuilderInfo, hndlrBldrValidator handlerBuilderValidator) (bool, string) {
-	handlerBuilder := info.CreateHandlerBuilder()
+	handlerBuilder := info.NewBuilder()
 	resultMsgs := make([]string, 0)
 	for _, t := range info.SupportedTemplates {
 		if ok, errMsg := hndlrBldrValidator(handlerBuilder, t); !ok {

--- a/pkg/config/adapterInfoRegistry_test.go
+++ b/pkg/config/adapterInfoRegistry_test.go
@@ -45,13 +45,6 @@ func (t *TestBuilderInfoInventory) getNewGetBuilderInfoFn() adapter.BuilderInfo 
 	return createBuilderInfo(t.name)
 }
 
-type fakeHandlerBuilderOld struct{}
-
-func (fakeHandlerBuilderOld) SetSampleTypes(map[string]*sample_report.Type) error { return nil }
-func (fakeHandlerBuilderOld) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
-	return fakeHandler{}, nil
-}
-
 type fakeHandlerBuilder struct{}
 
 func (fakeHandlerBuilder) SetSampleTypes(map[string]*sample_report.Type) {}
@@ -146,10 +139,6 @@ type badHandlerBuilder struct{}
 func (badHandlerBuilder) DefaultConfig() adapter.Config                       { return nil }
 func (badHandlerBuilder) ValidateConfig(adapter.Config) *adapter.ConfigErrors { return nil }
 
-// This misspelled function cause the Builder to not implement SampleProcessorBuilder
-func (fakeHandlerBuilderOld) MisspelledXXConfigureSample(map[string]*sample_report.Type) error {
-	return nil
-}
 func (badHandlerBuilder) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return fakeHandler{}, nil
 }

--- a/pkg/config/adapterInfoRegistry_test.go
+++ b/pkg/config/adapterInfoRegistry_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -32,12 +33,11 @@ type TestBuilderInfoInventory struct {
 
 func createBuilderInfo(name string) adapter.BuilderInfo {
 	return adapter.BuilderInfo{
-		Name:                 name,
-		Description:          "mock adapter for testing",
-		CreateHandlerBuilder: func() adapter.HandlerBuilder { return fakeHandlerBuilder{} },
-		SupportedTemplates:   []string{sample_report.TemplateName},
-		DefaultConfig:        &types.Empty{},
-		ValidateConfig:       func(c adapter.Config) *adapter.ConfigErrors { return nil },
+		Name:               name,
+		Description:        "mock adapter for testing",
+		SupportedTemplates: []string{sample_report.TemplateName},
+		DefaultConfig:      &types.Empty{},
+		NewBuilder:         func() adapter.HandlerBuilder { return fakeHandlerBuilder{} },
 	}
 }
 
@@ -45,12 +45,21 @@ func (t *TestBuilderInfoInventory) getNewGetBuilderInfoFn() adapter.BuilderInfo 
 	return createBuilderInfo(t.name)
 }
 
-type fakeHandlerBuilder struct{}
+type fakeHandlerBuilderOld struct{}
 
-func (fakeHandlerBuilder) SetSampleTypes(map[string]*sample_report.Type) error { return nil }
-func (fakeHandlerBuilder) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (fakeHandlerBuilderOld) SetSampleTypes(map[string]*sample_report.Type) error { return nil }
+func (fakeHandlerBuilderOld) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
 	return fakeHandler{}, nil
 }
+
+type fakeHandlerBuilder struct{}
+
+func (fakeHandlerBuilder) SetSampleTypes(map[string]*sample_report.Type) {}
+func (fakeHandlerBuilder) Build(context.Context, adapter.Env) (adapter.Handler, error) {
+	return fakeHandler{}, nil
+}
+func (fakeHandlerBuilder) SetAdapterConfig(config adapter.Config) {}
+func (fakeHandlerBuilder) Validate() *adapter.ConfigErrors        { return nil }
 
 type fakeHandler struct{}
 
@@ -115,23 +124,6 @@ func TestMissingDefaultValue(t *testing.T) {
 	t.Error("Should not reach this statement due to panic.")
 }
 
-func TestMissingValidateConfigFn(t *testing.T) {
-	builderCreatorInventory := TestBuilderInfoInventory{"foo"}
-	builderInfo := builderCreatorInventory.getNewGetBuilderInfoFn()
-	builderInfo.ValidateConfig = nil
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("Expected to recover from panic due to missing ValidateConfig in BuilderInfo, " +
-				"but recover was nil.")
-		}
-	}()
-
-	_ = newRegistry2([]adapter.InfoFn{func() adapter.BuilderInfo { return builderInfo }}, fakeValidateSupportedTmpl)
-
-	t.Error("Should not reach this statement due to panic.")
-}
-
 func TestHandlerMap(t *testing.T) {
 	testBuilderInfoInventory := TestBuilderInfoInventory{"foo"}
 	testBuilderInfoInventory2 := TestBuilderInfoInventory{"bar"}
@@ -155,32 +147,34 @@ func (badHandlerBuilder) DefaultConfig() adapter.Config                       { 
 func (badHandlerBuilder) ValidateConfig(adapter.Config) *adapter.ConfigErrors { return nil }
 
 // This misspelled function cause the Builder to not implement SampleProcessorBuilder
-func (fakeHandlerBuilder) MisspelledXXConfigureSample(map[string]*sample_report.Type) error {
+func (fakeHandlerBuilderOld) MisspelledXXConfigureSample(map[string]*sample_report.Type) error {
 	return nil
 }
-func (badHandlerBuilder) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (badHandlerBuilder) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return fakeHandler{}, nil
 }
+func (badHandlerBuilder) Validate() *adapter.ConfigErrors {
+	return nil
+}
+func (badHandlerBuilder) SetAdapterConfig(_ adapter.Config) {}
 
 func TestBuilderNotImplementRightTemplateInterface(t *testing.T) {
 	badHandlerBuilderBuilderInfo1 := func() adapter.BuilderInfo {
 		return adapter.BuilderInfo{
-			Name:                 "badAdapter1",
-			Description:          "mock adapter for testing",
-			DefaultConfig:        &types.Empty{},
-			ValidateConfig:       func(c adapter.Config) *adapter.ConfigErrors { return nil },
-			CreateHandlerBuilder: func() adapter.HandlerBuilder { return badHandlerBuilder{} },
-			SupportedTemplates:   []string{sample_report.TemplateName},
+			Name:               "badAdapter1",
+			Description:        "mock adapter for testing",
+			DefaultConfig:      &types.Empty{},
+			NewBuilder:         func() adapter.HandlerBuilder { return badHandlerBuilder{} },
+			SupportedTemplates: []string{sample_report.TemplateName},
 		}
 	}
 	badHandlerBuilderBuilderInfo2 := func() adapter.BuilderInfo {
 		return adapter.BuilderInfo{
-			Name:                 "badAdapter1",
-			Description:          "mock adapter for testing",
-			DefaultConfig:        &types.Empty{},
-			ValidateConfig:       func(c adapter.Config) *adapter.ConfigErrors { return nil },
-			CreateHandlerBuilder: func() adapter.HandlerBuilder { return badHandlerBuilder{} },
-			SupportedTemplates:   []string{sample_report.TemplateName},
+			Name:               "badAdapter1",
+			Description:        "mock adapter for testing",
+			DefaultConfig:      &types.Empty{},
+			NewBuilder:         func() adapter.HandlerBuilder { return badHandlerBuilder{} },
+			SupportedTemplates: []string{sample_report.TemplateName},
 		}
 	}
 

--- a/pkg/config/handler.go
+++ b/pkg/config/handler.go
@@ -101,7 +101,7 @@ func (h *handlerFactory) dispatchToHandler(hb *HandlerBuilderInfo, handler strin
 			typsToCnfgr[inst] = v
 		}
 
-		ti.SetType(typsToCnfgr, hb.handlerBuilder)
+		ti.SetType(typsToCnfgr, hb.b)
 	}
 	return nil
 }

--- a/pkg/config/handler.go
+++ b/pkg/config/handler.go
@@ -101,7 +101,7 @@ func (h *handlerFactory) dispatchToHandler(hb *HandlerBuilderInfo, handler strin
 			typsToCnfgr[inst] = v
 		}
 
-		ti.SetType(typsToCnfgr, hb.handlerBuilder2)
+		ti.SetType(typsToCnfgr, hb.handlerBuilder)
 	}
 	return nil
 }

--- a/pkg/config/handler.go
+++ b/pkg/config/handler.go
@@ -101,10 +101,7 @@ func (h *handlerFactory) dispatchToHandler(hb *HandlerBuilderInfo, handler strin
 			typsToCnfgr[inst] = v
 		}
 
-		if err := ti.SetType(typsToCnfgr, hb.handlerBuilder); err != nil {
-			glog.Warningf("Cannot configure handler %s with types %v: %v", handler, typsToCnfgr, err)
-			return err
-		}
+		ti.SetType(typsToCnfgr, hb.handlerBuilder2)
 	}
 	return nil
 }

--- a/pkg/config/handler_test.go
+++ b/pkg/config/handler_test.go
@@ -97,14 +97,14 @@ func TestDispatchToHandlers(t *testing.T) {
 	}{
 		{
 			name:                      "simple",
-			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder2: nil}},
+			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder: nil}},
 			infrdTyps:                 map[string]proto.Message{"inst1": nil},
 			instancesByTemplate:       map[string]instancesByTemplate{"hndlr": map[string][]string{"any": {"inst1"}}},
 			wantTrackInstancesPerCall: [][]string{{"inst1"}},
 		},
 		{
 			name:                      "MultiHandlerAndInsts",
-			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder2: nil}, "hndlr2": {handlerBuilder2: nil}},
+			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder: nil}, "hndlr2": {handlerBuilder: nil}},
 			infrdTyps:                 map[string]proto.Message{"inst1": nil, "inst2": nil, "inst3": nil},
 			instancesByTemplate:       map[string]instancesByTemplate{"hndlr": map[string][]string{"any1": {"inst1", "inst2"}, "any2": {"inst3"}}},
 			wantTrackInstancesPerCall: [][]string{{"inst1", "inst2"}, {"inst3"}},
@@ -151,9 +151,9 @@ func TestDispatchToHandlersPanicRecover(t *testing.T) {
 	goodHndlr2 := "goodHndlr2"
 
 	handlers := map[string]*HandlerBuilderInfo{
-		badHndlr:   {handlerBuilder2: nil},
-		goodHndlr1: {handlerBuilder2: nil},
-		goodHndlr2: {handlerBuilder2: nil},
+		badHndlr:   {handlerBuilder: nil},
+		goodHndlr1: {handlerBuilder: nil},
+		goodHndlr2: {handlerBuilder: nil},
 	}
 	infrdTypes := map[string]proto.Message{"inst1": nil, "inst2": nil, "inst3": nil}
 

--- a/pkg/config/handler_test.go
+++ b/pkg/config/handler_test.go
@@ -67,7 +67,7 @@ func newFakeTmplRepo2(cnfgTypePanicsForTmpl string, trackInstancesPerCall *insta
 }
 func (t fakeTmplRepo2) GetTemplateInfo(template string) (tmpl.Info, bool) {
 	return tmpl.Info{
-		SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
+		SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
 			instances := make([]string, 0)
 			for instance := range types {
 				instances = append(instances, instance)
@@ -97,14 +97,14 @@ func TestDispatchToHandlers(t *testing.T) {
 	}{
 		{
 			name:                      "simple",
-			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder: nil}},
+			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {b: nil}},
 			infrdTyps:                 map[string]proto.Message{"inst1": nil},
 			instancesByTemplate:       map[string]instancesByTemplate{"hndlr": map[string][]string{"any": {"inst1"}}},
 			wantTrackInstancesPerCall: [][]string{{"inst1"}},
 		},
 		{
 			name:                      "MultiHandlerAndInsts",
-			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder: nil}, "hndlr2": {handlerBuilder: nil}},
+			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {b: nil}, "hndlr2": {b: nil}},
 			infrdTyps:                 map[string]proto.Message{"inst1": nil, "inst2": nil, "inst3": nil},
 			instancesByTemplate:       map[string]instancesByTemplate{"hndlr": map[string][]string{"any1": {"inst1", "inst2"}, "any2": {"inst3"}}},
 			wantTrackInstancesPerCall: [][]string{{"inst1", "inst2"}, {"inst3"}},
@@ -151,9 +151,9 @@ func TestDispatchToHandlersPanicRecover(t *testing.T) {
 	goodHndlr2 := "goodHndlr2"
 
 	handlers := map[string]*HandlerBuilderInfo{
-		badHndlr:   {handlerBuilder: nil},
-		goodHndlr1: {handlerBuilder: nil},
-		goodHndlr2: {handlerBuilder: nil},
+		badHndlr:   {b: nil},
+		goodHndlr1: {b: nil},
+		goodHndlr2: {b: nil},
 	}
 	infrdTypes := map[string]proto.Message{"inst1": nil, "inst2": nil, "inst3": nil}
 

--- a/pkg/config/handler_test.go
+++ b/pkg/config/handler_test.go
@@ -57,18 +57,17 @@ func (t fakeTmplRepo) SupportsTemplate(hndlrBuilder adapter.HandlerBuilder, s st
 
 type instancesPerCall [][]string
 type fakeTmplRepo2 struct {
-	err       error
 	panicTmpl string
 	// used to track what is called and later verify in the test.
 	trace *instancesPerCall
 }
 
-func newFakeTmplRepo2(retErr error, cnfgTypePanicsForTmpl string, trackInstancesPerCall *instancesPerCall) fakeTmplRepo2 {
-	return fakeTmplRepo2{err: retErr, panicTmpl: cnfgTypePanicsForTmpl, trace: trackInstancesPerCall}
+func newFakeTmplRepo2(cnfgTypePanicsForTmpl string, trackInstancesPerCall *instancesPerCall) fakeTmplRepo2 {
+	return fakeTmplRepo2{panicTmpl: cnfgTypePanicsForTmpl, trace: trackInstancesPerCall}
 }
 func (t fakeTmplRepo2) GetTemplateInfo(template string) (tmpl.Info, bool) {
 	return tmpl.Info{
-		SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+		SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
 			instances := make([]string, 0)
 			for instance := range types {
 				instances = append(instances, instance)
@@ -77,7 +76,6 @@ func (t fakeTmplRepo2) GetTemplateInfo(template string) (tmpl.Info, bool) {
 			if t.panicTmpl == template {
 				panic("Panic from handler code")
 			}
-			return t.err
 		},
 	}, true
 }
@@ -94,40 +92,29 @@ func TestDispatchToHandlers(t *testing.T) {
 		instancesByTemplate map[string]instancesByTemplate
 		infrdTyps           map[string]proto.Message
 
-		cnfgTypeErr               error
 		wantErr                   string
 		wantTrackInstancesPerCall [][]string
 	}{
 		{
 			name:                      "simple",
-			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder: nil}},
+			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder2: nil}},
 			infrdTyps:                 map[string]proto.Message{"inst1": nil},
 			instancesByTemplate:       map[string]instancesByTemplate{"hndlr": map[string][]string{"any": {"inst1"}}},
-			cnfgTypeErr:               nil,
 			wantTrackInstancesPerCall: [][]string{{"inst1"}},
 		},
 		{
 			name:                      "MultiHandlerAndInsts",
-			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder: nil}, "hndlr2": {handlerBuilder: nil}},
+			handlers:                  map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder2: nil}, "hndlr2": {handlerBuilder2: nil}},
 			infrdTyps:                 map[string]proto.Message{"inst1": nil, "inst2": nil, "inst3": nil},
 			instancesByTemplate:       map[string]instancesByTemplate{"hndlr": map[string][]string{"any1": {"inst1", "inst2"}, "any2": {"inst3"}}},
-			cnfgTypeErr:               nil,
 			wantTrackInstancesPerCall: [][]string{{"inst1", "inst2"}, {"inst3"}},
-		},
-		{
-			name:                "ErrorFromAdapterCode",
-			handlers:            map[string]*HandlerBuilderInfo{"hndlr": {handlerBuilder: nil}},
-			infrdTyps:           map[string]proto.Message{"inst1": nil},
-			instancesByTemplate: map[string]instancesByTemplate{"hndlr": map[string][]string{"any": {"inst1"}}},
-			cnfgTypeErr:         fmt.Errorf("error from adapter configure code"),
-			wantErr:             "error from adapter configure code",
 		},
 	}
 
 	ex, _ := expr.NewCEXLEvaluator(expr.DefaultCacheSize)
 	for _, tt := range tests {
 		actualCallTrackInfo := make(instancesPerCall, 0)
-		tmplRepo := newFakeTmplRepo2(tt.cnfgTypeErr, "", &actualCallTrackInfo)
+		tmplRepo := newFakeTmplRepo2("", &actualCallTrackInfo)
 		hc := handlerFactory{typeChecker: ex, tmplRepo: tmplRepo}
 
 		err := hc.dispatch(tt.infrdTyps, tt.instancesByTemplate, tt.handlers)
@@ -164,9 +151,9 @@ func TestDispatchToHandlersPanicRecover(t *testing.T) {
 	goodHndlr2 := "goodHndlr2"
 
 	handlers := map[string]*HandlerBuilderInfo{
-		badHndlr:   {handlerBuilder: nil},
-		goodHndlr1: {handlerBuilder: nil},
-		goodHndlr2: {handlerBuilder: nil},
+		badHndlr:   {handlerBuilder2: nil},
+		goodHndlr1: {handlerBuilder2: nil},
+		goodHndlr2: {handlerBuilder2: nil},
 	}
 	infrdTypes := map[string]proto.Message{"inst1": nil, "inst2": nil, "inst3": nil}
 
@@ -187,22 +174,12 @@ func TestDispatchToHandlersPanicRecover(t *testing.T) {
 			wantCallTrackInfo:     wantcallTrackInfo,
 			cnfgTypeErr:           nil,
 		},
-		{
-			name:                  "PanicAfterError",
-			handlers:              handlers,
-			infrdTyps:             infrdTypes,
-			instancesByTemplate:   instancesByTemplate,
-			cnfgTypePanicsForTmpl: tmpCausingPanic,
-			wantCallTrackInfo:     wantcallTrackInfo,
-			cnfgTypeErr:           fmt.Errorf("error from configure-type"),
-			wantErr:               "error from configure-type",
-		},
 	}
 
 	for _, tt := range tests {
 		ex, _ := expr.NewCEXLEvaluator(expr.DefaultCacheSize)
 		actualCallTrackInfo := make(instancesPerCall, 0)
-		tmplRepo := newFakeTmplRepo2(tt.cnfgTypeErr, tt.cnfgTypePanicsForTmpl, &actualCallTrackInfo)
+		tmplRepo := newFakeTmplRepo2(tt.cnfgTypePanicsForTmpl, &actualCallTrackInfo)
 		hc := handlerFactory{typeChecker: ex, tmplRepo: tmplRepo}
 
 		err := hc.dispatch(tt.infrdTyps, tt.instancesByTemplate, tt.handlers)

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -156,8 +156,7 @@ type (
 
 	// HandlerBuilderInfo stores validated HandlerBuilders..
 	HandlerBuilderInfo struct {
-		handlerBuilder2 *adapter.HandlerBuilder
-		//handlerBuilder     *adapter.HandlerBuilder
+		handlerBuilder     *adapter.HandlerBuilder
 		isBroken           bool
 		handlerCnfg        *pb.Handler
 		supportedTemplates []string
@@ -640,12 +639,12 @@ func (p *validator) buildHandler(builder *HandlerBuilderInfo, handler string) (c
 		}
 	}()
 
-	(*builder.handlerBuilder2).SetAdapterConfig(builder.handlerCnfg.Params.(proto.Message))
-	if re := (*builder.handlerBuilder2).Validate(); re != nil {
+	(*builder.handlerBuilder).SetAdapterConfig(builder.handlerCnfg.Params.(proto.Message))
+	if re := (*builder.handlerBuilder).Validate(); re != nil {
 		return ce.Appendf("handlerConfig: "+handler, "failed to validate a handler configuration").Extend(re)
 	}
 	// TODO pass correct context here.
-	instance, err := (*builder.handlerBuilder2).Build(context.Background(), nil)
+	instance, err := (*builder.handlerBuilder).Build(context.Background(), nil)
 	// TODO Add validation to ensure handlerInstance support all the templates it claims to support.
 	if err != nil {
 		return ce.Appendf("handlerConfig: "+handler, "failed to build a handler instance: %v", err)
@@ -745,9 +744,8 @@ func (p *validator) validateHandlers(cfg string) (ce *adapter.ConfigErrors) {
 		}
 
 		hh.Params = hcfg
-		//hb := bi.CreateHandlerBuilder()
-		hb2 := bi.NewBuilder()
-		p.handlers[hh.GetName()] = &HandlerBuilderInfo{handlerCnfg: hh, handlerBuilder2: &hb2, supportedTemplates: bi.SupportedTemplates}
+		hb := bi.NewBuilder()
+		p.handlers[hh.GetName()] = &HandlerBuilderInfo{handlerCnfg: hh, handlerBuilder: &hb, supportedTemplates: bi.SupportedTemplates}
 	}
 	return
 }
@@ -757,9 +755,6 @@ func convertHandlerParams(bi *adapter.BuilderInfo, name string, params interface
 	if err := decode(params, hc, strict); err != nil {
 		return nil, ce.Appendf(name, "failed to decode handler params: %v", err)
 	}
-	//if ce := bi.ValidateConfig(hc); ce != nil {
-	//	return nil, ce.Extend(ce)
-	//}
 	return hc, nil
 }
 

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -156,7 +156,7 @@ type (
 
 	// HandlerBuilderInfo stores validated HandlerBuilders..
 	HandlerBuilderInfo struct {
-		handlerBuilder     *adapter.HandlerBuilder
+		b                  adapter.HandlerBuilder
 		isBroken           bool
 		handlerCnfg        *pb.Handler
 		supportedTemplates []string
@@ -639,12 +639,12 @@ func (p *validator) buildHandler(builder *HandlerBuilderInfo, handler string) (c
 		}
 	}()
 
-	(*builder.handlerBuilder).SetAdapterConfig(builder.handlerCnfg.Params.(proto.Message))
-	if re := (*builder.handlerBuilder).Validate(); re != nil {
+	(builder.b).SetAdapterConfig(builder.handlerCnfg.Params.(proto.Message))
+	if re := (builder.b).Validate(); re != nil {
 		return ce.Appendf("handlerConfig: "+handler, "failed to validate a handler configuration").Extend(re)
 	}
 	// TODO pass correct context here.
-	instance, err := (*builder.handlerBuilder).Build(context.Background(), nil)
+	instance, err := (builder.b).Build(context.Background(), nil)
 	// TODO Add validation to ensure handlerInstance support all the templates it claims to support.
 	if err != nil {
 		return ce.Appendf("handlerConfig: "+handler, "failed to build a handler instance: %v", err)
@@ -745,7 +745,7 @@ func (p *validator) validateHandlers(cfg string) (ce *adapter.ConfigErrors) {
 
 		hh.Params = hcfg
 		hb := bi.NewBuilder()
-		p.handlers[hh.GetName()] = &HandlerBuilderInfo{handlerCnfg: hh, handlerBuilder: &hb, supportedTemplates: bi.SupportedTemplates}
+		p.handlers[hh.GetName()] = &HandlerBuilderInfo{handlerCnfg: hh, b: hb, supportedTemplates: bi.SupportedTemplates}
 	}
 	return
 }

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -639,12 +639,12 @@ func (p *validator) buildHandler(builder *HandlerBuilderInfo, handler string) (c
 		}
 	}()
 
-	(builder.b).SetAdapterConfig(builder.handlerCnfg.Params.(proto.Message))
-	if re := (builder.b).Validate(); re != nil {
+	builder.b.SetAdapterConfig(builder.handlerCnfg.Params.(proto.Message))
+	if re := builder.b.Validate(); re != nil {
 		return ce.Appendf("handlerConfig: "+handler, "failed to validate a handler configuration").Extend(re)
 	}
 	// TODO pass correct context here.
-	instance, err := (builder.b).Build(context.Background(), nil)
+	instance, err := builder.b.Build(context.Background(), nil)
 	// TODO Add validation to ensure handlerInstance support all the templates it claims to support.
 	if err != nil {
 		return ce.Appendf("handlerConfig: "+handler, "failed to build a handler instance: %v", err)

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -875,7 +875,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder2: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"",
@@ -887,7 +887,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder2: &validationErrHndlr, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder: &validationErrHndlr, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"Validation failed",
@@ -899,7 +899,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(errors.New("some error during configuration")),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder2: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"some error during configuration",
@@ -911,7 +911,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder2: &hbb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder: &hbb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"failed to build a handler instance",
@@ -923,7 +923,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder2: &hpb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder: &hpb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"",
@@ -935,10 +935,10 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder2: &hbgood2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder: &hbgood2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 				handlerName2: {
-					handlerBuilder2: &hbb2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder: &hbb2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"failed to build a handler instance",

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -854,12 +854,6 @@ func getSetupHandlerFn(err error) SetupHandlerFn {
 }
 
 func TestBuildHandlers(t *testing.T) {
-	var hbgood adapter.HandlerBuilder = fakeGoodHndlrBldr{}
-	var hbgood2 adapter.HandlerBuilder = fakeGoodHndlrBldr{}
-	var hbb adapter.HandlerBuilder = fakeErrRetrningHndlrBldr{}
-	var hbb2 adapter.HandlerBuilder = fakeErrRetrningHndlrBldr{}
-	var hpb adapter.HandlerBuilder = fakePanicHndlrBldr{}
-	var validationErrHndlr adapter.HandlerBuilder = fakeHndlrBldr{validationError: "Validation failed"}
 	const handlerName = "foo"
 	const handlerName2 = "bar"
 	tests := []struct {
@@ -875,7 +869,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					b: fakeGoodHndlrBldr{}, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"",
@@ -887,7 +881,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &validationErrHndlr, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					b: fakeHndlrBldr{validationError: "Validation failed"}, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"Validation failed",
@@ -899,7 +893,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(errors.New("some error during configuration")),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					b: fakeGoodHndlrBldr{}, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"some error during configuration",
@@ -911,7 +905,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					b: fakeErrRetrningHndlrBldr{}, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"failed to build a handler instance",
@@ -923,7 +917,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hpb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					b: fakePanicHndlrBldr{}, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"",
@@ -935,10 +929,10 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbgood2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					b: fakeGoodHndlrBldr{}, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 				handlerName2: {
-					handlerBuilder: &hbb2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					b: fakeErrRetrningHndlrBldr{}, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"failed to build a handler instance",

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"crypto/sha1"
 	"errors"
 	"fmt"
@@ -644,19 +645,17 @@ quotas:
 
 func TestConvertHandlerParamsErrors(t *testing.T) {
 	tTable := []struct {
-		params            interface{}
-		defaultCnfg       proto.Message
-		hndlrValidateCnfg adapter.ValidateConfigFn
-		errorStr          string
+		params      interface{}
+		defaultCnfg proto.Message
+		errorStr    string
 	}{
 		{
 			params: map[string]interface{}{
 				"check_expression": "src.ip",
 				"blacklist":        "true (this should be bool)",
 			},
-			defaultCnfg:       &listcheckerpb.ListsParams{},
-			hndlrValidateCnfg: func(c adapter.Config) *adapter.ConfigErrors { return nil },
-			errorStr:          "failed to decode",
+			defaultCnfg: &listcheckerpb.ListsParams{},
+			errorStr:    "failed to decode",
 		},
 		{
 			params: map[string]interface{}{
@@ -664,20 +663,8 @@ func TestConvertHandlerParamsErrors(t *testing.T) {
 				"blacklist":        true,
 				"wrongextrafield":  true,
 			},
-			defaultCnfg:       &listcheckerpb.ListsParams{},
-			hndlrValidateCnfg: func(c adapter.Config) *adapter.ConfigErrors { return nil },
-			errorStr:          "failed to unmarshal",
-		},
-		{
-			params: map[string]interface{}{
-				"check_expression": "src.ip",
-				"blacklist":        true,
-			},
 			defaultCnfg: &listcheckerpb.ListsParams{},
-			hndlrValidateCnfg: func(c adapter.Config) (ce *adapter.ConfigErrors) {
-				return ce.Appendf("foo", "handler config validation failed")
-			},
-			errorStr: "handler config validation failed",
+			errorStr:    "failed to unmarshal",
 		},
 	}
 
@@ -685,12 +672,12 @@ func TestConvertHandlerParamsErrors(t *testing.T) {
 		t.Run(tt.errorStr, func(t *testing.T) {
 			_, ce := convertHandlerParams(
 				&adapter.BuilderInfo{
-					DefaultConfig:  tt.defaultCnfg,
-					ValidateConfig: tt.hndlrValidateCnfg,
+					DefaultConfig: tt.defaultCnfg,
+					NewBuilder:    func() adapter.HandlerBuilder { return fakeGoodHndlrBldr{} },
 				}, "TestConvertHandlerParamsErrors", tt.params, true)
 
 			if !strings.Contains(ce.Error(), tt.errorStr) {
-				t.Errorf("got %s, want %s\n", ce.Error(), tt.errorStr)
+				t.Errorf("got '%s', want '%s'\n", ce.Error(), tt.errorStr)
 			}
 		})
 	}
@@ -705,9 +692,8 @@ func TestValidateHandlers(t *testing.T) {
 			nil,
 			map[string]*adapter.BuilderInfo{
 				"fooHandlerAdapter": {
-					DefaultConfig:        &types.Empty{},
-					ValidateConfig:       func(c adapter.Config) *adapter.ConfigErrors { return nil },
-					CreateHandlerBuilder: func() adapter.HandlerBuilder { return nil },
+					DefaultConfig: &types.Empty{},
+					NewBuilder:    func() adapter.HandlerBuilder { return nil },
 				},
 			},
 			nil, 0, "service.name == “*”", false, ConstGlobalConfig,
@@ -723,9 +709,8 @@ func TestValidateHandlers(t *testing.T) {
 			nil,
 			map[string]*adapter.BuilderInfo{
 				"fooHandlerAdapter": {
-					DefaultConfig:        &types.Empty{},
-					ValidateConfig:       func(c adapter.Config) *adapter.ConfigErrors { return nil },
-					CreateHandlerBuilder: func() adapter.HandlerBuilder { return nil },
+					DefaultConfig: &types.Empty{},
+					NewBuilder:    func() adapter.HandlerBuilder { return nil },
 				},
 			},
 			nil, 1, "service.name == “*”", false, duplicateCnstrs,
@@ -773,10 +758,9 @@ handlers:
 		{
 			hbi: map[string]*adapter.BuilderInfo{
 				"fooHandlerAdapter": {
-					DefaultConfig:        &types.Empty{},
-					ValidateConfig:       func(c adapter.Config) *adapter.ConfigErrors { return nil },
-					CreateHandlerBuilder: func() adapter.HandlerBuilder { return nil },
-					SupportedTemplates:   []string{testSupportedTemplate},
+					DefaultConfig:      &types.Empty{},
+					NewBuilder:         func() adapter.HandlerBuilder { return nil },
+					SupportedTemplates: []string{testSupportedTemplate},
 				},
 			},
 			cfg:     globalConfig,
@@ -823,21 +807,44 @@ func (f *fakeGoodHndlr) Close() error {
 	return nil
 }
 
-func (f fakeGoodHndlrBldr) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (f fakeGoodHndlrBldr) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return &fakeGoodHndlr{}, nil
 }
+func (f fakeGoodHndlrBldr) Validate() *adapter.ConfigErrors   { return nil }
+func (f fakeGoodHndlrBldr) SetAdapterConfig(_ adapter.Config) {}
 
 type fakeErrRetrningHndlrBldr struct{}
 
-func (f fakeErrRetrningHndlrBldr) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (f fakeErrRetrningHndlrBldr) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return nil, errors.New("build failed")
 }
+func (f fakeErrRetrningHndlrBldr) Validate() *adapter.ConfigErrors {
+	return nil
+}
+func (f fakeErrRetrningHndlrBldr) SetAdapterConfig(config adapter.Config) {}
 
 type fakePanicHndlrBldr struct{}
 
-func (f fakePanicHndlrBldr) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (f fakePanicHndlrBldr) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	panic("panic from handler Build method")
 }
+func (f fakePanicHndlrBldr) Validate() *adapter.ConfigErrors   { return nil }
+func (f fakePanicHndlrBldr) SetAdapterConfig(_ adapter.Config) {}
+
+type fakeHndlrBldr struct {
+	validationError string
+}
+
+func (f fakeHndlrBldr) Build(context.Context, adapter.Env) (adapter.Handler, error) {
+	return &fakeGoodHndlr{}, nil
+}
+func (f fakeHndlrBldr) Validate() (ce *adapter.ConfigErrors) {
+	if f.validationError == "" {
+		return nil
+	}
+	return ce.Append("foo", errors.New(f.validationError))
+}
+func (f fakeHndlrBldr) SetAdapterConfig(_ adapter.Config) {}
 
 func getSetupHandlerFn(err error) SetupHandlerFn {
 	return func(actions []*pb.Action, instances map[string]*pb.Instance,
@@ -852,6 +859,7 @@ func TestBuildHandlers(t *testing.T) {
 	var hbb adapter.HandlerBuilder = fakeErrRetrningHndlrBldr{}
 	var hbb2 adapter.HandlerBuilder = fakeErrRetrningHndlrBldr{}
 	var hpb adapter.HandlerBuilder = fakePanicHndlrBldr{}
+	var validationErrHndlr adapter.HandlerBuilder = fakeHndlrBldr{validationError: "Validation failed"}
 	const handlerName = "foo"
 	const handlerName2 = "bar"
 	tests := []struct {
@@ -867,10 +875,22 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder2: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"",
+			false,
+			false,
+		},
+		{
+			"ErrorFromValidateMtd",
+			getSetupHandlerFn(nil),
+			map[string]*HandlerBuilderInfo{
+				handlerName: {
+					handlerBuilder2: &validationErrHndlr, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+				},
+			},
+			"Validation failed",
 			false,
 			false,
 		},
@@ -879,7 +899,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(errors.New("some error during configuration")),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder2: &hbgood, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"some error during configuration",
@@ -891,7 +911,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder2: &hbb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"failed to build a handler instance",
@@ -903,7 +923,7 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hpb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder2: &hpb, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"",
@@ -915,10 +935,10 @@ func TestBuildHandlers(t *testing.T) {
 			getSetupHandlerFn(nil),
 			map[string]*HandlerBuilderInfo{
 				handlerName: {
-					handlerBuilder: &hbgood2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder2: &hbgood2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 				handlerName2: {
-					handlerBuilder: &hbb2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
+					handlerBuilder2: &hbb2, handlerCnfg: &pb.Handler{Params: &types.Empty{}},
 				},
 			},
 			"failed to build a handler instance",

--- a/pkg/runtime/dispatcher.go
+++ b/pkg/runtime/dispatcher.go
@@ -262,7 +262,7 @@ func (m *dispatcher) Quota(ctx context.Context, requestBag attribute.Bag,
 	)
 	res, _ := qres.(*adapter.QuotaResult2)
 	if glog.V(3) {
-		glog.Infof("Quota %s", res)
+		glog.Infof("Quota %v", res)
 	}
 	return res, err
 }

--- a/pkg/runtime/handler.go
+++ b/pkg/runtime/handler.go
@@ -15,6 +15,7 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -98,7 +99,7 @@ func (h *handlerFactory) Build(handler *pb.Handler, instances []*pb.Instance, en
 	// HandlerBuilder should always be present for a valid configuration (reference integrity should already be checked).
 	hndlrBldrInfo, _ := h.builderInfoFinder(handler.Adapter)
 
-	hndlrBldr := hndlrBldrInfo.CreateHandlerBuilder()
+	hndlrBldr := hndlrBldrInfo.NewBuilder()
 	if hndlrBldr == nil {
 		msg := fmt.Sprintf("nil HandlerBuilder instantiated for adapter '%s' in handler config '%s'", handler.Adapter, handler.Name)
 		glog.Warning(msg)
@@ -137,12 +138,11 @@ func (h *handlerFactory) build(hndlrBldr adapter.HandlerBuilder, infrdTypesByTmp
 		typs = infrdTypesByTmpl[tmplName]
 		// ti should be there for a valid configuration.
 		ti, _ = h.tmplRepo.GetTemplateInfo(tmplName)
-		if err := ti.SetType(typs, &hndlrBldr); err != nil {
-			return nil, fmt.Errorf("cannot configure handler types %v for mesh function name '%s': %v", typs, tmplName, err)
-		}
+		ti.SetType(typs, &hndlrBldr)
 	}
-
-	return hndlrBldr.Build(adapterCnfg.(proto.Message), env)
+	hndlrBldr.SetAdapterConfig(adapterCnfg.(proto.Message))
+	// TODO call validate. hndlrBldr.Validate
+	return hndlrBldr.Build(context.Background(), env)
 }
 
 func (h *handlerFactory) inferTypesGrpdByTmpl(instances []*pb.Instance) (map[string]typeMap, error) {

--- a/pkg/runtime/handler.go
+++ b/pkg/runtime/handler.go
@@ -138,7 +138,7 @@ func (h *handlerFactory) build(hndlrBldr adapter.HandlerBuilder, infrdTypesByTmp
 		typs = infrdTypesByTmpl[tmplName]
 		// ti should be there for a valid configuration.
 		ti, _ = h.tmplRepo.GetTemplateInfo(tmplName)
-		ti.SetType(typs, &hndlrBldr)
+		ti.SetType(typs, hndlrBldr)
 	}
 	hndlrBldr.SetAdapterConfig(adapterCnfg.(proto.Message))
 	// TODO call validate. hndlrBldr.Validate

--- a/pkg/runtime/handler_test.go
+++ b/pkg/runtime/handler_test.go
@@ -44,7 +44,7 @@ func (t fakeTmplRepo) GetTemplateInfo(template string) (tmpl.Info, bool) {
 		InferType: func(proto.Message, tmpl.TypeEvalFn) (proto.Message, error) {
 			return t.typeResult, t.infrErr
 		},
-		SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
+		SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
 			if t.cnfgrPanic != "" {
 				panic(t.cnfgrPanic)
 			}

--- a/pkg/runtime/handler_test.go
+++ b/pkg/runtime/handler_test.go
@@ -156,9 +156,7 @@ func TestBuild_Error(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			bldrInfoFinder := func(name string) (*adapter.BuilderInfo, bool) {
-				return &adapter.BuilderInfo{
-					NewBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder },
-				}, true
+				return &adapter.BuilderInfo{NewBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
 			}
 
 			hf := NewHandlerFactory(tt.tmplRepo, nil, nil, bldrInfoFinder)

--- a/pkg/runtime/handler_test.go
+++ b/pkg/runtime/handler_test.go
@@ -15,6 +15,8 @@
 package runtime
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -31,7 +33,6 @@ import (
 
 type fakeTmplRepo struct {
 	infrErr    error
-	cnfgrErr   error
 	cnfgrPanic string
 	typeResult proto.Message
 
@@ -43,15 +44,13 @@ func (t fakeTmplRepo) GetTemplateInfo(template string) (tmpl.Info, bool) {
 		InferType: func(proto.Message, tmpl.TypeEvalFn) (proto.Message, error) {
 			return t.typeResult, t.infrErr
 		},
-		SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+		SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
 			if t.cnfgrPanic != "" {
 				panic(t.cnfgrPanic)
 			}
 			if t.cnfgMtdCallInfo != nil {
 				t.cnfgMtdCallInfo[template] = types
 			}
-
-			return t.cnfgrErr
 		},
 	}, true
 }
@@ -62,8 +61,10 @@ func (t fakeTmplRepo) SupportsTemplate(hndlrBuilder adapter.HandlerBuilder, s st
 }
 
 type fakeHndlrBldr struct {
-	bldPanic string
-	bldErr   error
+	bldPanic    string
+	bldErr      error
+	cfg         adapter.Config
+	validateErr string
 }
 type fakeHndlr struct {
 	createdWithCnfg adapter.Config
@@ -73,12 +74,21 @@ func (f fakeHndlr) Close() error {
 	return nil
 }
 
-func (f fakeHndlrBldr) Build(cnfg adapter.Config, env adapter.Env) (adapter.Handler, error) {
+func (f *fakeHndlrBldr) Validate() (ce *adapter.ConfigErrors) {
+	if f.validateErr == "" {
+		return nil
+	}
+	return ce.Append("", errors.New(f.validateErr))
+}
+
+func (f *fakeHndlrBldr) SetAdapterConfig(cfg adapter.Config) { f.cfg = cfg }
+
+func (f *fakeHndlrBldr) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 	if f.bldPanic != "" {
 		panic(f.bldPanic)
 	}
 
-	return fakeHndlr{createdWithCnfg: cnfg}, f.bldErr
+	return fakeHndlr{createdWithCnfg: f.cfg}, f.bldErr
 }
 
 func TestBuild_Error(t *testing.T) {
@@ -102,16 +112,6 @@ func TestBuild_Error(t *testing.T) {
 			hndlrCnfg: &pb.Handler{Name: "h1", Adapter: "a1"},
 		},
 		{
-			name:      "ErrorConfigureXXXX",
-			tmplRepo:  fakeTmplRepo{cnfgrErr: fmt.Errorf("FOOBAR ERROR")},
-			wantError: "for mesh function name 'tpml1': FOOBAR ERROR",
-
-			instsCnfg:    []*pb.Instance{{"inst1", "tpml1", &empty.Empty{}}},
-			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &empty.Empty{}},
-			hndlrBuilder: fakeHndlrBldr{},
-		},
-
-		{
 			name:     "PanicConfigureXXXX",
 			tmplRepo: fakeTmplRepo{cnfgrPanic: "FOOBAR PANIC"},
 			wantError: "handler panicked with 'FOOBAR PANIC' when trying to configure the " +
@@ -119,12 +119,12 @@ func TestBuild_Error(t *testing.T) {
 
 			instsCnfg:    []*pb.Instance{{"inst1", "tpml1", &empty.Empty{}}},
 			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1"},
-			hndlrBuilder: fakeHndlrBldr{},
+			hndlrBuilder: &fakeHndlrBldr{},
 		},
 
 		{
 			name:         "ErrorAdptBuildXXXX",
-			hndlrBuilder: fakeHndlrBldr{bldErr: fmt.Errorf("FOOBAR ERROR from HandlerBuidler build")},
+			hndlrBuilder: &fakeHndlrBldr{bldErr: fmt.Errorf("FOOBAR ERROR from HandlerBuidler build")},
 			wantError:    "cannot configure adapter 'a1' in handler config 'h1': FOOBAR ERROR from HandlerBuidler build",
 
 			tmplRepo:  fakeTmplRepo{},
@@ -134,7 +134,7 @@ func TestBuild_Error(t *testing.T) {
 
 		{
 			name:         "PanicAdptBuild",
-			hndlrBuilder: fakeHndlrBldr{bldPanic: "FOOBAR ERROR panic from HandlerBuidler build"},
+			hndlrBuilder: &fakeHndlrBldr{bldPanic: "FOOBAR ERROR panic from HandlerBuidler build"},
 			wantError: "handler panicked with 'FOOBAR ERROR panic from HandlerBuidler build' when trying to " +
 				"configure the associated adapter",
 
@@ -148,15 +148,17 @@ func TestBuild_Error(t *testing.T) {
 			wantError: "cannot infer type information from params in instance 'inst1': FOOBAR ERROR",
 
 			instsCnfg:    []*pb.Instance{{"inst1", "tpml1", &empty.Empty{}}},
-			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1"},
-			hndlrBuilder: fakeHndlrBldr{},
+			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &empty.Empty{}},
+			hndlrBuilder: &fakeHndlrBldr{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			bldrInfoFinder := func(name string) (*adapter.BuilderInfo, bool) {
-				return &adapter.BuilderInfo{CreateHandlerBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
+				return &adapter.BuilderInfo{
+					NewBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder },
+				}, true
 			}
 
 			hf := NewHandlerFactory(tt.tmplRepo, nil, nil, bldrInfoFinder)
@@ -164,7 +166,6 @@ func TestBuild_Error(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
 				t.Errorf("got error %v\nwant %v", err, tt.wantError)
 			}
-
 		})
 	}
 }
@@ -187,7 +188,7 @@ func TestBuild_Valid(t *testing.T) {
 			tmplRepo:     fakeTmplRepo{typeResult: &wrappers.Int32Value{Value: 1}, cnfgMtdCallInfo: make(map[string]map[string]proto.Message)},
 			instsCnfg:    []*pb.Instance{{"inst1", "tmpl1", &empty.Empty{}}},
 			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
-			hndlrBuilder: fakeHndlrBldr{},
+			hndlrBuilder: &fakeHndlrBldr{},
 
 			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{"tmpl1": {"inst1": &wrappers.Int32Value{Value: 1}}},
 			wantBldMtdCnfgParam: &wrappers.Int32Value{Value: 2},
@@ -197,7 +198,7 @@ func TestBuild_Valid(t *testing.T) {
 			tmplRepo:     fakeTmplRepo{cnfgMtdCallInfo: make(map[string]map[string]proto.Message)},
 			instsCnfg:    []*pb.Instance{},
 			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
-			hndlrBuilder: fakeHndlrBldr{},
+			hndlrBuilder: &fakeHndlrBldr{},
 
 			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{},
 			wantBldMtdCnfgParam: &wrappers.Int32Value{Value: 2},
@@ -210,7 +211,7 @@ func TestBuild_Valid(t *testing.T) {
 				{"inst2", "tmpl1", &empty.Empty{}},
 			},
 			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
-			hndlrBuilder: fakeHndlrBldr{},
+			hndlrBuilder: &fakeHndlrBldr{},
 
 			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{
 				"tmpl1": {
@@ -229,7 +230,7 @@ func TestBuild_Valid(t *testing.T) {
 				{"inst2", "tmpl1", &empty.Empty{}},
 			},
 			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
-			hndlrBuilder: fakeHndlrBldr{},
+			hndlrBuilder: &fakeHndlrBldr{},
 
 			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{
 				"tmpl1": {
@@ -252,7 +253,7 @@ func TestBuild_Valid(t *testing.T) {
 				{"inst6", "tmpl2", &empty.Empty{}},
 			},
 			hndlrCnfg:    &pb.Handler{Name: "h1", Adapter: "a1", Params: &wrappers.Int32Value{Value: 2}},
-			hndlrBuilder: fakeHndlrBldr{},
+			hndlrBuilder: &fakeHndlrBldr{},
 
 			wantCnfgMtdCallInfo: map[string]map[string]proto.Message{
 				"tmpl1": {
@@ -273,7 +274,7 @@ func TestBuild_Valid(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			bldrInfoFinder := func(name string) (*adapter.BuilderInfo, bool) {
-				return &adapter.BuilderInfo{CreateHandlerBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
+				return &adapter.BuilderInfo{NewBuilder: func() adapter.HandlerBuilder { return tt.hndlrBuilder }}, true
 			}
 
 			hf := NewHandlerFactory(tt.tmplRepo, nil, nil, bldrInfoFinder)

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -39,7 +39,7 @@ type (
 	// InferTypeFn does Type inference from the Instance.params proto message.
 	InferTypeFn func(proto.Message, TypeEvalFn) (proto.Message, error)
 	// SetTypeFn dispatches the inferred types to handlers
-	SetTypeFn func(types map[string]proto.Message, builder *adapter.HandlerBuilder)
+	SetTypeFn func(types map[string]proto.Message, builder adapter.HandlerBuilder)
 
 	// ProcessCheckFn instantiates the instance object and dispatches them to the handler.
 	ProcessCheckFn func(ctx context.Context, instName string, instCfg proto.Message, attrs attribute.Bag,

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -39,7 +39,7 @@ type (
 	// InferTypeFn does Type inference from the Instance.params proto message.
 	InferTypeFn func(proto.Message, TypeEvalFn) (proto.Message, error)
 	// SetTypeFn dispatches the inferred types to handlers
-	SetTypeFn func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error
+	SetTypeFn func(types map[string]proto.Message, builder *adapter.HandlerBuilder)
 
 	// ProcessCheckFn instantiates the instance object and dispatches them to the handler.
 	ProcessCheckFn func(ctx context.Context, instName string, instCfg proto.Message, attrs attribute.Bag,

--- a/template/sample/template.gen_test.go
+++ b/template/sample/template.gen_test.go
@@ -43,9 +43,11 @@ import (
 type fakeBadHandler struct{}
 
 func (h fakeBadHandler) Close() error { return nil }
-func (h fakeBadHandler) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (h fakeBadHandler) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return nil, nil
 }
+func (h fakeBadHandler) Validate() *adapter.ConfigErrors {return nil}
+func (h fakeBadHandler) SetAdapterConfig(cfg adapter.Config) {}
 
 type fakeReportHandler struct {
 	adapter.Handler
@@ -59,13 +61,14 @@ func (h *fakeReportHandler) HandleSample(ctx context.Context, instances []*sampl
 	h.procCallInput = instances
 	return h.retError
 }
-func (h *fakeReportHandler) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (h *fakeReportHandler) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return nil, nil
 }
-func (h *fakeReportHandler) SetSampleTypes(t map[string]*sample_report.Type) error {
+func (h *fakeReportHandler) SetSampleTypes(t map[string]*sample_report.Type) {
 	h.cnfgCallInput = t
-	return nil
 }
+func (h *fakeReportHandler) Validate() *adapter.ConfigErrors {return nil}
+func (h *fakeReportHandler) SetAdapterConfig(cfg adapter.Config) {}
 
 type fakeCheckHandler struct {
 	adapter.Handler
@@ -80,13 +83,12 @@ func (h *fakeCheckHandler) HandleSample(ctx context.Context, instance *sample_ch
 	h.procCallInput = instance
 	return h.retResult, h.retError
 }
-func (h *fakeCheckHandler) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (h *fakeCheckHandler) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return nil, nil
 }
-func (h *fakeCheckHandler) SetSampleTypes(t map[string]*sample_check.Type) error {
-	h.cnfgCallInput = t
-	return nil
-}
+func (h *fakeCheckHandler) SetSampleTypes(t map[string]*sample_check.Type) {h.cnfgCallInput = t}
+func (h *fakeCheckHandler) Validate() *adapter.ConfigErrors {return nil}
+func (h *fakeCheckHandler) SetAdapterConfig(cfg adapter.Config) {}
 
 type fakeQuotaHandler struct {
 	adapter.Handler
@@ -101,13 +103,14 @@ func (h *fakeQuotaHandler) HandleQuota(ctx context.Context, instance *sample_quo
 	h.procCallInput = instance
 	return h.retResult, h.retError
 }
-func (h *fakeQuotaHandler) Build(adapter.Config, adapter.Env) (adapter.Handler, error) {
+func (h *fakeQuotaHandler) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return nil, nil
 }
-func (h *fakeQuotaHandler) SetQuotaTypes(t map[string]*sample_quota.Type) error {
+func (h *fakeQuotaHandler) SetQuotaTypes(t map[string]*sample_quota.Type) {
 	h.cnfgCallInput = t
-	return nil
 }
+func (h *fakeQuotaHandler) Validate() *adapter.ConfigErrors {return nil}
+func (h *fakeQuotaHandler) SetAdapterConfig(cfg adapter.Config) {}
 
 type fakeBag struct{}
 
@@ -583,7 +586,7 @@ func TestSetType(t *testing.T) {
 	} {
 		t.Run(tst.name, func(t *testing.T) {
 			hb := &tst.hdlrBldr
-			_ = SupportedTmplInfo[tst.tmpl].SetType(tst.types, hb)
+			SupportedTmplInfo[tst.tmpl].SetType(tst.types, hb)
 
 			var c interface{}
 			if tst.tmpl == sample_report.TemplateName {

--- a/template/sample/template.gen_test.go
+++ b/template/sample/template.gen_test.go
@@ -46,7 +46,7 @@ func (h fakeBadHandler) Close() error { return nil }
 func (h fakeBadHandler) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return nil, nil
 }
-func (h fakeBadHandler) Validate() *adapter.ConfigErrors {return nil}
+func (h fakeBadHandler) Validate() *adapter.ConfigErrors     { return nil }
 func (h fakeBadHandler) SetAdapterConfig(cfg adapter.Config) {}
 
 type fakeReportHandler struct {
@@ -67,7 +67,7 @@ func (h *fakeReportHandler) Build(context.Context, adapter.Env) (adapter.Handler
 func (h *fakeReportHandler) SetSampleTypes(t map[string]*sample_report.Type) {
 	h.cnfgCallInput = t
 }
-func (h *fakeReportHandler) Validate() *adapter.ConfigErrors {return nil}
+func (h *fakeReportHandler) Validate() *adapter.ConfigErrors     { return nil }
 func (h *fakeReportHandler) SetAdapterConfig(cfg adapter.Config) {}
 
 type fakeCheckHandler struct {
@@ -86,9 +86,9 @@ func (h *fakeCheckHandler) HandleSample(ctx context.Context, instance *sample_ch
 func (h *fakeCheckHandler) Build(context.Context, adapter.Env) (adapter.Handler, error) {
 	return nil, nil
 }
-func (h *fakeCheckHandler) SetSampleTypes(t map[string]*sample_check.Type) {h.cnfgCallInput = t}
-func (h *fakeCheckHandler) Validate() *adapter.ConfigErrors {return nil}
-func (h *fakeCheckHandler) SetAdapterConfig(cfg adapter.Config) {}
+func (h *fakeCheckHandler) SetSampleTypes(t map[string]*sample_check.Type) { h.cnfgCallInput = t }
+func (h *fakeCheckHandler) Validate() *adapter.ConfigErrors                { return nil }
+func (h *fakeCheckHandler) SetAdapterConfig(cfg adapter.Config)            {}
 
 type fakeQuotaHandler struct {
 	adapter.Handler
@@ -109,7 +109,7 @@ func (h *fakeQuotaHandler) Build(context.Context, adapter.Env) (adapter.Handler,
 func (h *fakeQuotaHandler) SetQuotaTypes(t map[string]*sample_quota.Type) {
 	h.cnfgCallInput = t
 }
-func (h *fakeQuotaHandler) Validate() *adapter.ConfigErrors {return nil}
+func (h *fakeQuotaHandler) Validate() *adapter.ConfigErrors     { return nil }
 func (h *fakeQuotaHandler) SetAdapterConfig(cfg adapter.Config) {}
 
 type fakeBag struct{}

--- a/template/sample/template.gen_test.go
+++ b/template/sample/template.gen_test.go
@@ -585,7 +585,7 @@ func TestSetType(t *testing.T) {
 		},
 	} {
 		t.Run(tst.name, func(t *testing.T) {
-			hb := &tst.hdlrBldr
+			hb := tst.hdlrBldr
 			SupportedTmplInfo[tst.tmpl].SetType(tst.types, hb)
 
 			var c interface{}

--- a/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -120,9 +120,9 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
+			SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
-				castedBuilder := (*builder).({{.GoPackageName}}.HandlerBuilder)
+				castedBuilder := builder.({{.GoPackageName}}.HandlerBuilder)
 				castedTypes := make(map[string]*{{.GoPackageName}}.Type, len(types))
 				for k, v := range types {
 					// Mixer framework should have ensured the type safety.

--- a/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -120,7 +120,7 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
 				castedBuilder := (*builder).({{.GoPackageName}}.HandlerBuilder)
 				castedTypes := make(map[string]*{{.GoPackageName}}.Type, len(types))
@@ -129,7 +129,7 @@ var (
 					v1 := v.(*{{.GoPackageName}}.Type)
 					castedTypes[k] = v1
 				}
-				return castedBuilder.Set{{.Name}}Types(castedTypes)
+				castedBuilder.Set{{.Name}}Types(castedTypes)
 			},
 			{{if eq .VarietyName "TEMPLATE_VARIETY_REPORT"}}
 				ProcessReport: func(ctx context.Context, insts map[string]proto.Message, attrs attribute.Bag, mapper expr.Evaluator, handler adapter.Handler) error {

--- a/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
+++ b/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
@@ -148,9 +148,9 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
+			SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
-				castedBuilder := (*builder).(istio_mixer_template_list.HandlerBuilder)
+				castedBuilder := builder.(istio_mixer_template_list.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_list.Type, len(types))
 				for k, v := range types {
 					// Mixer framework should have ensured the type safety.
@@ -362,9 +362,9 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
+			SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
-				castedBuilder := (*builder).(istio_mixer_template_quota.HandlerBuilder)
+				castedBuilder := builder.(istio_mixer_template_quota.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_quota.Type, len(types))
 				for k, v := range types {
 					// Mixer framework should have ensured the type safety.
@@ -591,9 +591,9 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
+			SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
-				castedBuilder := (*builder).(istio_mixer_template_log.HandlerBuilder)
+				castedBuilder := builder.(istio_mixer_template_log.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_log.Type, len(types))
 				for k, v := range types {
 					// Mixer framework should have ensured the type safety.
@@ -820,9 +820,9 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
+			SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
-				castedBuilder := (*builder).(istio_mixer_template_metric.HandlerBuilder)
+				castedBuilder := builder.(istio_mixer_template_metric.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_metric.Type, len(types))
 				for k, v := range types {
 					// Mixer framework should have ensured the type safety.

--- a/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
+++ b/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
@@ -148,7 +148,7 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
 				castedBuilder := (*builder).(istio_mixer_template_list.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_list.Type, len(types))
@@ -157,7 +157,7 @@ var (
 					v1 := v.(*istio_mixer_template_list.Type)
 					castedTypes[k] = v1
 				}
-				return castedBuilder.SetListTypes(castedTypes)
+				castedBuilder.SetListTypes(castedTypes)
 			},
 
 			ProcessCheck: func(ctx context.Context, instName string, inst proto.Message, attrs attribute.Bag,
@@ -362,7 +362,7 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
 				castedBuilder := (*builder).(istio_mixer_template_quota.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_quota.Type, len(types))
@@ -371,7 +371,7 @@ var (
 					v1 := v.(*istio_mixer_template_quota.Type)
 					castedTypes[k] = v1
 				}
-				return castedBuilder.SetQuotaTypes(castedTypes)
+				castedBuilder.SetQuotaTypes(castedTypes)
 			},
 
 			ProcessReport: func(ctx context.Context, insts map[string]proto.Message, attrs attribute.Bag, mapper expr.Evaluator, handler adapter.Handler) error {
@@ -591,7 +591,7 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
 				castedBuilder := (*builder).(istio_mixer_template_log.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_log.Type, len(types))
@@ -600,7 +600,7 @@ var (
 					v1 := v.(*istio_mixer_template_log.Type)
 					castedTypes[k] = v1
 				}
-				return castedBuilder.SetLogTypes(castedTypes)
+				castedBuilder.SetLogTypes(castedTypes)
 			},
 
 			ProcessReport: func(ctx context.Context, insts map[string]proto.Message, attrs attribute.Bag, mapper expr.Evaluator, handler adapter.Handler) error {
@@ -820,7 +820,7 @@ var (
 				_ = cpb
 				return infrdType, err
 			},
-			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) error {
+			SetType: func(types map[string]proto.Message, builder *adapter.HandlerBuilder) {
 				// Mixer framework should have ensured the type safety.
 				castedBuilder := (*builder).(istio_mixer_template_metric.HandlerBuilder)
 				castedTypes := make(map[string]*istio_mixer_template_metric.Type, len(types))
@@ -829,7 +829,7 @@ var (
 					v1 := v.(*istio_mixer_template_metric.Type)
 					castedTypes[k] = v1
 				}
-				return castedBuilder.SetMetricTypes(castedTypes)
+				castedBuilder.SetMetricTypes(castedTypes)
 			},
 
 			ProcessReport: func(ctx context.Context, insts map[string]proto.Message, attrs attribute.Bag, mapper expr.Evaluator, handler adapter.Handler) error {

--- a/tools/codegen/pkg/interfacegen/template/interface.go
+++ b/tools/codegen/pkg/interfacegen/template/interface.go
@@ -55,7 +55,7 @@ type HandlerBuilder interface {
 
 	// Set{{.Name}}Types is invoked by Mixer to pass all possible Types for instances that an adapter
 	// may receive at runtime. Each type holds information about the shape of the instances.
-	Set{{.Name}}Types(map[string]*Type /*Instance name -> Type*/) error
+	Set{{.Name}}Types(map[string]*Type /*Instance name -> Type*/)
 }
 
 // Handler must be implemented by adapter code if it wants to

--- a/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.go.golden
+++ b/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.go.golden
@@ -63,7 +63,7 @@ type HandlerBuilder interface {
 
 	// SetListTypes is invoked by Mixer to pass all possible Types for instances that an adapter
 	// may receive at runtime. Each type holds information about the shape of the instances.
-	SetListTypes(map[string]*Type /*Instance name -> Type*/) error
+	SetListTypes(map[string]*Type /*Instance name -> Type*/)
 }
 
 // Handler must be implemented by adapter code if it wants to

--- a/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.go.golden
+++ b/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.go.golden
@@ -64,7 +64,7 @@ type HandlerBuilder interface {
 
 	// SetQuotaTypes is invoked by Mixer to pass all possible Types for instances that an adapter
 	// may receive at runtime. Each type holds information about the shape of the instances.
-	SetQuotaTypes(map[string]*Type /*Instance name -> Type*/) error
+	SetQuotaTypes(map[string]*Type /*Instance name -> Type*/)
 }
 
 // Handler must be implemented by adapter code if it wants to

--- a/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
+++ b/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
@@ -73,7 +73,7 @@ type HandlerBuilder interface {
 
 	// SetMetricTypes is invoked by Mixer to pass all possible Types for instances that an adapter
 	// may receive at runtime. Each type holds information about the shape of the instances.
-	SetMetricTypes(map[string]*Type /*Instance name -> Type*/) error
+	SetMetricTypes(map[string]*Type /*Instance name -> Type*/)
 }
 
 // Handler must be implemented by adapter code if it wants to


### PR DESCRIPTION
- deleted the old code
- Updates tests as needed
- Updates stackdriver adapter to support Builder2

Changes in this PR:
* rename adapter/handler.go.Builder2 -> HandlerBuilder and delete the existing HandlerBuilder. So now Adapters implementing HandlerBuilder will have to implement (SetAdapterConfig, Validate() and Build(context..) functions)
* Change all adapters to pass NewBuilder in the Info object. 
```
CreateHandlerBuilder: func() adapter.HandlerBuilder { return &builder{m: sdmetric.NewBuilder(), l: log.NewBuilder()} },
-->
NewBuilder:    func() adapter.HandlerBuilder { return &builder{m: sdmetric.NewBuilder(), l: log.NewBuilder()} },
```
* Updated the existing builder implementation in tests and stackdriver adapters (most of the other adapters were already updated) to implemented (`Builder2` methods, which with this PR is renamed to HandlerBuider)
```
func (b *builder) SetMetricTypes(metrics map[string]*metric.Type) error 
-->
func (b *builder) SetMetricTypes(metrics map[string]*metric.Type)

func (b *builder) Build(c adapter.Config, env adapter.Env) (adapter.Handler, error) 
-->
func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error)

Added
+ func (b *builder) Validate() (ce *adapter.ConfigErrors)
+ func (b *builder) SetAdapterConfig(c adapter.Config) {
```
* Removed the ValidateConfigFn from adapters.Info and Mixer

TODOs (in next PR. I have already created issues for the below items):
- We are not calling validate config in runtime/handler.go. Currently we are only doing validation in validator.go. Need to fix that.
- Pass context to the handlerBuilder.Build method from validator.go and handler.go

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1231)
<!-- Reviewable:end -->
