### PR TITLE
Grand rename and switch off legacy check/report

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,7 +109,7 @@ go_x_tools_imports_repositories()
 
 go_googleapis_repositories()
 
-go_istio_api_repositories(True)
+go_istio_api_repositories(False)
 
 new_http_archive(
     name = "docker_ubuntu",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,7 +109,7 @@ go_x_tools_imports_repositories()
 
 go_googleapis_repositories()
 
-go_istio_api_repositories(False)
+go_istio_api_repositories(True)
 
 new_http_archive(
     name = "docker_ubuntu",

--- a/adapter/inventory.go
+++ b/adapter/inventory.go
@@ -15,32 +15,16 @@
 package adapter
 
 import (
-	"istio.io/mixer/adapter/denyChecker"
-	"istio.io/mixer/adapter/genericListChecker"
-	"istio.io/mixer/adapter/ipListChecker"
 	"istio.io/mixer/adapter/kubernetes"
 	"istio.io/mixer/adapter/memQuota"
 	"istio.io/mixer/adapter/noopLegacy"
-	"istio.io/mixer/adapter/prometheus"
-	"istio.io/mixer/adapter/redisquota"
-	"istio.io/mixer/adapter/serviceControl"
-	"istio.io/mixer/adapter/statsd"
-	"istio.io/mixer/adapter/stdioLogger"
 	"istio.io/mixer/pkg/adapter"
 )
 
 // InventoryLegacy returns the inventory of all available adapters.
 func InventoryLegacy() []adapter.RegisterFn {
 	return []adapter.RegisterFn{
-		denyChecker.Register,
-		genericListChecker.Register,
-		ipListChecker.Register,
 		memQuota.Register,
-		prometheus.Register,
-		redisquota.Register,
-		serviceControl.Register,
-		statsd.Register,
-		stdioLogger.Register,
 		kubernetes.Register,
 		noopLegacy.Register,
 	}

--- a/adapter/memquota2/dedup.go
+++ b/adapter/memquota2/dedup.go
@@ -105,7 +105,7 @@ func (du *dedupUtil) reapDedup() {
 	du.oldDedup = du.recentDedup
 	du.recentDedup = t
 
-	if du.logger.VerbosityLevel(4) {
+	if len(t) > 0 && du.logger.VerbosityLevel(4) {
 		du.logger.Infof("Running repear to reclaim %d old deduplication entries", len(t))
 	}
 

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -159,7 +159,7 @@ func serverCmd(info map[string]template.Info, adapters []adptr.InfoFn, printf, f
 	// Hide configIdentityAttribute and configIdentityAttributeDomain until we have a need to expose it.
 	// These parameters ensure that rest of Mixer makes no assumptions about specific identity attribute.
 	// Rules selection is based on scopes.
-	serverCmd.PersistentFlags().StringVarP(&sa.configIdentityAttribute, "configIdentityAttribute", "", "target.service",
+	serverCmd.PersistentFlags().StringVarP(&sa.configIdentityAttribute, "configIdentityAttribute", "", "destination.service",
 		"Attribute that is used to identify applicable scopes.")
 	if err := serverCmd.PersistentFlags().MarkHidden("configIdentityAttribute"); err != nil {
 		fatalf("unable to hide: %v", err)

--- a/istio_api.bzl
+++ b/istio_api.bzl
@@ -15,7 +15,7 @@
 ################################################################################
 #
 
-ISTIO_API_SHA = "a0ba5903ae2771eac13f80c3a936ed70fd3494d5"  # Aug 16, 2017 (no release)
+ISTIO_API_SHA = "5eca337930080b44b9b23c1c1e2cca14e12969ba"  # Sep 7, 2017 (no release)
 
 def go_istio_api_repositories(use_local=False):
     ISTIO_API_BUILD_FILE = """

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -98,7 +98,12 @@ func (c *compatBag) Get(name string) (v interface{}, found bool) {
 	if !strings.HasPrefix(name, "destination.") {
 		return
 	}
-	return c.parent.Get(strings.Replace(name, "destination.", "target.", 1))
+	compatAttr := strings.Replace(name, "destination.", "target.", 1)
+	v, found = c.parent.Get(compatAttr)
+	if found {
+		glog.Warningf("Deprecated attribute %s found", compatAttr)
+	}
+	return
 }
 
 func (c *compatBag) Names() []string {

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -411,11 +411,11 @@ func (p *validator) validateAspectRules(rules []*pb.AspectRule, path string, val
 
 func (p *validator) validateRules(rules []*pb.Rule, path string) (ce *adapter.ConfigErrors) {
 	for _, rule := range rules {
-		if err := p.validateSelector(rule.GetSelector(), p.descriptorFinder); err != nil {
-			ce = ce.Append(path+":Selector "+rule.GetSelector(), err)
+		if err := p.validateSelector(rule.GetMatch(), p.descriptorFinder); err != nil {
+			ce = ce.Append(path+":Selector "+rule.GetMatch(), err)
 		}
 
-		path = path + "/" + rule.GetSelector()
+		path = path + "/" + rule.GetMatch()
 		for idx, aa := range rule.GetActions() {
 			hasError := false
 
@@ -448,13 +448,6 @@ func (p *validator) validateRules(rules []*pb.Rule, path string) (ce *adapter.Co
 			if !hasError {
 				p.actions = append(p.actions, aa)
 			}
-		}
-		rs := rule.GetRules()
-		if len(rs) == 0 {
-			continue
-		}
-		if verr := p.validateRules(rs, path); verr != nil {
-			ce = ce.Extend(verr)
 		}
 	}
 	return ce

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -253,7 +253,7 @@ func TestFullConfigValidator(tt *testing.T) {
 			cok := ce == nil
 			ok := ctx.cerr == nil
 			if ok != cok {
-				t.Fatalf("%d got %t, want %t ", idx, cok, ok)
+				t.Fatalf("%d ok:= got %t, want %t ", idx, cok, ok)
 			}
 			if ce == nil {
 				return
@@ -366,7 +366,7 @@ const sSvcConfig1 = `
 subject: "namespace:ns"
 revision: "2022"
 rules:
-- match: service.name == “*”
+- selector: service.name == “*”
   aspects:
   - kind: metrics
     params:
@@ -381,7 +381,7 @@ const sSvcConfig2 = `
 subject: namespace:ns
 revision: "2022"
 rules:
-- match: service.name == “*”
+- selector: service.name == “*”
   aspects:
   - kind: lists
     inputs: {}
@@ -391,7 +391,7 @@ const sSvcConfig3 = `
 subject: namespace:ns
 revision: "2022"
 rules:
-- match: service.name == “*”
+- selector: service.name == “*”
   aspects:
   - kind: lists
     inputs: {}
@@ -402,7 +402,7 @@ const sSvcConfig = `
 subject: namespace:ns
 revision: "2022"
 rules:
-- match: %s
+- selector: %s
   aspects:
   - kind: metrics
     adapter: ""
@@ -1040,26 +1040,11 @@ action_rules:
   - instances:
     - RequestCountByService
 `
-	const sSvcConfigNestedMissingHandler = `
-subject: namespace:ns
-revision: "2022"
-action_rules:
-- selector: target.ip == "*"
-  actions:
-  - handler: somehandler
-    instances:
-    - RequestCountByService
-  rules:
-  - selector: source.ip == "*"
-    actions:
-    - instances:
-      - RequestCountByService
-`
 	const sSvcConfigInvalidSelector = `
 subject: namespace:ns
 revision: "2022"
 action_rules:
-- selector: == * == invalid
+- match: == * == invalid
   actions:
   - handler: somehandler
     instances:

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -1015,22 +1015,6 @@ action_rules:
     instances:
     - RequestCountByService
 `
-	const sSvcConfigNestedValid = `
-subject: namespace:ns
-revision: "2022"
-action_rules:
-- selector: target.service == "*"
-  actions:
-  - handler: somehandler
-    instances:
-    - RequestCountByService
-  rules:
-  - selector: target.service == "*"
-    actions:
-    - handler: somehandler
-      instances:
-      - RequestCountByService
-`
 	const sSvcConfigMissingHandler = `
 subject: namespace:ns
 revision: "2022"

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -366,7 +366,7 @@ const sSvcConfig1 = `
 subject: "namespace:ns"
 revision: "2022"
 rules:
-- selector: service.name == “*”
+- match: service.name == “*”
   aspects:
   - kind: metrics
     params:
@@ -381,7 +381,7 @@ const sSvcConfig2 = `
 subject: namespace:ns
 revision: "2022"
 rules:
-- selector: service.name == “*”
+- match: service.name == “*”
   aspects:
   - kind: lists
     inputs: {}
@@ -391,7 +391,7 @@ const sSvcConfig3 = `
 subject: namespace:ns
 revision: "2022"
 rules:
-- selector: service.name == “*”
+- match: service.name == “*”
   aspects:
   - kind: lists
     inputs: {}
@@ -402,7 +402,7 @@ const sSvcConfig = `
 subject: namespace:ns
 revision: "2022"
 rules:
-- selector: %s
+- match: %s
   aspects:
   - kind: metrics
     adapter: ""
@@ -412,7 +412,7 @@ rules:
       blacklist: true
       unknown_field: true
   rules:
-  - selector: src.name == "abc"
+  - match: src.name == "abc"
     aspects:
     - kind: quotas
       adapter: ""
@@ -1089,16 +1089,6 @@ action_rules:
 			evaluator,
 		},
 		{
-			"Nested Rule",
-			sSvcConfigNestedValid,
-			0,
-			map[string]*pb.Instance{"RequestCountByService": {Template: "tmp1"}},
-			map[string]*HandlerBuilderInfo{"somehandler": {supportedTemplates: []string{tmpl1}}},
-			nil,
-			2,
-			evaluator,
-		},
-		{
 			"HandlerNotFoundInstanceNotFound",
 			sSvcConfigValid,
 			2,
@@ -1116,16 +1106,6 @@ action_rules:
 			map[string]*HandlerBuilderInfo{"somehandler": {}},
 			[]string{"handler not specified or is invalid"},
 			0,
-			evaluator,
-		},
-		{
-			"MissingHandlerNestedCnfg",
-			sSvcConfigNestedMissingHandler,
-			1,
-			map[string]*pb.Instance{"RequestCountByService": {Template: "tmp1"}},
-			map[string]*HandlerBuilderInfo{"somehandler": {supportedTemplates: []string{tmpl1}}},
-			[]string{"handler not specified or is invalid"},
-			1,
 			evaluator,
 		},
 		{

--- a/pkg/runtime/controller.go
+++ b/pkg/runtime/controller.go
@@ -359,7 +359,7 @@ func (c *Controller) processRules(handlerConfig map[string]*cpb.Handler,
 		cfg := obj.Spec
 		rulec := cfg.(*cpb.Rule)
 		rule := &Rule{
-			selector: rulec.Selector,
+			selector: rulec.Match,
 			name:     k.Name,
 			rtype:    resourceType(obj.Metadata.Labels),
 		}

--- a/pkg/runtime/controller_test.go
+++ b/pkg/runtime/controller_test.go
@@ -197,7 +197,7 @@ func TestController_workflow(t *testing.T) {
 		{
 			Key: store.Key{RulesKind, DefaultConfigNamespace, "r2"},
 			Value: &store.Resource{Spec: &cpb.Rule{
-			Match: "target.service == \"bcd\"",
+				Match: "target.service == \"bcd\"",
 				Actions: []*cpb.Action{
 					{
 						Handler:   "a1.AA." + DefaultConfigNamespace,

--- a/pkg/runtime/controller_test.go
+++ b/pkg/runtime/controller_test.go
@@ -133,7 +133,7 @@ func TestController_workflow(t *testing.T) {
 	}
 	configState := map[store.Key]*store.Resource{
 		{RulesKind, DefaultConfigNamespace, "r1"}: {Spec: &cpb.Rule{
-			Selector: "target.service == \"abc\"",
+			Match: "target.service == \"abc\"",
 			Actions: []*cpb.Action{
 				{
 					Handler:   "a1.AA." + DefaultConfigNamespace,
@@ -197,7 +197,7 @@ func TestController_workflow(t *testing.T) {
 		{
 			Key: store.Key{RulesKind, DefaultConfigNamespace, "r2"},
 			Value: &store.Resource{Spec: &cpb.Rule{
-				Selector: "target.service == \"bcd\"",
+			Match: "target.service == \"bcd\"",
 				Actions: []*cpb.Action{
 					{
 						Handler:   "a1.AA." + DefaultConfigNamespace,

--- a/testdata/config/attributes.yaml
+++ b/testdata/config/attributes.yaml
@@ -51,6 +51,8 @@ spec:
         valueType: STRING
       target.uid:
         valueType: STRING
+      destination.uid:
+        valueType: STRING
       connection.id:
         valueType: STRING
       connection.received.bytes:
@@ -103,5 +105,17 @@ spec:
       target.service:
         valueType: STRING
       target.serviceAccount:
+        valueType: STRING
+      destination.ip:
+        valueType: IP_ADDRESS
+      destination.labels:
+        valueType: STRING_MAP
+      destination.name:
+        valueType: STRING
+      destination.namespace:
+        valueType: STRING
+      destination.service:
+        valueType: STRING
+      destination.serviceAccount:
         valueType: STRING
 

--- a/testdata/config/deny.yaml
+++ b/testdata/config/deny.yaml
@@ -22,7 +22,7 @@ metadata:
   name: mixerdenysome
   namespace: istio-config-default
 spec:
-  selector: request.headers["clnt"] == "abc"
+  match: request.headers["clnt"] == "abc"
   actions:
   # handler and instance names default to the rule's namespace.
   - handler: denyall.denier

--- a/testdata/config/metrics.yaml
+++ b/testdata/config/metrics.yaml
@@ -12,6 +12,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -27,6 +28,8 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"UNSPECIFIED"'
+
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -42,6 +45,8 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"UNSPECIFIED"'
+
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -57,3 +62,4 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"UNSPECIFIED"'

--- a/testdata/config/prometheus.yaml
+++ b/testdata/config/prometheus.yaml
@@ -41,7 +41,7 @@ metadata:
   name: prommetrics
   namespace: istio-config-default
 spec:
-  selector: "true"
+  #match: request.method == "/login"
   actions:
   - handler: handler.prometheus.istio-config-default
     instances:

--- a/testdata/config/prometheus.yaml
+++ b/testdata/config/prometheus.yaml
@@ -41,7 +41,6 @@ metadata:
   name: prommetrics
   namespace: istio-config-default
 spec:
-  #match: request.method == "/login"
   actions:
   - handler: handler.prometheus.istio-config-default
     instances:

--- a/testdata/config/quota.yaml
+++ b/testdata/config/quota.yaml
@@ -25,7 +25,7 @@ metadata:
   name: quota
   namespace: istio-config-default
 spec:
-#  selector: request.headers["user"] != "admin"
+#  match: source.user  != "admin"
   actions:
   - handler: handler.memquota
     instances:

--- a/testdata/config/stackdriver.yaml
+++ b/testdata/config/stackdriver.yaml
@@ -51,7 +51,7 @@ metadata:
   name: stackdriver
   namespace: istio-config-default
 spec:
-  selector: "true"
+  match: "true" # If omitted match is true.
   actions:
   - handler: stackdriver.stackdriver.istio-config-default
     instances:

--- a/testdata/configroot/scopes/global/adapters.yml
+++ b/testdata/configroot/scopes/global/adapters.yml
@@ -5,16 +5,6 @@ adapters:
     impl: memQuota
     params:
   - name: default
-    impl: stdioLogger
-    params:
-      logStream: STDERR
-      omitEmptyFields: true
-  - name: prometheus
-    kind: metrics
-    impl: prometheus
-  - name: default
-    impl: denyChecker
-  - name: default
     kind: attributes
     impl: kubernetes
     params:

--- a/testdata/configroot/scopes/global/descriptors.yml
+++ b/testdata/configroot/scopes/global/descriptors.yml
@@ -28,6 +28,18 @@ manifests:
         valueType: STRING
       target.serviceAccount:
         valueType: STRING
+      destination.ip:
+        valueType: IP_ADDRESS
+      destination.labels:
+        valueType: STRING_MAP
+      destination.name:
+        valueType: STRING
+      destination.namespace:
+        valueType: STRING
+      destination.service:
+        valueType: STRING
+      destination.serviceAccount:
+        valueType: STRING
   - name: istio-proxy
     revision: "1"
     attributes:
@@ -98,118 +110,6 @@ manifests:
       # DEPRECATED, to be removed. Use request.useragent instead.
       request.user-agent:
         valueType: STRING
-# Enums as struct fields can be symbolic names.
-# However enums inside maps *cannot* be symbolic names.
-metrics:
-  - name: request_count
-    kind: COUNTER
-    value: INT64
-    description: request count by source, target, service, and code
-    labels:
-      source: 1 # STRING
-      target: 1 # STRING
-      service: 1 # STRING
-      method: 1 # STRING
-      version: 1 # STRING
-      response_code: 2 # INT64
-  - name: request_duration
-    kind: DISTRIBUTION
-    value: DURATION
-    description: request duration by source, target, and service
-    buckets:
-      explicit_buckets:
-        bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-    # Examples of other possible bucket configurations:
-    #      linear_buckets:
-    #         num_finite_buckets: 10
-    #         offset: 0.001
-    #         width: 0.1
-    #      exponential_buckets:
-    #        num_finite_buckets: 15
-    #        scale: 0.001
-    #        growth_factor: 4
-    labels:
-      source: 1 # STRING
-      target: 1 # STRING
-      service: 1 # STRING
-      method: 1 # STRING
-      version: 1 # STRING
-      response_code: 2 # INT64
-  - name: request_size
-    kind: DISTRIBUTION
-    value: INT64
-    description: request size by source, target, and service
-    buckets:
-      exponentialBuckets:
-        numFiniteBuckets: 8
-        scale: 1
-        growthFactor: 10
-    # Examples of other possible bucket configurations:
-    #      explicit_buckets:
-    #         bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-    #      linear_buckets:
-    #         num_finite_buckets: 10
-    #         offset: 0.001
-    #         width: 0.1
-    labels:
-      source: 1 # STRING
-      target: 1 # STRING
-      service: 1 # STRING
-      method: 1 # STRING
-      version: 1 # STRING
-      response_code: 2 # INT64
-  - name: response_size
-    kind: DISTRIBUTION
-    value: INT64
-    description: response size by source, target, and service
-    buckets:
-      exponentialBuckets:
-        numFiniteBuckets: 8
-        scale: 1
-        growthFactor: 10
-    # Examples of other possible bucket configurations:
-    #      explicitBuckets:
-    #         bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-    #      linearBuckets:
-    #         numFiniteBuckets: 10
-    #         offset: 0.001
-    #         width: 0.1
-    labels:
-      source: 1 # STRING
-      target: 1 # STRING
-      service: 1 # STRING
-      method: 1 # STRING
-      version: 1 # STRING
-      response_code: 2 # INT64
 quotas:
   - name: RequestCount
     rate_limit: true
-logs:
-  - name: accesslog.common
-    display_name: Apache Common Log Format
-    payload_format: TEXT
-    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}'
-    labels:
-      originIp: 6 # IP_ADDRESS
-      sourceUser: 1 # STRING
-      timestamp: 5 # TIMESTAMP
-      method: 1 # STRING
-      url: 1 # STRING
-      protocol: 1 # STRING
-      responseCode: 2 # INT64
-      responseSize: 2 # INT64
-  - name: accesslog.combined
-    display_name: Apache Combined Log Format
-    payload_format: TEXT
-    log_template: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}} {{or (.referer) "-"}} {{or (.userAgent) "-"}}'
-    labels:
-      originIp: 6 # IP_ADDRESS
-      sourceUser: 1 # STRING
-      timestamp: 5 # TIMESTAMP
-      method: 1 # STRING
-      url: 1 # STRING
-      protocol: 1 # STRING
-      responseCode: 2 # INT64
-      responseSize: 2 # INT64
-      referer: 1 # STRING
-      userAgent: 1 # STRING

--- a/testdata/configroot/scopes/global/descriptors.yml
+++ b/testdata/configroot/scopes/global/descriptors.yml
@@ -40,6 +40,8 @@ manifests:
         valueType: STRING
       destination.serviceAccount:
         valueType: STRING
+      destination.uid:
+        valueType: STRING
   - name: istio-proxy
     revision: "1"
     attributes:

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -11,8 +11,8 @@ rules:
       input_expressions:
         sourceUID: source.uid | ""
         sourceIP: source.ip | ip("0.0.0.0") # default to unspecified ip addr
-        targetUID: target.uid | ""
-        targetIP: target.ip | ip("0.0.0.0") # default to unspecified ip addr
+        targetUID: destination.uid | ""
+        targetIP: destination.ip | ip("0.0.0.0") # default to unspecified ip addr
       attribute_bindings:
         source.ip: sourcePodIp
         source.labels: sourceLabels
@@ -20,61 +20,16 @@ rules:
         source.namespace: sourceNamespace
         source.service: sourceService
         source.serviceAccount: sourceServiceAccountName
-        target.ip: targetPodIp
-        target.labels: targetLabels
-        target.name: targetPodName
-        target.namespace: targetNamespace
-        target.service: targetService
-        target.serviceAccount: targetServiceAccountName
+        destination.ip: targetPodIp
+        destination.labels: targetLabels
+        destination.name: targetPodName
+        destination.namespace: targetNamespace
+        destination.service: targetService
+        destination.serviceAccount: targetServiceAccountName
   - kind: quotas
     params:
       quotas:
       - descriptorName: RequestCount
         maxAmount: 5000
         expiration: 1s
-  - kind: metrics
-    adapter: prometheus
-    params:
-      metrics:
-      - descriptor_name: request_count
-        # we want to increment this counter by 1 for each unique (source, target, service, method, response_code) tuple
-        value: "1"
-        labels:
-          source: source.labels["app"] | "unknown"
-          target: target.service | "unknown"
-          service: target.labels["app"] | "unknown"
-          method: request.path | "unknown"
-          version: target.labels["version"] | "unknown"
-          response_code: response.code | 200
-      - descriptor_name:  request_duration
-        value: response.latency | response.duration | "0ms"
-        labels:
-          source: source.labels["app"] | "unknown"
-          target: target.service | "unknown"
-          service: target.labels["app"] | "unknown"
-          method: request.path | "unknown"
-          version: target.labels["version"] | "unknown"
-          response_code: response.code | 200
-  - kind: access-logs
-    params:
-      logName: access_log
-      log:
-        descriptor_name: accesslog.common
-        template_expressions:
-           originIp: origin.ip
-           sourceUser: origin.user
-           timestamp: request.time
-           method: request.method
-           url: request.path
-           protocol: request.scheme
-           responseCode: response.code
-           responseSize: response.size
-        labels:
-           originIp: origin.ip
-           sourceUser: origin.user
-           timestamp: request.time
-           method: request.method
-           url: request.path
-           protocol: request.scheme
-           responseCode: response.code
-           responseSize: response.size
+

--- a/testdata/configroot/scopes/global/subjects/myservice.ns.svc/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/myservice.ns.svc/rules.yml
@@ -1,6 +1,0 @@
-subject: namespace:ns
-revision: "2022"
-rules:
-- aspects:
-  - kind: denials
- 


### PR DESCRIPTION
1. Rename rule.selector to rule.match
   Accept "selector" in yaml with a  deprecation warning.
2. Rename target.* to destination.*
    Look for target.* if destination.* is not present. 
3. Remove legacy check and report calls. 
4. Remove chck/report legacy adapters. Keep K8s and memquota
5. Purge legacy config files of unnecessary sections.
**Release note**:
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1237)
<!-- Reviewable:end -->
