### PR TITLE
Add logging in case type inference fails.

### DIFF
--- a/pkg/runtime/handler.go
+++ b/pkg/runtime/handler.go
@@ -94,6 +94,7 @@ func NewHandlerFactory(tmplRepo TemplateFinder, expr expr.TypeChecker, df expr.A
 func (h *handlerFactory) Build(handler *pb.Handler, instances []*pb.Instance, env adapter.Env) (adapter.Handler, error) {
 	infrdTypsByTmpl, err := h.inferTypesGrpdByTmpl(instances)
 	if err != nil {
+		glog.Error(err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1266)
<!-- Reviewable:end -->
