### PR TITLE
JWT Token adapter

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -615,3 +615,15 @@ git_repository(
     commit = "b0822890273f91d5aa8c40ea1a89ba01e0f0ee9d",  # Aug 22, 2017
     remote = "https://github.com/istio/test-infra.git",
 )
+
+go_repository(
+    name = "com_github_asaskevich_govalidator",
+    commit = "15028e809df8c71964e8efa6c11e81d5c0262302", # Jul 30, 2017
+    importpath = "github.com/asaskevich/govalidator",
+)
+
+go_repository(
+    name = "com_github_dgrijalva_jwt-go",
+    commit = "a539ee1a749a2b895533f979515ac7e6e0f5b650", # June 8, 2017
+    importpath = "github.com/dgrijalva/jwt-go",
+)

--- a/adapter/BUILD
+++ b/adapter/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//adapter/statsd2:go_default_library",
         "//adapter/stdio:go_default_library",
         "//adapter/stdioLogger:go_default_library",
+        "//adapter/token:go_default_library",
         "//pkg/adapter:go_default_library",
     ],
 )

--- a/adapter/inventory.go
+++ b/adapter/inventory.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/mixer/adapter/serviceControl"
 	"istio.io/mixer/adapter/statsd"
 	"istio.io/mixer/adapter/stdioLogger"
+	"istio.io/mixer/adapter/token"
 	"istio.io/mixer/pkg/adapter"
 )
 
@@ -43,5 +44,6 @@ func Inventory() []adapter.RegisterFn {
 		stdioLogger.Register,
 		kubernetes.Register,
 		noop.Register,
+		token.Register,
 	}
 }

--- a/adapter/token/BUILD
+++ b/adapter/token/BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["token.go","adapterConfig.go","issuer.go","jwk.go","parser.go","localJWKTestServer.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//adapter/token/config:go_default_library",
+        "//pkg/adapter:go_default_library",
+        "//pkg/status:go_default_library",
+        "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_asaskevich_govalidator//:go_default_library",
+        "@com_github_dgrijalva_jwt-go//:go_default_library"
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["token_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/adapter:go_default_library",
+        "//pkg/adapterManager:go_default_library",
+        "//pkg/config:go_default_library",
+        "//pkg/adapter/test:go_default_library",
+    ],
+)

--- a/adapter/token/adapterConfig.go
+++ b/adapter/token/adapterConfig.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2017 IBM Corp. Licensed Materials - Property of IBM.
+
+package token
+
+import (
+	"crypto"
+	"regexp"
+	"time"
+
+	"github.com/asaskevich/govalidator"
+
+	"istio.io/mixer/adapter/token/config"
+	"istio.io/mixer/pkg/adapter"
+)
+
+const (
+	minPubkeyInterval = 60 * time.Second
+)
+
+//Config derived from adapter's config.pb
+type Config struct { // structure should not be marshaled to JSON, not even using defaults
+	Issuers         map[string]Issuer //supported issuers. tokens by other issuers will not be accepted.
+	PubKeysInterval time.Duration
+}
+
+//NewConfig creates a configuration object with default values
+func NewConfig(c adapter.Config) (*Config, error) {
+	cfg := &Config{
+		Issuers:         map[string]Issuer{},
+		PubKeysInterval: minPubkeyInterval,
+	}
+	params := c.(*config.Params)
+	//extract issuers from config:
+	for _, issuer := range params.Issuers {
+		//currently only jwt is supported:
+		iss := &jwtIssuer{
+			name:         issuer.Name,
+			pubKeysURL:   issuer.PubKeyUrl,
+			pubKeys:      map[string]crypto.PublicKey{},
+			claimNames:   issuer.ClaimNames,
+			claimRenames: issuer.ClaimRenames,
+		}
+		cfg.Issuers[iss.name] = iss
+	}
+
+	return cfg, nil
+}
+
+func validIssuerName(name string) bool {
+	return regexp.MustCompile("^[a-zA-z][a-zA-Z0-9_/:.-]+$").MatchString(name) //starts with a letter, and contains only URL characters
+}
+
+func (*tokenBuilder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
+	params := c.(*config.Params)
+	if len(params.Issuers) == 0 {
+		return // no issuers = default config
+	}
+	issuers := params.Issuers
+	for _, issuer := range issuers {
+		if issuer == nil {
+			ce = ce.Appendf("Issuer", "is nil")
+			continue
+		}
+		if len(issuer.Name) == 0 {
+			ce = ce.Appendf("Issuer.Name", "field must be populated")
+		} else if !validIssuerName(issuer.Name) {
+			ce = ce.Appendf("Issuer.Name", "contains invalid characters")
+		}
+		if len(issuer.PubKeyUrl) == 0 {
+			ce = ce.Appendf("Issuer.Url", "field must be populated")
+		} else if !govalidator.IsURL(issuer.PubKeyUrl) {
+			ce = ce.Appendf("Issuer.Url", "invalid: "+issuer.PubKeyUrl)
+		}
+		if issuer.ClaimNames != nil {
+			duplicateCatcher := make(map[string]bool)
+			for _, name := range issuer.ClaimNames {
+				if _, exists := duplicateCatcher[name]; !exists {
+					duplicateCatcher[name] = true
+				} else {
+					ce = ce.Appendf("Issuer.ClaimNames", "contains duplicates")
+					break
+				}
+			}
+		}
+	}
+	return
+}

