### PR TITLE
Update linters, pre-commit, and pre-push hooks

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run local pre-commit hook
 #
 # If called directly install pre-commit hook
@@ -29,6 +29,9 @@ fi
 BRANCH_NAME=$(git branch | grep '*' | sed 's/* //')
 if [ $BRANCH_NAME != '(no branch)' ]; then
   cd $ROOT
+
+  echo "ensuring go environment setup for fmt..."
+  bin/bazel_to_go.py
 
   echo "formatting..."
   bin/fmt.sh

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -29,4 +29,4 @@ if ! [[ -f WORKSPACE ]]; then
 fi
 
 bazel test --features=race //...
-bin/linters.sh
+bin/linters.sh -c upstream/master


### PR DESCRIPTION
Update:
- linter script to always skip //bin and //testdata
- the linter script's invocation in the pre-push script to set the branch to diff against to upstream/master, vastly reducing the amount linted from the entire repo to only the packages your PR touched relative to upstream/master.
- always run ./bin/bazel_to_go.py before running ./bin/fmt.sh to avoid fmt changing a ton of stuff due to the golang representation of our repo not matching the latest state.

I was able to actually use `git push` to send this PR rather than the `git push --no-verify` I've been doing for weeks now. Big improvement.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1248)
<!-- Reviewable:end -->
