### PR TITLE
Use rbac+auth for e2e

### DIFF
--- a/prow/mixer-e2e-smoketest.sh
+++ b/prow/mixer-e2e-smoketest.sh
@@ -53,7 +53,7 @@ echo "=== Smoke Test ==="
 #
 # In the future, this should be parameterized similarly to the integration tests, with the kubeconfig
 # location specified explicitly.
-./prow/e2e-suite-rbac-no_auth.sh \
+./prow/e2e-suite-rbac-auth.sh \
     --mixer_hub="${HUB}" \
     --mixer_tag="${GIT_SHA}"
 


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
As decided, we are switching to use rbac-auth as e2e-gate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1251)
<!-- Reviewable:end -->