--- a/adapter/token/adapterConfig.go
+++ b/adapter/token/adapterConfig.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017 IBM Corp. Licensed Materials - Property of IBM.
-
 package token
 
 import (

--- a/adapter/token/config/BUILD
+++ b/adapter/token/config/BUILD
@@ -1,0 +1,27 @@
+load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogoslick_proto_library")
+
+gogoslick_proto_library(
+    name = "go_default_library",
+    importmap = {
+        "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
+        "gogoproto/gogo.proto": "github.com/gogo/protobuf/gogoproto",
+    },
+    imports = [
+        "external/com_github_gogo_protobuf",
+        "external/com_github_google_protobuf/src",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_gogo_protobuf//gogoproto:go_default_library_protos",
+    ],
+    protos = [
+        "config.proto",
+    ],
+    verbose = 0,
+    visibility = ["//adapter/token:__pkg__"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_gogo_protobuf//sortkeys:go_default_library",
+    ],
+)

--- a/adapter/token/config/config.proto
+++ b/adapter/token/config/config.proto
@@ -1,0 +1,36 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package adapter.token.config;
+
+import "google/protobuf/duration.proto";
+import "gogoproto/gogo.proto";
+
+option go_package="config";
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
+
+message Issuer {
+    string name = 1;
+    string pubKeyUrl = 2;
+    repeated string claimNames = 3;
+    map<string, string> claimRenames = 4;
+}
+
+message Params {
+    repeated Issuer issuers = 1;
+}

--- a/adapter/token/issuer.go
+++ b/adapter/token/issuer.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2017 IBM Corp. Licensed Materials - Property of IBM.
+
+package token
+
+import (
+	"crypto"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/asaskevich/govalidator"
+)
+
+/*
+Issuer : Represents a token issuer, that issues tokens and provides public keys for validation of said tokens.
+The tokens issued can be of any kind, as long as there are available token parsers for that type (see parser.go)
+*/
+type Issuer interface {
+	//GetName : get the issuer's name
+	GetName() string
+	//GetPublicKey : get an issuer's public key by the key id. if no such key exists, KeyDoesNotExist error returned.
+	GetPublicKey(kid string) (crypto.PublicKey, error)
+	//UpdatePublicKeys : fetch once and update the public key cache of the issuer.
+	UpdatePublicKeys() error
+	//GetClaimNames: get the wanted claim names from tokens issued by this issuer.
+	GetClaimNames() []string
+	//GetClaimRenames: get the wanted claim rename mapping for claim names of tokens issued by this issuer.
+	GetClaimRenames() map[string]string
+}
+
+//Error when requesting an issuer for a key that does not exist
+type keyDoesNotExist struct{}
+
+func (k keyDoesNotExist) Error() string {
+	return "key does not exist"
+}
+
+//The default jwt token issuer, that maintains key according to the JOSE standard (jwk).
+type jwtIssuer struct {
+	name         string
+	pubKeysURL   string
+	pubKeys      map[string]crypto.PublicKey // (kid -> public key)
+	pubKeysTime  time.Time
+	claimNames   []string
+	claimRenames map[string]string
+	sync.RWMutex //sync accesses to key pools
+}
+
+//GetName : get the issuer's name
+func (iss *jwtIssuer) GetName() string {
+	return iss.name
+}
+
+//GetPublicKey : get an issuer's public by the key id. if no such key exists, KeyDoesNotExist error returned.
+func (iss *jwtIssuer) GetPublicKey(kid string) (crypto.PublicKey, error) {
+	iss.RLock()
+	defer iss.RUnlock()
+	if key := iss.pubKeys[kid]; key != nil {
+		return key, nil
+	}
+	return nil, keyDoesNotExist{}
+}
+
+//UpdateKeys : update the issuer's public key cache
+func (iss *jwtIssuer) UpdatePublicKeys() error {
+	if iss.pubKeysURL == "" {
+		return errors.New("Url for public keys for IAM must be provided")
+	}
+	if !govalidator.IsURL(iss.pubKeysURL) {
+		return errors.New("Public keys url for issuer " + iss.GetName())
+	}
+
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+	resp, err := client.Get(iss.pubKeysURL)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Failed to retrieve the public keys from %s with status: %d(%s)",
+			iss.pubKeysURL, resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var keys []key
+	var ks keySet
+
+	if err := json.Unmarshal(body, &ks); err == nil { // an RFC compliant JWK Set object, extract key array
+		keys = ks.Keys
+	} else if err := json.Unmarshal(body, &keys); err != nil { // attempt to decode as JWK array directly
+		return err
+	}
+
+	mkeys := make(map[string]crypto.PublicKey)
+	for i, k := range keys {
+		if k.Kid == "" {
+			return fmt.Errorf("Failed to parse the public key %d: kid is missing", i)
+		}
+
+		pubkey, err := k.decodePublicKey()
+		if err != nil {
+			return fmt.Errorf("Failed to parse the public key %d: %s", i, err)
+		}
+		mkeys[k.Kid] = pubkey
+	}
+
+	iss.Lock() // lock RW lock ot update key cache
+	defer iss.Unlock()
+
+	iss.pubKeysTime = time.Now()
+	if len(iss.pubKeys) != len(mkeys) || !reflect.DeepEqual(iss.pubKeys, mkeys) {
+		iss.pubKeys = mkeys //updating key cache
+	}
+
+	return nil
+}
+
+func (iss *jwtIssuer) GetClaimNames() []string {
+	return iss.claimNames
+}
+
+func (iss *jwtIssuer) GetClaimRenames() map[string]string {
+	return iss.claimRenames
+}

--- a/adapter/token/issuer.go
+++ b/adapter/token/issuer.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017 IBM Corp. Licensed Materials - Property of IBM.
-
 package token
 
 import (

--- a/adapter/token/jwk.go
+++ b/adapter/token/jwk.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017 IBM Corp. Licensed Materials - Property of IBM.
-
 package token
 
 import (

--- a/adapter/token/jwk.go
+++ b/adapter/token/jwk.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2017 IBM Corp. Licensed Materials - Property of IBM.
+
+package token
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data
+// structure that represents a cryptographic key (see RFC 7517).
+type key struct {
+	// The "kty" (key type) parameter identifies the cryptographic algorithm
+	// family used with the key, such as "RSA" or "EC".
+	Kty string `json:"kty"`
+
+	// The "use" (public key use) parameter identifies the intended use of
+	// the public key.  The "use" parameter is employed to indicate whether
+	// a public key is used for encrypting data or verifying the signature
+	// on data.
+	Use string `json:"use,omitempty"`
+
+	// The "kid" (key ID) parameter is used to match a specific key.  This
+	// is used, for instance, to choose among a set of keys within a JWK Set
+	// during key rollover.
+	Kid string `json:"kid,omitempty"`
+
+	// The "alg" (algorithm) parameter identifies the algorithm intended for
+	// use with the key.
+	Alg string `json:"alg,omitempty"`
+
+	Crv string `json:"crv,omitempty"` // EC Curve
+	X   string `json:"x,omitempty"`   // EC x coordinate
+	Y   string `json:"y,omitempty"`   // EC y coordinate
+	D   string `json:"d,omitempty"`   // RSA private exponent
+	N   string `json:"n,omitempty"`   // RSA modulus
+	E   string `json:"e,omitempty"`   // RSA public exponent
+	K   string `json:"k,omitempty"`   // oct key
+}
+
+// A JSON Web Key Set (JWK Set) is a JavaScript Object Notation (JSON) data
+// structure that represents a set of cryptographic key (see RFC 7517).
+type keySet struct {
+	// The 'keys' attribute is mandatory
+	Keys []key `json:"keys"`
+	// optional attributes may also be present but are currently ignored
+}
+
+// Decode as a public key
+func (k *key) decodePublicKey() (crypto.PublicKey, error) {
+	// The "kty" (key type) parameter identifies the cryptographic algorithm
+	// family used with the key, such as "RSA" or "EC".  "kty" values should
+	// either be registered in the IANA "JSON Web Key Types" registry
+	// established by [JWA] or be a value that contains a Collision-
+	// Resistant Name. The "kty" value is a case-sensitive string.
+	switch k.Kty {
+	case "RSA":
+		if k.N == "" || k.E == "" {
+			return nil, errors.New("Malformed JWK RSA key")
+		}
+
+		// decode exponent
+		data, err := safeDecode(k.E)
+		if err != nil {
+			return nil, errors.New("Malformed JWK RSA key")
+		}
+		if len(data) < 4 {
+			ndata := make([]byte, 4)
+			copy(ndata[4-len(data):], data)
+			data = ndata
+		}
+
+		pubKey := &rsa.PublicKey{
+			N: &big.Int{},
+			E: int(binary.BigEndian.Uint32(data[:])),
+		}
+
+		data, err = safeDecode(k.N)
+		if err != nil {
+			return nil, errors.New("Malformed JWK RSA key")
+		}
+		pubKey.N.SetBytes(data)
+
+		return pubKey, nil
+
+	case "EC":
+		if k.Crv == "" || k.X == "" || k.Y == "" {
+			return nil, errors.New("Malformed JWK EC key")
+		}
+
+		var curve elliptic.Curve
+		switch k.Crv {
+		case "P-224":
+			curve = elliptic.P224()
+		case "P-256":
+			curve = elliptic.P256()
+		case "P-384":
+			curve = elliptic.P384()
+		case "P-521":
+			curve = elliptic.P521()
+		default:
+			return nil, fmt.Errorf("Unknown curve type: %s", k.Crv)
+		}
+
+		pubKey := &ecdsa.PublicKey{
+			Curve: curve,
+			X:     &big.Int{},
+			Y:     &big.Int{},
+		}
+
+		data, err := safeDecode(k.X)
+		if err != nil {
+			return nil, fmt.Errorf("Malformed JWK EC key")
+		}
+		pubKey.X.SetBytes(data)
+
+		data, err = safeDecode(k.Y)
+		if err != nil {
+			return nil, fmt.Errorf("Malformed JWK EC key")
+		}
+		pubKey.Y.SetBytes(data)
+
+		return pubKey, nil
+
+	case "oct":
+		if k.K == "" {
+			return nil, errors.New("Malformed JWK octect key")
+		}
+
+		data, err := safeDecode(k.K)
+		if err != nil {
+			return nil, errors.New("Malformed JWK octect key")
+		}
+
+		return data, nil
+
+	default:
+		return nil, fmt.Errorf("Unknown JWK key type %s", k.Kty)
+	}
+}
+
+func safeDecode(str string) ([]byte, error) {
+	lenMod4 := len(str) % 4
+	if lenMod4 > 0 {
+		str = str + strings.Repeat("=", 4-lenMod4)
+	}
+
+	integer, err := base64.URLEncoding.DecodeString(str) // RFC 7517 compliant encoding
+	if err != nil {                                      // compensate for services that use base64 instead of base64url
+		return base64.StdEncoding.DecodeString(str)
+	}
+	return integer, err
+}
+
+//encode an integer representation of rsa exponent e into the corresponding base64 url-encoded string, according to the jwk RFC
+func encodeRSAE(e int) string {
+	bs := make([]byte, 4)
+	binary.BigEndian.PutUint32(bs, uint32(e))
+	var zeroPrefixIndex int
+	for i := range bs {
+		if bs[i] != 0 {
+			zeroPrefixIndex = i
+			break
+		}
+	}
+	bs = bs[zeroPrefixIndex:]
+	return base64.URLEncoding.EncodeToString(bs)
+}
+
+//encode a big integer representation of rsa modulus n into the corresponding base64 url-encoded string, according to the jwk RFC
+func encodeRSAN(n *big.Int) string {
+	bs := n.Bytes()
+	var zeroPrefixIndex int
+	for i := range bs {
+		if bs[i] != 0 {
+			zeroPrefixIndex = i
+			break
+		}
+	}
+	bs = bs[zeroPrefixIndex:]
+	return base64.URLEncoding.EncodeToString(bs)
+}
+
+//populate the e,n fields of the key json struct according to a given public key
+func (k *key) putRSAPublicKey(pubkey *rsa.PublicKey) {
+	k.E = encodeRSAE(pubkey.E)
+	k.N = encodeRSAN(pubkey.N)
+}

--- a/adapter/token/localJWKTestServer.go
+++ b/adapter/token/localJWKTestServer.go
@@ -1,0 +1,199 @@
+package token
+
+import (
+	cryptoRand "crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"math/big"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+/*
+A local JWK server used for testing the adapter. serves keys according to the JWK RFC https://tools.ietf.org/html/rfc7517
+*/
+
+const (
+	testServerPort         = "21356"
+	testServerKeysLocation = "/keys" //localhost
+	testServerAddr         = "http://localhost:" + testServerPort + testServerKeysLocation
+	testServerIssName      = "local"
+	//crypto testing constants.
+	//Using a predefined set of keys to allow testing of a persistent set of tokens.
+	e1          = 65537
+	n1          = "18738892009081519719845870431266951090046656171854280447005872078714046821952756050537228138106196550752508022019816731555094189004287665983819001535160668468594740189745339028257267968871048339993040577699838638277550476563233572454949402966399558670387670403570634026189554182981838554821158102488698440045977277902240961498131426869260113477807234364105166861405097632790020767744845422811128659685312246833069948729848729479918680024898335255952043297617273178616626827576955145484012521905279078436587772766821541705010996142708734415088364299426473567014523363379271183494202325991841529645373006457112060098691"
+	d1          = "450623217515487054312481373875470572621778997006917405198304078551861357575072760969325290227739532843827954326612923523060690020458021599867231432922062552550548705907176927667324630650484034725865266192455341164920877535798954944367307918809919655530936242977666344588167560193163824441127075842992336260616578549868695069084255035372638508617331247617855748686174305491692105123111908877677031643571626669535172414500727437213154924271748239398275022701288983617408179488878471389366581431859811133126440057869486820275198177720710216591859678216269566798431523359967046398157491673547936096993370444401599533505"
+	pf11        = "137483878809329042769707446870118861832684600046359643704369199548839215785525177146682858096094687372070938113731809940077887693595291334614103772697328221561165965309100428634939799182219205434922484431751230329493730682288646840164701105480168197718720255252997245082172606141223207712231322182003568420999"
+	pf12        = "136298831334761425809167231262704045381886074254611658280801111534947101798542852189623705888231711084522745051945489303395021854147228968644570132296609855955156383103750415170825484588671267524693523060582647834669763573819716087118645597969364633719149081195969166967837123524913316864198461676918371990309"
+	id1         = "1"
+	e2          = 65537
+	n2          = "26658957953236697552708592674599081539601909769135437983264396336208232986117022830573184468855487390454112595615638924035406523350193981653873954952458916378588190665393364059361957986455214182136446330546485792402548829317462029468047065758378998687394513321794064879425565607819155476399205755120729084609536540721277798169287677392646632336356691536716467336517077072971573775572197320061768310457236440835427606212147055095456081892397513460973811116465596136477523876533292387786887605271603371018145368387047488479432458660323845811456961985117210185715951453441833297390458575874612717922520361214054854152663"
+	pf21        = "166723200685882014193571146441857183092884521548753919894720712548455582909203385592343431387466127009946781640017314327837113563514516014395696360157512857177448158800569092433547776591271660671246201581702349700040522096081358932119233864019396529966018871375008447485530175912849622896260633181333330293787"
+	pf22        = "159899509147884038632862931597948599270924347531228992364878986822592193680714224767384304053858742301471116154931570373700983478968478282953925017232663946607129278051489510801378158804603842299070848025853283091336478855290464481487032201709094752992371420467698434292476967920390192649972794486283447983349"
+	d2          = "5310883242099246582055379189764035713887461036450131655545721631529284066508138152127248675181611049785142652980114771689370394874042641934677790497876064089580655466795485926408436813878561367807092837505758861492098776501347090296089575210055330681334555532437299709565286549211695590275234300301451682693102288624096514691128949947594591261255948183601048882968485353155140873746321068859878263384160725663632310802980595887254424374025115006794290572247259941828876950676384153853707242655255856161137167248806714800238827774357654522275030683789906678584657804382840143464549275931644179828567102619623960795137"
+	id2         = "2"
+	expDuration = 30000000 * time.Minute
+)
+
+type (
+	testJwkServer struct {
+		privKeys map[string]*rsa.PrivateKey //maps from key id to private key
+	}
+)
+
+func newTestServer() *testJwkServer {
+	var N1, _ = (&big.Int{}).SetString(n1, 10)
+	var PF11, _ = (&big.Int{}).SetString(pf11, 10)
+	var PF12, _ = (&big.Int{}).SetString(pf12, 10)
+	var D1, _ = (&big.Int{}).SetString(d1, 10)
+	var N2, _ = (&big.Int{}).SetString(n2, 10)
+	var PF21, _ = (&big.Int{}).SetString(pf21, 10)
+	var PF22, _ = (&big.Int{}).SetString(pf22, 10)
+	var D2, _ = (&big.Int{}).SetString(d2, 10)
+	var priv1 = &rsa.PrivateKey{rsa.PublicKey{N: N1, E: e1}, D1, []*big.Int{PF11, PF12}, rsa.PrecomputedValues{}}
+	var priv2 = &rsa.PrivateKey{rsa.PublicKey{N: N2, E: e2}, D2, []*big.Int{PF21, PF22}, rsa.PrecomputedValues{}}
+
+	return &testJwkServer{map[string]*rsa.PrivateKey{id1: priv1, id2: priv2}}
+}
+
+func (ts *testJwkServer) start() {
+	keySet := keySet{Keys: make([]key, 0)}
+	for kid, priv := range ts.privKeys {
+		key := key{Kty: "RSA", Kid: kid, Alg: "RS256"}
+		key.putRSAPublicKey(&priv.PublicKey)
+		keySet.Keys = append(keySet.Keys, key)
+	}
+	//starts the test server, listening for requests for the JWKs
+	http.HandleFunc(testServerKeysLocation, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(keySet)
+	})
+	http.ListenAndServe(":"+testServerPort, nil)
+}
+
+func (ts *testJwkServer) getKidAtRandom() (kid string) {
+	rand.Seed(time.Now().Unix())
+	i := rand.Intn(len(ts.privKeys))
+	var k string
+	for k = range ts.privKeys {
+		if i == 0 {
+			break
+		}
+		i--
+	}
+	return k
+}
+
+func (ts *testJwkServer) getValidNoClaimsToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["iss"] = testServerIssName                  //token issued by test issuer
+	claims["exp"] = time.Now().Add(expDuration).Unix() //not expired
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	testToken.Header["kid"] = kid
+	tokenString, _ := testToken.SignedString(ts.privKeys[kid])
+	return tokenString
+}
+
+func (ts *testJwkServer) getExpiredToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["iss"] = testServerIssName                        //token issued by test issuer
+	claims["exp"] = time.Now().Add(-30 * time.Minute).Unix() //expired
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	testToken.Header["kid"] = kid
+	tokenString, _ := testToken.SignedString(ts.privKeys[kid])
+	return tokenString
+}
+
+func (ts *testJwkServer) getLateNbfToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["iss"] = testServerIssName                       //token issued by test issuer
+	claims["exp"] = time.Now().Add(expDuration).Unix()      //not expired
+	claims["nbf"] = time.Now().Add(20 * time.Minute).Unix() //not valid yet
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	testToken.Header["kid"] = kid
+	tokenString, _ := testToken.SignedString(ts.privKeys[kid])
+	return tokenString
+}
+
+func (ts *testJwkServer) getNoIssToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["exp"] = time.Now().Add(expDuration).Unix() //not expired
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	testToken.Header["kid"] = kid
+	tokenString, _ := testToken.SignedString(ts.privKeys[kid])
+	return tokenString
+}
+
+func (ts *testJwkServer) getNoKidToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["iss"] = testServerIssName                  //token issued by test issuer
+	claims["exp"] = time.Now().Add(expDuration).Unix() //not expired
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	tokenString, _ := testToken.SignedString(ts.privKeys[kid])
+	return tokenString
+}
+
+func (ts *testJwkServer) getNoExpToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["iss"] = testServerIssName //token issued by test issuer
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	testToken.Header["kid"] = kid
+	tokenString, _ := testToken.SignedString(ts.privKeys[kid])
+	return tokenString
+}
+
+func (ts *testJwkServer) getInvalidToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["iss"] = testServerIssName                  //token issued by test issuer
+	claims["exp"] = time.Now().Add(expDuration).Unix() //not expired
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	testToken.Header["kid"] = kid
+	privatek, _ := rsa.GenerateKey(cryptoRand.Reader, 2048)
+	tokenString, _ := testToken.SignedString(privatek) //token signed by arbitrary key
+	return tokenString
+}
+
+func (ts *testJwkServer) getValidWithClaimsToken() string {
+	//build the test token:
+	claims := make(jwt.MapClaims)
+	claims["iss"] = testServerIssName                  //token issued by test issuer
+	claims["exp"] = time.Now().Add(expDuration).Unix() //not expired
+	claims["locations"] = make(map[string](map[string]int))
+	locations := claims["locations"].(map[string](map[string]int))
+	locations["us"] = map[string]int{
+		"ca": 3,
+		"ny": 5,
+		"dc": 10,
+	}
+	locations["israel"] = map[string]int{
+		"haifa":    3,
+		"tel-aviv": 5,
+	}
+	claims["servers"] = map[string][]string{
+		"ny":    {"jimmy", "carl", "eliot"},
+		"haifa": {"jake", "roey"},
+		"ca":    {},
+	}
+	claims["name"] = "johnDoe"
+	testToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	kid := ts.getKidAtRandom()
+	testToken.Header["kid"] = kid
+	tokenString, _ := testToken.SignedString(ts.privKeys[kid])
+	return tokenString
+}

