### PR TITLE
Better error (instead of silent failing at runtime) for bad adapters

### DIFF
--- a/pkg/runtime/handler.go
+++ b/pkg/runtime/handler.go
@@ -98,21 +98,21 @@ func (h *handlerFactory) Build(handler *pb.Handler, instances []*pb.Instance, en
 	}
 
 	// HandlerBuilder should always be present for a valid configuration (reference integrity should already be checked).
-	hndlrBldrInfo, _ := h.builderInfoFinder(handler.Adapter)
+	info, _ := h.builderInfoFinder(handler.Adapter)
 
-	hndlrBldr := hndlrBldrInfo.NewBuilder()
+	bldr := info.NewBuilder()
 
-	if hndlrBldr == nil {
+	if bldr == nil {
 		msg := fmt.Sprintf("nil HandlerBuilder instantiated for adapter '%s' in handler config '%s'", handler.Adapter, handler.Name)
 		glog.Warning(msg)
 		return nil, errors.New(msg)
 	}
 
 	// validate if the builder supports all the necessary interfaces
-	for _, tmplName := range hndlrBldrInfo.SupportedTemplates {
+	for _, tmplName := range info.SupportedTemplates {
 		// ti should be there for a valid configuration.
 		ti, _ := h.tmplRepo.GetTemplateInfo(tmplName)
-		if supports := ti.BuilderSupportsTemplate(hndlrBldr); !supports {
+		if supports := ti.BuilderSupportsTemplate(bldr); !supports {
 			// adapter's builder is bad since it does not support the necessary interface
 			msg := fmt.Sprintf("adapter is invalid because it does not implement interface '%s'. "+
 				"Therefore, it cannot support template '%s'", ti.BldrInterfaceName, tmplName)
@@ -122,14 +122,14 @@ func (h *handlerFactory) Build(handler *pb.Handler, instances []*pb.Instance, en
 	}
 
 	var hndlr adapter.Handler
-	hndlr, err = h.build(hndlrBldr, infrdTypsByTmpl, handler.Params, env)
+	hndlr, err = h.build(bldr, infrdTypsByTmpl, handler.Params, env)
 	if err != nil {
 		msg := fmt.Sprintf("cannot configure adapter '%s' in handler config '%s': %v", handler.Adapter, handler.Name, err)
 		glog.Warning(msg)
 		return nil, errors.New(msg)
 	}
 	// validate if the handler supports all the necessary interfaces
-	for _, tmplName := range hndlrBldrInfo.SupportedTemplates {
+	for _, tmplName := range info.SupportedTemplates {
 		// ti should be there for a valid configuration.
 		ti, _ := h.tmplRepo.GetTemplateInfo(tmplName)
 		if supports := ti.HandlerSupportsTemplate(hndlr); !supports {
@@ -144,8 +144,8 @@ func (h *handlerFactory) Build(handler *pb.Handler, instances []*pb.Instance, en
 	return hndlr, err
 }
 
-func (h *handlerFactory) build(hndlrBldr adapter.HandlerBuilder, infrdTypesByTmpl map[string]typeMap,
-	adapterCnfg interface{}, env adapter.Env) (handler adapter.Handler, err error) {
+func (h *handlerFactory) build(bldr adapter.HandlerBuilder, infrdTypesByTmpl map[string]typeMap,
+	adapterCnfg interface{}, env adapter.Env) (hndlr adapter.Handler, err error) {
 	var ti template.Info
 	var typs typeMap
 
@@ -155,7 +155,7 @@ func (h *handlerFactory) build(hndlrBldr adapter.HandlerBuilder, infrdTypesByTmp
 			msg := fmt.Sprintf("handler panicked with '%v' when trying to configure the associated adapter."+
 				" Please remove the handler or fix the configuration. %v\nti=%v\ntype=%v", r, adapterCnfg, ti, typs)
 			glog.Error(msg)
-			handler = nil
+			hndlr = nil
 			err = errors.New(msg)
 			return
 		}
@@ -165,19 +165,19 @@ func (h *handlerFactory) build(hndlrBldr adapter.HandlerBuilder, infrdTypesByTmp
 		typs = infrdTypesByTmpl[tmplName]
 		// ti should be there for a valid configuration.
 		ti, _ = h.tmplRepo.GetTemplateInfo(tmplName)
-		ti.SetType(typs, hndlrBldr)
+		ti.SetType(typs, bldr)
 	}
-	hndlrBldr.SetAdapterConfig(adapterCnfg.(proto.Message))
+	bldr.SetAdapterConfig(adapterCnfg.(proto.Message))
 	// validate and only construct if the validation passes.
-	if ce := hndlrBldr.Validate(); ce != nil {
+	if ce := bldr.Validate(); ce != nil {
 		msg := fmt.Sprintf("handler validation failed: %s", ce.Error())
 		glog.Error(msg)
-		handler = nil
+		hndlr = nil
 		err = errors.New(msg)
 		return
 	}
 
-	return hndlrBldr.Build(context.Background(), env)
+	return bldr.Build(context.Background(), env)
 }
 
 func (h *handlerFactory) inferTypesGrpdByTmpl(instances []*pb.Instance) (map[string]typeMap, error) {


### PR DESCRIPTION
in case adapter code miss-spells methods and accidentally not implement required interfaces, we will now provide better error instead of logging and moving on.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1249)
<!-- Reviewable:end -->
