### PR TITLE
Add overrides to memquota2

### DIFF
--- a/adapter/kubernetes/kubeconfig
+++ b/adapter/kubernetes/kubeconfig
@@ -1,0 +1,1 @@
+/Users/mjog/.kube/config

--- a/adapter/kubernetes/kubeconfig
+++ b/adapter/kubernetes/kubeconfig
@@ -1,1 +1,0 @@
-/Users/mjog/.kube/config

--- a/adapter/memQuota/util/util.go
+++ b/adapter/memQuota/util/util.go
@@ -120,7 +120,7 @@ func (qu *QuotaUtil) ReapDedup() {
 	qu.OldDedup = qu.RecentDedup
 	qu.RecentDedup = t
 
-	if qu.Logger.VerbosityLevel(4) {
+	if len(t) > 0 && qu.Logger.VerbosityLevel(4) {
 		qu.Logger.Infof("Running repear to reclaim %d old deduplication entries", len(t))
 	}
 

--- a/adapter/memquota2/config/config.proto
+++ b/adapter/memquota2/config/config.proto
@@ -26,8 +26,28 @@ option (gogoproto.gostring_all) = false;
 
 message Params {
 	message Quota {
+		option (gogoproto.goproto_getters) = true;
 		// The name of the quota
 		string name = 1;
+
+		// The upper limit for this quota.
+		int64 max_amount = 2;
+
+		// The amount of time allocated quota remains valid before it is
+		// automatically released. This is only meaningful for rate limit
+		// quotas, otherwise the value must be zero.
+		google.protobuf.Duration valid_duration = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+
+		// Overrides associated with this quota.
+		// The first matching override is applied.
+		repeated Override overrides = 4 [(gogoproto.nullable) = false];
+	}
+	message Override {
+		option (gogoproto.goproto_getters) = true;
+
+		// The specific dimensions for which this override applies.
+		// String representation of instance dimensions is used to check against configured dimensions.
+		map <string, string> dimensions = 1;
 
 		// The upper limit for this quota.
 		int64 max_amount = 2;

--- a/adapter/memquota2/dedup.go
+++ b/adapter/memquota2/dedup.go
@@ -58,7 +58,7 @@ const (
 )
 
 // handleDedup is a wrapper function that handles dedupping semantics.
-func (du *dedupUtil) handleDedup(instance *quota.Instance, args adapter.QuotaArgs, qf quotaFunc) (int64, time.Duration, error) {
+func (du *dedupUtil) handleDedup(instance *quota.Instance, args adapter.QuotaArgs, qf quotaFunc) (int64, time.Duration, string, error) {
 	key := makeKey(instance.Name, instance.Dimensions)
 
 	du.Lock()
@@ -92,7 +92,7 @@ func (du *dedupUtil) handleDedup(instance *quota.Instance, args adapter.QuotaArg
 		du.logger.Infof("Quota operation satisfied through deduplication: dedupID %v, amount %v", args.DeduplicationID, result.amount)
 	}
 
-	return amount, exp, nil
+	return amount, exp, key, nil
 }
 
 // reapDedup cleans up dedup entries from the oldDedup map and moves all entries from

--- a/adapter/memquota2/memquota_test.go
+++ b/adapter/memquota2/memquota_test.go
@@ -16,6 +16,7 @@ package memquota
 
 import (
 	"context"
+	"net"
 	"strconv"
 	"testing"
 	"time"
@@ -364,5 +365,117 @@ func TestReaperTicker(t *testing.T) {
 
 	if err := h.Close(); err != nil {
 		t.Errorf("Unable to close handler: %v", err)
+	}
+}
+
+func TestHandler_Limit(t *testing.T) {
+	var limit1 int64 = 42
+	var limit2 int64 = 75
+
+	cfgDim1 := map[string]string{
+		"destination": "dest1",
+	}
+	cfgDimIP := map[string]string{
+		"source.ip": "192.10.1.118",
+	}
+	instIP := quota.Instance{
+		Dimensions: map[string]interface{}{
+			"source.ip": net.ParseIP("192.10.1.118"),
+		},
+	}
+
+	inst1 := quota.Instance{
+		Dimensions: map[string]interface{}{
+			"destination": "dest1",
+		},
+	}
+
+	inst2 := quota.Instance{
+		Dimensions: map[string]interface{}{
+			"destination": "dest2",
+		},
+	}
+
+	for _, tc := range []struct {
+		desc  string
+		cfg   config.Params_Quota
+		inst  quota.Instance
+		limit int64
+	}{
+		{
+			desc: "no override",
+			cfg: config.Params_Quota{
+				MaxAmount: limit1,
+			},
+			inst:  inst1,
+			limit: limit1,
+		},
+		{
+			desc: "override no match",
+			cfg: config.Params_Quota{
+				MaxAmount: limit1,
+				Overrides: []config.Params_Override{
+					{
+						Dimensions: cfgDim1,
+						// Empty dimensions match everything.
+						MaxAmount: limit2,
+					},
+				},
+			},
+			inst:  inst2,
+			limit: limit1,
+		},
+		{
+			desc: "override match",
+			cfg: config.Params_Quota{
+				MaxAmount: limit1,
+				Overrides: []config.Params_Override{
+					{
+						Dimensions: cfgDim1,
+						// Empty dimensions match everything.
+						MaxAmount: limit2,
+					},
+				},
+			},
+			inst:  inst1,
+			limit: limit2,
+		},
+		{
+			desc: "override match ip",
+			cfg: config.Params_Quota{
+				MaxAmount: limit1,
+				Overrides: []config.Params_Override{
+					{
+						Dimensions: cfgDimIP,
+						// Empty dimensions match everything.
+						MaxAmount: limit2,
+					},
+				},
+			},
+			inst:  instIP,
+			limit: limit2,
+		},
+		{
+			desc: "override no dim",
+			cfg: config.Params_Quota{
+				MaxAmount: limit1,
+				Overrides: []config.Params_Override{
+					{
+						// Empty dimensions match everything.
+						MaxAmount: limit2,
+					},
+				},
+			},
+			inst:  inst2,
+			limit: limit2,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			l := limit(&tc.cfg, &tc.inst)
+
+			if l.GetMaxAmount() != tc.limit {
+				t.Fatalf("got %v, want %v\n", l.GetMaxAmount(), tc.limit)
+			}
+		})
 	}
 }

--- a/adapter/memquota2/memquota_test.go
+++ b/adapter/memquota2/memquota_test.go
@@ -387,6 +387,7 @@ func TestHandler_Limit(t *testing.T) {
 	inst1 := quota.Instance{
 		Dimensions: map[string]interface{}{
 			"destination": "dest1",
+			"source":      "src1",
 		},
 	}
 
@@ -471,7 +472,8 @@ func TestHandler_Limit(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			l := limit(&tc.cfg, &tc.inst)
+			env := test.NewEnv(t)
+			l := limit(&tc.cfg, &tc.inst, env.Logger())
 
 			if l.GetMaxAmount() != tc.limit {
 				t.Fatalf("got %v, want %v\n", l.GetMaxAmount(), tc.limit)

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -218,6 +218,17 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 					GrantedAmount: qma.Amount,
 				}
 			}
+
+			if glog.V(2) {
+				src, _ := compatRespBag.Get("source.name")
+				dest, _ := compatRespBag.Get("destination.service")
+				msg := ""
+				if qr.GrantedAmount == 0 {
+					msg = "exhausted"
+				}
+				glog.Infof("AccessLog Quota %s %s %d/%d %s", dest, src, qr.GrantedAmount, qma.Amount, msg)
+			}
+
 			qr.ReferencedAttributes = requestBag.GetReferencedAttributes(s.globalDict, globalWordCount)
 			resp.Quotas[name] = *qr
 			requestBag.ClearReferencedAttributes()

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -150,6 +150,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 			glog.Infof("  %s: %v", name, v)
 		}
 	}
+	dest, _ := compatRespBag.Get("destination.service")
 
 	glog.V(1).Info("Dispatching Check")
 	cr, err := s.dispatcher.Check(legacyCtx, compatRespBag)
@@ -205,11 +206,6 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 				break
 			}
 
-			if qr == nil {
-				//TODO remove
-				qr = quotaOld(legacyCtx, s.aspectDispatcher, compatRespBag, qma)
-			}
-
 			// If qma.Quota does not apply to this request give the client what it asked for.
 			// Effectively the quota is unlimited.
 			if qr == nil {
@@ -219,15 +215,11 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 				}
 			}
 
-			if glog.V(2) {
-				src, _ := compatRespBag.Get("source.name")
-				dest, _ := compatRespBag.Get("destination.service")
-				msg := ""
-				if qr.GrantedAmount == 0 {
-					msg = "exhausted"
-				}
-				glog.Infof("AccessLog Quota %s %s %d/%d %s", dest, src, qr.GrantedAmount, qma.Amount, msg)
+			msg := ""
+			if qr.GrantedAmount == 0 {
+				msg = "exhausted"
 			}
+			glog.Infof("AccessLog Quota %s %d/%d %s", dest, qr.GrantedAmount, qma.Amount, msg)
 
 			qr.ReferencedAttributes = requestBag.GetReferencedAttributes(s.globalDict, globalWordCount)
 			resp.Quotas[name] = *qr
@@ -239,32 +231,6 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 	preprocResponseBag.Done()
 
 	return resp, nil
-}
-
-// quotaOld is to be removed.
-func quotaOld(legacyCtx legacyContext.Context, d adapterManager.AspectDispatcher, bag attribute.Bag,
-	qma *aspect.QuotaMethodArgs) *mixerpb.CheckResponse_QuotaResult {
-	glog.V(1).Info("Dispatching Quota")
-	qmr, out := d.Quota(legacyCtx, bag, qma)
-	if status.IsOK(out) {
-		glog.V(1).Infof("Quota returned with ok '%s' and quota response '%v'", status.String(out), qmr)
-	} else {
-		glog.Warningf("Quota returned with error '%s' and quota response '%v'", status.String(out), qmr)
-
-		if out.Code == int32(rpc.RESOURCE_EXHAUSTED) {
-			qmr = &aspect.QuotaMethodResp{
-				Amount:     0,
-				Expiration: defaultValidDuration,
-			}
-		}
-	}
-	if qmr == nil {
-		return nil
-	}
-	return &mixerpb.CheckResponse_QuotaResult{
-		GrantedAmount: qmr.Amount,
-		ValidDuration: qmr.Expiration,
-	}
 }
 
 func quota(legacyCtx legacyContext.Context, d runtime.Dispatcher, bag attribute.Bag,

--- a/pkg/api/perf_test.go
+++ b/pkg/api/perf_test.go
@@ -138,8 +138,8 @@ func (bs *benchState) Check(ctx context.Context, bag attribute.Bag, output *attr
 	return status.OK
 }
 
-func (bs *benchState) Report(ctx context.Context, bag attribute.Bag) rpc.Status {
-	return status.WithPermissionDenied("Not Implementd")
+func (bs *benchState) Report(_ context.Context, _ attribute.Bag) rpc.Status {
+	return status.WithPermissionDenied("Not Implemented")
 }
 
 func (bs *benchState) Quota(ctx context.Context, requestBag attribute.Bag,

--- a/pkg/config/adapterInfoRegistry.go
+++ b/pkg/config/adapterInfoRegistry.go
@@ -33,7 +33,7 @@ type handlerBuilderValidator func(hndlrBuilder adapter.HandlerBuilder, t string)
 func newRegistry2(infos []adapter.InfoFn, hndlrBldrValidator handlerBuilderValidator) *adapterInfoRegistry {
 	r := &adapterInfoRegistry{make(map[string]*adapter.Info)}
 	for idx, info := range infos {
-		glog.V(3).Infof("registering [%d] %#v", idx, info)
+		glog.V(6).Infof("registering [%d] %#v", idx, info)
 		adptInfo := info()
 		if a, ok := r.adapterInfosByName[adptInfo.Name]; ok {
 			// panic only if 2 different adapter.Info objects are trying to identify by the

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -379,7 +379,7 @@ func Parse(src string) (ex *Expression, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse expression '%s': %v", src, err)
 	}
-	if glog.V(4) {
+	if glog.V(6) {
 		glog.Infof("Parsed expression '%s' into '%v'", src, a)
 	}
 
@@ -408,7 +408,7 @@ func (e *cexl) cacheGetExpression(exprStr string) (ex *Expression, err error) {
 		return v.(*Expression), nil
 	}
 
-	if glog.V(4) {
+	if glog.V(6) {
 		glog.Infof("expression cache miss for '%s'", exprStr)
 	}
 
@@ -416,7 +416,7 @@ func (e *cexl) cacheGetExpression(exprStr string) (ex *Expression, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if glog.V(4) {
+	if glog.V(6) {
 		glog.Infof("caching expression for '%s''", exprStr)
 	}
 

--- a/pkg/il/evaluator/evaluator.go
+++ b/pkg/il/evaluator/evaluator.go
@@ -200,7 +200,7 @@ func (e *IL) getOrCreateCacheEntry(expr string) (cacheEntry, error) {
 		return entry.(cacheEntry), nil
 	}
 
-	if glog.V(4) {
+	if glog.V(6) {
 		glog.Infof("expression cache miss for '%s'", expr)
 	}
 
@@ -211,7 +211,7 @@ func (e *IL) getOrCreateCacheEntry(expr string) (cacheEntry, error) {
 		return cacheEntry{}, err
 	}
 
-	if glog.V(4) {
+	if glog.V(6) {
 		glog.Infof("caching expression for '%s''", expr)
 	}
 

--- a/pkg/runtime/dispatcher.go
+++ b/pkg/runtime/dispatcher.go
@@ -236,15 +236,21 @@ func (m *dispatcher) Quota(ctx context.Context, requestBag attribute.Bag,
 	qres, err := m.dispatch(ctx, requestBag, adptTmpl.TEMPLATE_VARIETY_QUOTA,
 		func(call *Action) []dispatchFn {
 			for _, inst := range call.instanceConfig {
-				if inst.Name != qma.Quota {
-					continue
-				}
+				// if inst.Name != qma.Quota {
+				//	continue
+				// }
+				// TODO Re-enable inst.Name check
+				// proxy - mixer quota protocol dictates that quota name is passed in as a parameter.
+				// As of 0.2, there is no mechanism to distribute configuration from Mixer to Mixer client(Proxy).
+				// When such a mechanism is created, re-enable the inst.Name filter.
+				// Until then Proxy always calls with exactly 1 quota request named
+				// "RequestCount" which is intended for rate limit.
 				if dispatched { // ensures only one call is dispatched.
 					glog.Warningf("Multiple dispatch: not dispatching %s to handler %s", inst.Name, call.handlerName)
 					return nil
 				}
 				dispatched = true
-				return []dispatchFn{
+				return []dispatchFn{ // nolint: staticcheck
 					func(ctx context.Context) *result {
 						resp, err := call.processor.ProcessQuota(ctx, inst.Name,
 							inst.Params.(proto.Message), requestBag, m.mapper, call.handler,

--- a/testdata/config/quota.yaml
+++ b/testdata/config/quota.yaml
@@ -8,6 +8,12 @@ spec:
   - name: requestcount.quota.istio-config-default
     max_amount: 5
     valid_duration: 1s
+    overrides:
+    - dimensions:
+        destination: abc.com.svc.cluster.local
+      max_amount: 6
+      valid_duration: 60s
+
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: quota
@@ -17,7 +23,7 @@ metadata:
 spec:
   dimensions:
     source: source.labels["app"] | "unknown"
-    target: target.service | "unknown"
+    destination: destination.service | "unknown"
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -30,4 +36,3 @@ spec:
   - handler: handler.memquota
     instances:
     - requestcount.quota
----

--- a/testdata/config/quota.yaml
+++ b/testdata/config/quota.yaml
@@ -6,13 +6,24 @@ metadata:
 spec:
   quotas:
   - name: requestcount.quota.istio-config-default
-    max_amount: 5
-    valid_duration: 1s
+    maxAmount: 5000
+    validDuration: 1s
+    # The first matching override is applied.
+    # A requestcount instance is checked against override dimensions.
     overrides:
+    # The following override applies to 'ratings' when
+    # the source is 'reviews'.
     - dimensions:
-        destination: abc.com.svc.cluster.local
-      max_amount: 6
-      valid_duration: 60s
+        destination: ratings
+        source: reviews
+      maxAmount: 1
+      validDuration: 1s
+    # The following override applies to 'ratings' regardless
+    # of the source.
+    - dimensions:
+        destination: ratings
+      maxAmount: 100
+      validDuration: 1s
 
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -22,8 +33,11 @@ metadata:
   namespace: istio-config-default
 spec:
   dimensions:
-    source: source.labels["app"] | "unknown"
-    destination: destination.service | "unknown"
+    source: source.labels["app"] | source.service | "unknown"
+    sourceVersion: source.labels["version"] | "unknown"
+    destination: destination.labels["app"] | destination.service | "unknown"
+    destinationVersion: destination.labels["version"] | "unknown"
+
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -31,7 +45,6 @@ metadata:
   name: quota
   namespace: istio-config-default
 spec:
-#  match: source.user  != "admin"
   actions:
   - handler: handler.memquota
     instances:


### PR DESCRIPTION
This PR adds override support to memquota2 as `back end configuration` with the intention of migrating then to individual config resources in 0.3

It gains feature parity with the old memquota setup + old config model. 
This lets Mixer switch off old quota dispatch after creating replacement test configurations.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1256)
<!-- Reviewable:end -->