--- a/adapter/token/parser.go
+++ b/adapter/token/parser.go
@@ -1,0 +1,90 @@
+package token
+
+import (
+	"fmt"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// @todo
+// validationErrorMissingAuthorizationHeader value relies on jwt.ValidationErrorClaimsInvalid being the last error
+// code in jwt package. Should probably use our own error wrapper type with specific redirect indication instead
+const (
+	_                                                = iota // ignore first value by assigning to blank identifier
+	ValidationErrorMissingAuthorizationHeader uint32 = jwt.ValidationErrorClaimsInvalid << iota
+)
+
+//A JWT token parser that works according to the JWT,JWS standards.
+type defaultJWTTokenParser struct {
+	supportedIssuers map[string]Issuer
+}
+
+//given a raw jwt token (type string), returns the parsed token (type *jwt.Token)
+func (j *defaultJWTTokenParser) Parse(rawToken interface{}, md *tokenMetaData) (interface{}, error) {
+	rt, ok := rawToken.(string)
+	if !ok {
+		return nil, fmt.Errorf("default JWT parser expects a raw token of type string, but recieved type %T instead", rawToken)
+	}
+	switch rt {
+	case "":
+		return nil, jwt.NewValidationError("Token is empty", ValidationErrorMissingAuthorizationHeader)
+	default:
+		md.ttype = "jwt"
+		token, err := jwt.Parse(rt, func(token *jwt.Token) (interface{}, error) {
+			if token.Method != nil && token.Method.Alg() != "none" { //"none" alg according to RFC
+				md.signed = true
+			}
+			if md.signed {
+				md.signAlg = token.Method.Alg()
+			}
+			kid, ok := token.Header["kid"].(string)
+			if kid == "" || !ok {
+				return nil, fmt.Errorf("kid is missing")
+			}
+			iss, exists := token.Claims.(jwt.MapClaims)["iss"]
+			if iss == "" || !exists {
+				return nil, fmt.Errorf("iss claim is missing")
+			}
+			exp, exists := token.Claims.(jwt.MapClaims)["exp"]
+			if !exists || exp == "" {
+				return nil, fmt.Errorf("exp claim is missing")
+			}
+			//if exp does exist, it's time validation is made by the jwt lib
+
+			relevantIssuer, exists := j.supportedIssuers[iss.(string)]
+			if !exists {
+				return nil, fmt.Errorf("%v is not a supported issuer", iss)
+			}
+
+			if _, ok := token.Method.(*jwt.SigningMethodRSA); ok {
+				//asymmetric key signing
+				pk, err := relevantIssuer.GetPublicKey(kid)
+				if err != nil {
+					return nil, err
+				}
+
+				return pk, nil
+			}
+			return nil, fmt.Errorf("unsupported signing method: %v. RSA supported", token.Header["alg"])
+		})
+
+		//handle validation errors:
+		if ve, ok := err.(*jwt.ValidationError); ok {
+			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
+				md.encrypted = true //assuming that an authorization header with bearer prefix but malformed token implies an encrypted token
+				md.ttype = "Unknown"
+				return nil, fmt.Errorf("token malformed")
+			} else if ve.Errors&(jwt.ValidationErrorExpired) != 0 {
+				// Token expired
+				return token, fmt.Errorf("token expired")
+			}
+		}
+
+		//handle non-validation errors:
+		if err != nil {
+			return nil, err
+		}
+
+		return token, nil
+	}
+}

