### PR TITLE
Add TCP Check examples

### DIFF
--- a/pkg/adapter/check.go
+++ b/pkg/adapter/check.go
@@ -58,5 +58,5 @@ func (r *CheckResult) Combine(otherPtr interface{}) interface{} {
 }
 
 func (r *CheckResult) String() string {
-	return fmt.Sprintf("CheckResult: status:%d, duration:%d, usecount:%d", status.String(r.Status), r.ValidDuration, r.ValidDuration)
+	return fmt.Sprintf("CheckResult: status:%s, duration:%d, usecount:%d", status.String(r.Status), r.ValidDuration, r.ValidDuration)
 }

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -380,7 +380,7 @@ func Parse(src string) (ex *Expression, err error) {
 		return nil, fmt.Errorf("unable to parse expression '%s': %v", src, err)
 	}
 	if glog.V(4) {
-		glog.Infof("Parsed expression '%s' into '%s'", src, a)
+		glog.Infof("Parsed expression '%s' into '%v'", src, a)
 	}
 
 	ex = &Expression{}

--- a/pkg/expr/func.go
+++ b/pkg/expr/func.go
@@ -15,6 +15,7 @@
 package expr
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -124,6 +125,14 @@ func (f *eqFunc) call(args0 interface{}, args1 interface{}) bool {
 			return false
 		}
 		return matchWithWildcards(s0, s1)
+	case []byte:
+		if len(args0.([]byte)) == net.IPv4len || len(args0.([]byte)) == net.IPv6len {
+			// TODO: have the types be net.IP earlier, so this hack isn't necessary
+			ip1 := net.IP(args0.([]byte))
+			ip2 := net.IP(args1.([]byte))
+			return ip1.Equal(ip2)
+		}
+		return bytes.Equal(args0.([]byte), args1.([]byte))
 	}
 }
 

--- a/pkg/expr/func_test.go
+++ b/pkg/expr/func_test.go
@@ -16,6 +16,7 @@ package expr
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"testing"
 
@@ -49,6 +50,10 @@ func TestEQFunc(tt *testing.T) {
 		{"ns1.svc.local", "ns2.*", false},
 		{"svc1.ns1.cluster", "*.ns1.cluster", true},
 		{"svc1.ns1.cluster", "*.ns1.cluster1", false},
+		{net.ParseIP("10.3.25.1"), net.ParseIP("10.3.25.1"), true},
+		{net.ParseIP("10.3.25.1"), net.ParseIP("103.4.15.3"), false},
+		{[]byte{'a', 'b', 'e'}, []byte{'a', 'b', 'e'}, true},
+		{[]byte{'a', 'b', 'e'}, []byte{'a', 'b', 'e', 'z', 'z', 'z'}, false},
 	}
 	for idx, tst := range tbl {
 		tt.Run(fmt.Sprintf("[%d] %s", idx, tst.val), func(t *testing.T) {
@@ -56,7 +61,6 @@ func TestEQFunc(tt *testing.T) {
 			if rv != tst.equal {
 				tt.Errorf("[%d] %v ?= %v -- got %#v\nwant %#v", idx, tst.val, tst.match, rv, tst.equal)
 			}
-
 		})
 	}
 

--- a/pkg/il/compiler/compiler.go
+++ b/pkg/il/compiler/compiler.go
@@ -259,6 +259,15 @@ func (g *generator) generateEq(f *expr.Function, depth int) {
 			g.builder.EQDouble()
 		}
 
+	case il.Interface:
+		dvt, _ := f.Args[0].EvalType(g.finder, expr.FuncMap())
+		switch dvt {
+		case dpb.IP_ADDRESS:
+			g.builder.Call("ip_equal")
+		default:
+			g.internalError("equality for type not yet implemented: %v", exprType)
+		}
+
 	default:
 		g.internalError("equality for type not yet implemented: %v", exprType)
 	}

--- a/pkg/il/compiler/compiler_test.go
+++ b/pkg/il/compiler/compiler_test.go
@@ -987,6 +987,20 @@ end`,
   ret
 end`,
 	},
+	{
+		expr: `aip == bip`,
+		input: map[string]interface{}{
+			"aip": []byte{0x1, 0x2, 0x3, 0x4},
+			"bip": []byte{0x4, 0x5, 0x6, 0x7},
+		},
+		result: false,
+		code: `fn eval() bool
+  resolve_f "aip"
+  resolve_f "bip"
+  call ip_equal
+  ret
+end`,
+	},
 }
 
 var globalConfig = pb.GlobalConfig{
@@ -1086,8 +1100,16 @@ func TestCompile(t *testing.T) {
 				return []byte{}
 			})
 
+			ipEqualExtern := interpreter.ExternFromFn("ip_equal", func(a []byte, b []byte) bool {
+				// net.IP is an alias for []byte, so these are safe to convert
+				ip1 := net.IP(a)
+				ip2 := net.IP(b)
+				return ip1.Equal(ip2)
+			})
+
 			externMap := map[string]interpreter.Extern{
-				"ip": ipExtern,
+				"ip":       ipExtern,
+				"ip_equal": ipEqualExtern,
 			}
 
 			i := interpreter.New(result.Program, externMap)

--- a/pkg/il/evaluator/evaluator.go
+++ b/pkg/il/evaluator/evaluator.go
@@ -53,6 +53,7 @@ var _ expr.Evaluator = &IL{}
 var _ config.ChangeListener = &IL{}
 
 const ipFnName = "ip"