--- a/adapter/token/token.go
+++ b/adapter/token/token.go
@@ -1,0 +1,264 @@
+package token
+
+//sample file to experiment with the istio mixer features
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/golang/glog"
+
+	"istio.io/mixer/adapter/token/config"
+	"istio.io/mixer/pkg/adapter"
+)
+
+const (
+	authHeaderKey = "authorizationHeader"
+	existsKey     = "request.token.exists"
+	encryptedKey  = "request.token.encrypted"
+	typeKey       = "request.token.type"
+	validKey      = "request.token.valid"
+	signedKey     = "request.token.signed"
+	signAlgKey    = "request.token.signAlg"
+	claimsKey     = "request.token.claims"
+)
+
+type (
+	// Builder implements all adapter.*Builder interfaces
+	tokenBuilder struct{ adapter.DefaultBuilder }
+	tokenAttrGen struct {
+		cfg *Config
+		//adapter environment
+		env adapter.Env
+		//context of key updating threads of all issuers supported by the server.
+		pubKeyContext context.Context
+		//cancel function of public key context
+		pubKeyCancel context.CancelFunc
+		//sync all key fetching
+		pubkeySync sync.WaitGroup
+		//sync server resources
+		sync.RWMutex
+	}
+	tokenMetaData struct {
+		encrypted bool
+		ttype     string
+		signed    bool
+		signAlg   string
+	}
+)
+
+var (
+	name = "token"
+	desc = "token attribute generating adapter"
+	conf = &config.Params{}
+)
+
+func newBuilder() *tokenBuilder {
+	return &tokenBuilder{
+		adapter.NewDefaultBuilder(name, desc, conf),
+	}
+}
+
+func (b *tokenBuilder) Close() error {
+	return nil
+}
+
+// Register registers the no-op adapter as every aspect.
+func Register(r adapter.Registrar) {
+	r.RegisterAttributesGeneratorBuilder(newBuilder())
+}
+
+// BuildAttributesGenerator creates an adapter.AttributesGenerator instance
+func (*tokenBuilder) BuildAttributesGenerator(env adapter.Env, cfg adapter.Config) (adapter.AttributesGenerator, error) {
+	config, err := NewConfig(cfg)
+	if err != nil {
+		return nil, errors.New("Failed generating token configuration")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ta := &tokenAttrGen{env: env, cfg: config, pubKeyContext: ctx, pubKeyCancel: cancel}
+
+	ta.fetchPublicKeys()
+
+	return ta, nil
+}
+
+func (ta tokenAttrGen) Generate(inputAttributes map[string]interface{}) (map[string]interface{}, error) {
+	tokenAttrs := make(map[string]interface{})
+
+	//default values:
+	tokenAttrs[existsKey] = false
+	tokenAttrs[encryptedKey] = false
+	tokenAttrs[typeKey] = ""
+	tokenAttrs[validKey] = false
+	tokenAttrs[signedKey] = false
+	tokenAttrs[signAlgKey] = ""
+	tokenAttrs[claimsKey] = make(map[string]string) //attribute ValueType STRING_MAP
+
+	authHeader, exists := inputAttributes[authHeaderKey]
+	ta.env.Logger().Warningf("auth: %v", authHeader)
+	if !exists || authHeader == nil || authHeader == "" {
+		ta.env.Logger().Infof("Request with no Authorization header made")
+		return tokenAttrs, nil
+	}
+	tokenAttrs[existsKey] = true
+	tokenAttrs[typeKey] = "Unknown"
+	rawToken, err := extractTokenFromAuthHeader(authHeader.(string))
+	if err != nil {
+		ta.env.Logger().Infof("Request with malformed Authorization header made")
+		return tokenAttrs, nil
+	}
+
+	metaData := &tokenMetaData{ttype: "Unknown", signAlg: "none", signed: false, encrypted: false}
+
+	//currently only JWT supported:
+	parser := &defaultJWTTokenParser{ta.cfg.Issuers}
+
+	parsedToken, err := parser.Parse(rawToken, metaData)
+	if err != nil {
+		ta.env.Logger().Infof("Failed validating token: %v , reason: %v", rawToken, err.Error())
+	} else {
+		//convert to jwt.Token and use the Header iss to get claim renames
+		tokenAttrs[validKey] = parsedToken.(*jwt.Token).Valid
+		if tokenAttrs[validKey].(bool) {
+
+			//extract claims:
+			tokenClaims := parsedToken.(*jwt.Token).Claims.(jwt.MapClaims)
+			tokenAttrs[claimsKey] = ta.extractClaimsFromJWT(tokenClaims)
+
+			//claim renamings:
+			if tokenAttrs != nil {
+				issName := tokenClaims["iss"].(string)
+				claimRenames := ta.cfg.Issuers[issName].GetClaimRenames()
+				for k, v := range claimRenames {
+					if _, exists := tokenAttrs[claimsKey].(map[string]string)[k]; !exists {
+						ta.env.Logger().Infof("requested to rename claim named: %v, to: %v, but no such claim requested or exists in the token", k, v)
+
+					}
+					temp := tokenAttrs[claimsKey].(map[string]string)[k]
+					delete(tokenAttrs[claimsKey].(map[string]string), k)
+					tokenAttrs[claimsKey].(map[string]string)[v] = temp
+				}
+			}
+
+		}
+	}
+	tokenAttrs[encryptedKey] = metaData.encrypted
+	tokenAttrs[signedKey] = metaData.signed
+	if tokenAttrs[signedKey].(bool) {
+		tokenAttrs[signAlgKey] = metaData.signAlg
+	}
+	tokenAttrs[typeKey] = metaData.ttype
+
+	return tokenAttrs, nil
+}
+
+func (ta tokenAttrGen) extractClaimsFromJWT(tokenClaims jwt.MapClaims) map[string]string {
+	claims := make(map[string]string)
+	//token is valid, meaning it has an iss claim that contains a name of a supported issuer
+	issName := tokenClaims["iss"].(string)
+	claimNames := ta.cfg.Issuers[issName].GetClaimNames()
+	if claimNames != nil && len(claimNames) > 0 {
+		for _, name := range claimNames {
+			hierarchyKeys := strings.Split(name, ".")
+			var nextHeirarchyValue map[string]interface{}
+			for i, nextKey := range hierarchyKeys {
+				var val interface{}
+				var exists bool
+				if i == 0 {
+					val, exists = tokenClaims[nextKey]
+				} else {
+					val, exists = nextHeirarchyValue[nextKey]
+				}
+				if !exists {
+					ta.env.Logger().Infof("requested claim name: %v, which wasn't provided with the given token", name)
+					break
+				}
+				if reflect.ValueOf(val).Kind() == reflect.Map && reflect.TypeOf(val).Key() == reflect.TypeOf("string") {
+					nextHeirarchyValue = val.(map[string]interface{})
+				} else if i < len(hierarchyKeys)-1 { //still more nested keys remain, but next value is not a map with string key types - cannot nest further
+					ta.env.Logger().Infof("requested claim name: %v, which wasn't provided with the given token", name)
+					break
+				}
+				if i == len(hierarchyKeys)-1 {
+					var claimString string
+					if reflect.TypeOf(val).Kind() == reflect.Map || reflect.TypeOf(val).Kind() == reflect.Slice || reflect.TypeOf(val).Kind() == reflect.Array {
+						byt, _ := json.Marshal(val)
+						claimString = string(byt)
+					} else {
+						claimString = fmt.Sprint(val)
+					}
+					claims[name] = claimString
+				}
+			}
+
+		}
+	}
+	return claims
+}
+
+func (ta *tokenAttrGen) Close() error {
+	glog.Info("Shutting down the token attribute generator")
+	ta.pubKeyCancel()
+	ta.pubkeySync.Wait()
+	return nil
+}
+
+//fetch the public keys of all supported issuers, and initialize fetching deamons.
+func (ta *tokenAttrGen) fetchPublicKeys() {
+	//initial fetching
+	var wg sync.WaitGroup
+	for _, issuer := range ta.cfg.Issuers {
+		wg.Add(1)
+		ta.env.ScheduleWork(
+			func(issuer Issuer) func() {
+				return func() {
+					if err := issuer.UpdatePublicKeys(); err != nil {
+						glog.Warningf("Error fetching public keys: " + err.Error())
+					}
+					wg.Done()
+				}
+			}(issuer))
+	}
+	wg.Wait()
+
+	//periodically refresh public keys until context termination:
+	for _, issuer := range ta.cfg.Issuers {
+		ta.pubkeySync.Add(1)
+		localTicker := time.NewTicker(ta.cfg.PubKeysInterval)
+		ta.env.ScheduleDaemon(
+			func(ctx context.Context, issuer Issuer) func() {
+				return func() {
+					for {
+						select {
+						case _, ok := <-ctx.Done():
+							if !ok {
+								ta.pubkeySync.Done()
+								localTicker.Stop()
+								return
+							}
+						case <-localTicker.C:
+							if err := issuer.UpdatePublicKeys(); err != nil {
+								glog.Warning("Error fetching public keys: " + err.Error())
+							}
+						}
+					}
+				}
+			}(ta.pubKeyContext, issuer))
+	}
+
+}
+
+func extractTokenFromAuthHeader(authHeader string) (string, error) {
+	parts := strings.SplitN(authHeader, " ", 3)
+	if len(parts) != 2 || (parts[0] != "Bearer" && parts[0] != "bearer") {
+		return "", fmt.Errorf("Invalid authorization header. expected \"bearer <token>\" or \"Bearer <token>\"")
+	}
+
+	return parts[1], nil
+}

--- a/adapter/token/token_test.go
+++ b/adapter/token/token_test.go
@@ -1,0 +1,595 @@
+package token
+
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	tokenConfig "istio.io/mixer/adapter/token/config"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/adapter/test"
+	"istio.io/mixer/pkg/adapterManager"
+	"istio.io/mixer/pkg/config"
+)
+
+func assertEquals(t *testing.T, expected interface{}, value interface{}) {
+	if reflect.TypeOf(expected) != reflect.TypeOf(value) {
+		t.Errorf("expected %v, but recieved %v", expected, value)
+		return
+	}
+	if expected != nil && reflect.TypeOf(expected).Kind() == reflect.Map {
+		if !reflect.DeepEqual(expected, value) {
+			t.Errorf("expected %v, but recieved %v", expected, value)
+		}
+	} else if expected != value {
+		t.Errorf("expected %v, but recieved %v", expected, value)
+	}
+}
+
+func TestRegisteredForAttributes(t *testing.T) {
+	builders := adapterManager.BuilderMap([]adapter.RegisterFn{Register})
+
+	k := config.AttributesKind
+	found := false
+	for _, token := range builders {
+		if token.Kinds.IsSet(k) {
+			found = true
+		}
+		if !found {
+			t.Errorf("The token adapter is not registered for kind %s", k)
+		}
+	}
+}
+
+func TestBasicLifecycle(t *testing.T) {
+	b := newBuilder()
+	env := test.NewEnv(t)
+	ta, err := b.BuildAttributesGenerator(env, b.DefaultConfig())
+	if err != nil {
+		t.Errorf("Unable to create aspect: %v", err)
+	}
+	if err := ta.Close(); err != nil {
+		t.Errorf("Unable to close aspect: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Errorf("Unable to close builder: %v", err)
+	}
+}
+
+func TestDefaultBuilderConf(t *testing.T) {
+	//default conf = empty conf
+	b := newBuilder()
+
+	if b.Name() == "" {
+		t.Error("Name() => all builders need names")
+	}
+
+	if b.Description() == "" {
+		t.Errorf("Description() => builder '%s' doesn't provide a valid description", b.Name())
+	}
+
+	c := b.DefaultConfig()
+	if err := b.ValidateConfig(c); err != nil {
+		t.Errorf("ValidateConfig() => builder '%s' can't validate its default configuration: %v", b.Name(), err)
+	}
+
+	if err := b.Close(); err != nil {
+		t.Errorf("Close() => builder '%s' fails to close when used with its default configuration: %v", b.Name(), err)
+	}
+}
+
+func TestConfig(t *testing.T) {
+	testConfigs := []struct {
+		name     string
+		conf     *tokenConfig.Params
+		errCount int
+	}{
+		{
+			"empty config (default)",
+			&tokenConfig.Params{},
+			0, //default empty config is valid - considered as having no issuers
+		},
+		{
+			"empty issuer array config",
+			&tokenConfig.Params{Issuers: make([]*tokenConfig.Issuer, 0)},
+			0, //config has an empty issuer array
+		},
+		{
+			"single empty issuer",
+			&tokenConfig.Params{Issuers: make([]*tokenConfig.Issuer, 1)},
+			1, //nil issuer
+		},
+		{
+			"invalid name",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "invalidchars>", PubKeyUrl: "https://pubkeys.org:5111"},
+				},
+			},
+			1, //invalid name character >
+		},
+		{
+			"invalid url",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "validchars", PubKeyUrl: "https://pubkeys..org::5111"},
+				},
+			},
+			1, //invalid url
+		},
+		{
+			"invalid name,url",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "3badstartingcharacter", PubKeyUrl: "www.pubkeys..org"},
+				},
+			},
+			2, //invalid url + name
+		},
+		{
+			"valid name,url",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "w3", PubKeyUrl: "W3.ibm.com/pubkeys:7670"},
+				},
+			},
+			0, //
+		},
+		{
+			"issuer with multiple mappings to the same claim name",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "w3", PubKeyUrl: "W3.ibm.com/pubkeys:7670", ClaimNames: []string{"dup", "dup", "sub"}},
+				},
+			},
+			1, //duplicate claim name
+		},
+		{
+			"issuer with empty claim names",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "w3", PubKeyUrl: "W3.ibm.com/pubkeys:7670", ClaimNames: []string{}},
+				},
+			},
+			0, //duplicate claim name
+		},
+	}
+
+	b := newBuilder()
+	for _, v := range testConfigs {
+		err := b.ValidateConfig(v.conf)
+		if err != nil && v.errCount == 0 {
+			t.Fatalf("Expected config: %v, to pass validation: %v, but got the following errors: %v", v.name, v.conf, err.Multi.Errors)
+		}
+		if err == nil && v.errCount != 0 {
+			t.Fatalf("Expected config: %v to fail validation, but it didn't: %v", v.name, v.conf)
+		}
+		if (err != nil && v.errCount != 0) && (len(err.Multi.Errors) != v.errCount) {
+			t.Fatalf("Expected config to generate %d errors; got %d ;\n errors: %v", v.errCount, len(err.Multi.Errors), err.Multi.Errors)
+		}
+	}
+}
+
+func TestIssuersFromConfig(t *testing.T) {
+	testConfigs := []struct {
+		name string
+		conf *tokenConfig.Params
+	}{
+		{
+			"empty config (default)",
+			&tokenConfig.Params{}, //default empty config is valid - no issuer objects will be created
+		},
+		{
+			"empty issuer array config",
+			&tokenConfig.Params{Issuers: make([]*tokenConfig.Issuer, 0)}, //no issuer objects will be created
+		},
+		{
+			"valid single issuer",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "w3", PubKeyUrl: "W3.iss1.com/pubkeys:7670"},
+				},
+			},
+		},
+		{
+			"valid single issuer with claim names and re-names",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "w3", PubKeyUrl: "W3.iss1.com/pubkeys:7670", ClaimNames: []string{"sub", "admin", "servers.NY.ip"}},
+				},
+			},
+		},
+		{
+			"valid multiple issuers",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "w3", PubKeyUrl: "W3.iss1.com/pubkeys:7670", ClaimNames: []string{"sub", "admin", "servers.NY.ip"}},
+					{Name: "giss", PubKeyUrl: "login.iss2.com/pubkeys:5120", ClaimNames: []string{"sub", "admin", "last-login"}},
+				},
+			},
+		},
+	}
+
+	for _, v := range testConfigs {
+		cfg, err := NewConfig(v.conf)
+		if err != nil {
+			t.Fatalf("Expected config: %v, to generate config issuer objects successfuly: %v, but got the following error: %v", v.name, v.conf, err)
+		}
+		if issNum := len(v.conf.Issuers); len(cfg.Issuers) != issNum {
+			t.Fatalf("Expected config: %v, to generate %v issuer objects, but got %v", v.name, issNum, len(cfg.Issuers))
+		}
+		for _, issuer := range v.conf.Issuers {
+			if _, exists := cfg.Issuers[issuer.Name]; !exists {
+				t.Fatalf("Expected config: %v, to create an issuer object named %v, but it didn't", v.name, issuer.Name)
+			}
+		}
+	}
+
+}
+
+func TestPubkeyFetch(t *testing.T) {
+	testConfigs := []struct {
+		name          string
+		conf          *tokenConfig.Params
+		isValidIssuer []bool
+	}{
+		{
+			"single working issuer",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "Iam", PubKeyUrl: "https://iam.ng.bluemix.net/oidc/jwks"},
+				},
+			},
+			[]bool{true},
+		},
+		{
+			"working issuer and more non-working issuers",
+			&tokenConfig.Params{
+				Issuers: []*tokenConfig.Issuer{
+					{Name: "Iam", PubKeyUrl: "https://iam.ng.bluemix.net/oidc/jwks"},
+					{Name: "almostIam", PubKeyUrl: "https://iam.ng.bluemix.net/oidc/jwksy"},
+					{Name: "jwks24/7", PubKeyUrl: "https://keys.all.day.org"},
+				},
+			},
+			[]bool{true, false, false},
+		},
+	}
+
+	for _, v := range testConfigs {
+
+		b := newBuilder()
+		env := test.NewEnv(t)
+		a, err := b.BuildAttributesGenerator(env, v.conf)
+		if err != nil {
+			t.Errorf("Unable to create aspect: %v", err)
+		}
+		ta := a.(*tokenAttrGen)
+		for i, issuer := range v.conf.Issuers {
+			iss := ta.cfg.Issuers[issuer.Name].(*jwtIssuer)
+			iss.RLock()
+			if v.isValidIssuer[i] && len(iss.pubKeys) <= 0 {
+				t.Errorf("Expected keys to be fetched from working issuer: %v, but they werent", iss.name)
+			}
+			if !v.isValidIssuer[i] && len(iss.pubKeys) > 0 {
+				t.Errorf("issuer: %v isn't real, didn't expect to find keys in cache.", iss.name)
+			}
+			iss.RUnlock()
+		}
+		if err := ta.Close(); err != nil {
+			t.Errorf("Unable to close aspect: %v", err)
+		}
+		if err := b.Close(); err != nil {
+			t.Errorf("Unable to close builder: %v", err)
+		}
+	}
+
+}
+
+func TestAttributes(t *testing.T) {
+
+	tokenConfMock := &tokenConfig.Params{
+		Issuers: []*tokenConfig.Issuer{
+			{Name: "Mock", PubKeyUrl: "mock.issuer.org"},
+		},
+	}
+
+	tokenConfIam := &tokenConfig.Params{
+		Issuers: []*tokenConfig.Issuer{
+			{Name: "https://iam.stage1.ng.bluemix.net/oidc/token", PubKeyUrl: "https://iam.stage1.ng.bluemix.net/oidc/jwks"},
+		},
+	}
+	expiredIAMToken := "eyJraWQiOiIyMDE3MDQwMS0wMDowMDowMCIsImFsZyI6IlJTMjU2In0.eyJpYW1faWQiOiJpYW0tU2VydmljZUlkLTcxZTk0MjVmLTNkM2EtNDY2NS1hOTg5LTY3NjlmOWViZGRhZiIsImlkIjoiaWFtLVNlcnZpY2VJZC03MWU5NDI1Zi0zZDNhLTQ2NjUtYTk4OS02NzY5ZjllYmRkYWYiLCJyZWFsbWlkIjoiaWFtIiwiaWRlbnRpZmllciI6IlNlcnZpY2VJZC03MWU5NDI1Zi0zZDNhLTQ2NjUtYTk4OS02NzY5ZjllYmRkYWYiLCJzdWIiOiJTZXJ2aWNlSWQtNzFlOTQyNWYtM2QzYS00NjY1LWE5ODktNjc2OWY5ZWJkZGFmIiwic3ViX3R5cGUiOiJTZXJ2aWNlSWQiLCJhY2NvdW50Ijp7ImJzcyI6ImQ1MTEyM2Q3NGFjODgwMDIxODlmN2U2ZjQ1Y2Y5ZTczIn0sImlhdCI6MTQ5OTk1OTUzMywiZXhwIjoxNDk5OTYzMTMzLCJpc3MiOiJodHRwczovL2lhbS5zdGFnZTEubmcuYmx1ZW1peC5uZXQvb2lkYy90b2tlbiIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoib3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCJ9.M43SSEZH_6tq8YVkvcZme1vVtCgYTM-YC_VHpgD_cgkwIs_a9JD0z9vAQQmI8zABBrwIyiZ61XeR40qaWUprsnOxL61CoGl5tsoK9mrwrmyMi5ODwnEZjXiGMgcfAi46ZRKyjiWXnNesyF3HRM9_Ckdbo2H17PIYFNDIael7YRKtr4fkMiDL-Ee5Yyz21eBtC6NFb8DEnx1vSLOd6SrfSjiC0NZOSmDeyewYd1S2ZAAlhRypocKYFUCFrheH0i7qN6zc08qa4HmWPJvJ64tiZ45EUaiFwpFTnIxSYTt0AHWfWrw9vh_aeVYxkwY17j2ozb1M8tthOx241Xd_QoRCOA"
+
+	tokenConfLocalServer := &tokenConfig.Params{
+		Issuers: []*tokenConfig.Issuer{
+			{Name: testServerIssName, PubKeyUrl: testServerAddr},
+		},
+	}
+	tokenConfLocalServerWithClaims := &tokenConfig.Params{
+		Issuers: []*tokenConfig.Issuer{
+			{Name: testServerIssName, PubKeyUrl: testServerAddr,
+				ClaimNames: []string{"name", "locations.us.ca", "servers.haifa"}},
+		},
+	}
+	tokenConfLocalServerWithClaimsandRenames := &tokenConfig.Params{
+		Issuers: []*tokenConfig.Issuer{
+			{Name: testServerIssName, PubKeyUrl: testServerAddr,
+				ClaimNames: []string{"name", "locations.us.ca", "servers.haifa"},
+				ClaimRenames: map[string]string{
+					"locations.us.ca": "ca",
+					"name":            "customerName",
+				},
+			},
+		},
+	}
+
+	ts := newTestServer()
+	go func() { ts.start() }()
+	for {
+		if _, err := http.Get(testServerAddr); err == nil {
+			break
+		}
+	}
+	testConfigs := []struct {
+		name                string
+		conf                *tokenConfig.Params
+		authHeader          string
+		predictedAttributes map[string]interface{}
+	}{
+		{
+			name:       "token doesn't exist",
+			conf:       tokenConfMock,
+			authHeader: "",
+			predictedAttributes: map[string]interface{}{
+				existsKey:    false,
+				encryptedKey: false,
+				typeKey:      "",
+				validKey:     false,
+				signedKey:    false,
+				signAlgKey:   "",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token exists but cannot be understood - not in the form of <type> <token>",
+			conf:       tokenConfMock,
+			authHeader: "a54fbd121a11a2fd3g343bb2bab1fada223ba",
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "Unknown",
+				validKey:     false,
+				signedKey:    false,
+				signAlgKey:   "",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token exists but cannot be understood 2 - more than just <type> <token> in header",
+			conf:       tokenConfMock,
+			authHeader: "Bearer a54fbd121a11a2fd3g343bb2bab1fada223ba abcdf",
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "Unknown",
+				validKey:     false,
+				signedKey:    false,
+				signAlgKey:   "",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token encrypted",
+			conf:       tokenConfMock,
+			authHeader: "bearer a54fbd121a11a2fd3g343bb2bab1fada223ba",
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: true,
+				typeKey:      "Unknown",
+				validKey:     false,
+				signedKey:    false,
+				signAlgKey:   "",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token encrypted 2",
+			conf:       tokenConfMock,
+			authHeader: "Bearer a54fbd121a11a2fd3g343bb2bab1fada223ba",
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: true,
+				typeKey:      "Unknown",
+				validKey:     false,
+				signedKey:    false,
+				signAlgKey:   "",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "expired token from IAM",
+			conf:       tokenConfIam,
+			authHeader: "Bearer " + expiredIAMToken,
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     false,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "valid token from local test server",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getValidNoClaimsToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     true,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "expired token from local test server",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getExpiredToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     false,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token with late nbf from local test server",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getLateNbfToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     false,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token with no iss claim from local test server",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getNoIssToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     false,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token with no kid in header from local test server",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getNoKidToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     false,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token with no exp in claims from local test server",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getNoExpToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     false,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "token with invalid signature from local test server",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getInvalidToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     false,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{},
+			},
+		},
+		{
+			name:       "valid token with claims from local test server - no claim names requested in configuration",
+			conf:       tokenConfLocalServer,
+			authHeader: "Bearer " + ts.getValidWithClaimsToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     true,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{}, //because the configuration does not specify claim names to be taken
+			},
+		},
+		{
+			name:       "valid token with claims from local test server",
+			conf:       tokenConfLocalServerWithClaims,
+			authHeader: "Bearer " + ts.getValidWithClaimsToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     true,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{"name": "johnDoe", "locations.us.ca": "3", "servers.haifa": "[\"jake\",\"roey\"]"}, //according to the configuration's "claimNames"
+			},
+		},
+		{
+			name:       "valid token with claims and claim renames from local test server",
+			conf:       tokenConfLocalServerWithClaimsandRenames,
+			authHeader: "Bearer " + ts.getValidWithClaimsToken(),
+			predictedAttributes: map[string]interface{}{
+				existsKey:    true,
+				encryptedKey: false,
+				typeKey:      "jwt",
+				validKey:     true,
+				signedKey:    true,
+				signAlgKey:   "RS256",
+				claimsKey:    map[string]string{"customerName": "johnDoe", "ca": "3", "servers.haifa": "[\"jake\",\"roey\"]"}, //according to the configuration's "claimNames"
+			},
+		},
+	}
+
+	for _, v := range testConfigs {
+		t.Logf("****checking matching attributes for setup \"%v\":****", v.name)
+		b := newBuilder()
+		env := test.NewEnv(t)
+		a, err := b.BuildAttributesGenerator(env, v.conf)
+		if err != nil {
+			t.Errorf("Unable to create aspect: %v", err)
+		}
+		ta := a.(*tokenAttrGen)
+		resAttributes, err := ta.Generate(map[string]interface{}{authHeaderKey: v.authHeader})
+		for key, val := range resAttributes {
+			t.Logf("checking that %v matches:", key)
+			assertEquals(t, v.predictedAttributes[key], val)
+		}
+	}
+
+}

--- a/testdata/configroot/scopes/global/adapters.yml
+++ b/testdata/configroot/scopes/global/adapters.yml
@@ -1,5 +1,9 @@
 subject: global
 adapters:
+  - name: token
+    kind: attributes
+    impl: token
+    params:
   - name: default
     kind: quotas
     impl: memQuota

--- a/testdata/configroot/scopes/global/descriptors.yml
+++ b/testdata/configroot/scopes/global/descriptors.yml
@@ -28,6 +28,23 @@ manifests:
         valueType: STRING
       target.serviceAccount:
         valueType: STRING
+  - name: token
+    revision: "1"
+    attributes:
+      request.token.exists:
+        valueType: BOOL
+      request.token.encrypted:
+        valueType: BOOL
+      request.token.type:
+        valueType: STRING
+      request.token.valid:
+        valueType: BOOL
+      request.token.signed:
+        valueType: BOOL
+      request.token.signAlg:
+        valueType: STRING
+      request.token.claims:
+        valueType: STRING_MAP
   - name: istio-proxy
     revision: "1"
     attributes:

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -26,6 +26,19 @@ rules:
         target.namespace: targetNamespace
         target.service: targetService
         target.serviceAccount: targetServiceAccountName
+  - kind: attributes
+    adapter: token
+    params:
+      input_expressions:
+        authorizationHeader: request.headers["authorization"] | ""
+      attribute_bindings:
+        request.token.exists: request.token.exists
+        request.token.encrypted: request.token.encrypted
+        request.token.type: request.token.type
+        request.token.valid: request.token.valid
+        request.token.signed: request.token.signed
+        request.token.signAlg: request.token.signAlg
+        request.token.claims: request.token.claims
   - kind: quotas
     params:
       quotas:


### PR DESCRIPTION
**Release note**:

```release-note
JWT Token attribute generating adapter.
used for token validation and policy definition based on token claims and metadata.

The adapter is configured with a list of token issuers, from which it accepts tokens and fetches public keys, according to the JWT,JWK standards.

See descriptors.yml for the list of attributes generated by the adapter

Examples:

example adapter params (in adapters.yml):
issuers:
-  name: "local" (needs to match the value of the token's "iss" claim)
   pubKeyUrl: "https://jwktestserver:21356/keys"
   claimNames: ['name','locations.us.ca','servers.haifa'] (requested claims to output, with hierarchical . notation)
   claimRenames:
     haifa: servers.haifa (ability to rename requested claims in the output)

example policy based on adapter's attributes:
rules:
- aspects:
  - kind: denials
  selector: request.token.valid==false || request.token.claims["name"]!="johnDoe"

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1232)
<!-- Reviewable:end -->