+const ipEqualFnName = "ip_equal"
 const matchFnName = "match"
 
 var ipExternFn = interpreter.ExternFromFn(ipFnName, func(in string) ([]byte, error) {
@@ -60,6 +61,13 @@ var ipExternFn = interpreter.ExternFromFn(ipFnName, func(in string) ([]byte, err
 		return []byte(ip), nil
 	}
 	return []byte{}, fmt.Errorf("could not convert %s to IP_ADDRESS", in)
+})
+
+var ipEqualExternFn = interpreter.ExternFromFn(ipEqualFnName, func(a []byte, b []byte) bool {
+	// net.IP is an alias for []byte, so these are safe to convert
+	ip1 := net.IP(a)
+	ip2 := net.IP(b)
+	return ip1.Equal(ip2)
 })
 
 var matchExternFn = interpreter.ExternFromFn(matchFnName, func(str string, pattern string) bool {
@@ -73,8 +81,9 @@ var matchExternFn = interpreter.ExternFromFn(matchFnName, func(str string, patte
 })
 
 var externMap = map[string]interpreter.Extern{
-	ipFnName:    ipExternFn,
-	matchFnName: matchExternFn,
+	ipFnName:      ipExternFn,
+	ipEqualFnName: ipEqualExternFn,
+	matchFnName:   matchExternFn,
 }
 
 type cacheEntry struct {

--- a/testdata/config/source_ip_deny.yaml
+++ b/testdata/config/source_ip_deny.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     istio-protocol: tcp
 spec:
-  match: source.ip != ip("10.11.12.13") && destination.service == "foo.default.svc.cluster.local"
+  match: destination.service == "foo.default.svc.cluster.local" && source.ip != ip("10.11.12.13")
   actions:
   - handler: denyall.denier
     instances: [ denyrequest.checknothing ]

--- a/testdata/config/source_ip_deny.yaml
+++ b/testdata/config/source_ip_deny.yaml
@@ -1,0 +1,16 @@
+# This rule denies all TCP traffic sent to the  
+# destination service of "foo.default.svc.cluster.local"
+# that is NOT from a source ip addr of "10.11.12.13"
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: mixerdenyip
+  namespace: istio-config-default
+  labels:
+    istio-protocol: tcp
+spec:
+  match: source.ip != ip("10.11.12.13") && destination.service == "foo.default.svc.cluster.local"
+  actions:
+  - handler: denyall.denier
+    instances: [ denyrequest.checknothing ]
+---

--- a/testdata/config/source_user_filter.yaml
+++ b/testdata/config/source_user_filter.yaml
@@ -1,0 +1,16 @@
+# This rule denies all TCP traffic sent to the  
+# destination service of "bar.default.svc.cluster.local"
+# that is NOT from a source user of "tcp-test-user"
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: mixerdenyuser
+  namespace: istio-config-default
+  labels:
+    istio-protocol: tcp
+spec:
+  match: destination.service == "bar.default.svc.cluster.local" && source.user != "tcp-test-user"
+  actions:
+  - handler: denyall.denier
+    instances: [ denyrequest.checknothing ]
+---


### PR DESCRIPTION
This PR adds two configuration resources that provide examples of Check()-related functionality in the `tcp` context.

To provide this functionality, this PR adds equality methods to the AST and the IL to support comparing IP_ADDRESSes.

A few `fmt.Printf` strings were also cleaned up in this PR (as I noticed them while testing).

Tested with both the AST and IL, as follows:

```
$ bazel-bin/cmd/client/mixc check --attributes source.ip=d:b:c:d,connection.sent.bytes=900,destination.service=bar.default.svc.cluster.local -t request.time=2006-01-02T15:04:05Z --string_attributes context.protocol=tcp,source.user="test"
Check RPC completed successfully. Check status was PERMISSION_DENIED (denyall.denier.istio-config-default:Not allowed)
  Valid use count: 1000, valid duration: 16m40s

$ bazel-bin/cmd/client/mixc check --attributes source.ip=d:b:c:d,connection.sent.bytes=900,destination.service=foobar.default.svc.cluster.local -t request.time=2006-01-02T15:04:05Z --string_attributes context.protocol=tcp,source.user="test"
Check RPC completed successfully. Check status was OK
  Valid use count: 200, valid duration: 10s

$ bazel-bin/cmd/client/mixc check --attributes source.ip=a:b:c:d,connection.sent.bytes=900,destination.service=foo.default.svc.cluster.local -t request.time=2006-01-02T15:04:05Z --string_attributes context.protocol=tcp,source.user="test"
Check RPC completed successfully. Check status was OK
  Valid use count: 200, valid duration: 10s

$ bazel-bin/cmd/client/mixc check --attributes source.ip=d:b:c:d,connection.sent.bytes=900,destination.service=bar.default.svc.cluster.local -t request.time=2006-01-02T15:04:05Z --string_attributes context.protocol=tcp,source.user="tcp-test-user"
Check RPC completed successfully. Check status was OK
  Valid use count: 200, valid duration: 10s

$ bazel-bin/cmd/client/mixc check --attributes source.ip=d:b:c:d,connection.sent.bytes=900,destination.service=bar.default.svc.cluster.local -t request.time=2006-01-02T15:04:05Z --string_attributes context.protocol=tcp,source.user="tcp-test-user"
Check RPC completed successfully. Check status was OK
  Valid use count: 200, valid duration: 10s
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds TCP Check() examples.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1253)
<!-- Reviewable:end -->
