### PR TITLE
Remove problematic response.latency refs

### DIFF
--- a/deploy/kube/README.md
+++ b/deploy/kube/README.md
@@ -14,7 +14,7 @@ mixer server with our test client (`mixc`), providing some attribute values:
 
 ```shell
 $ MIXS=$(minikube service mixer --url --format "{{.IP}}:{{.Port}}" | head -n 1)
-$ bazel run //cmd/client:mixc -- report "something happened" -m $MIXS -a source.name=source,target.name=target,api.name=myapi,api.method=v1.foo.bar,response.http.code=200,response.latency=100,client.id=$USER
+$ bazel run //cmd/client:mixc -- report "something happened" -m $MIXS -a source.name=source,target.name=target,api.name=myapi,api.method=v1.foo.bar,response.http.code=200,response.duration=100,client.id=$USER
 ```
 
 <aside class="notice">
@@ -102,7 +102,7 @@ aspects:
           method: api.method | "unknown"
           response_code: response.http.code
       - descriptor:  request_latency
-        value: response.latency
+        value: response.duration | "0ms"
         labels:
           source: source.name
           target: target.name

--- a/pkg/api/perf_test.go
+++ b/pkg/api/perf_test.go
@@ -238,7 +238,7 @@ func getGlobalDict() []string {
 		"server", "envoy",
 		"x-envoy-upstream-service-time",
 		"response.http.code",
-		"response.latency",
+		"response.duration",
 		"response.size",
 		"response.time",
 		"source.namespace",
@@ -272,7 +272,7 @@ func setRequestAttrs(bag *attribute.MutableBag, uuid []byte) {
 		"x-envoy-upstream-service-time": "0",
 	})
 	bag.Set("response.http.code", int64(200))
-	bag.Set("response.latency", time.Duration(50)*time.Millisecond)
+	bag.Set("response.duration", time.Duration(50)*time.Millisecond)
 	bag.Set("response.size", int64(64))
 	bag.Set("response.time", time.Now())
 	bag.Set("source.namespace", "XYZ11")

--- a/testdata/config/attributes.yaml
+++ b/testdata/config/attributes.yaml
@@ -39,8 +39,6 @@ spec:
         valueType: DURATION
       response.headers:
         valueType: STRING_MAP
-      response.latency:
-        valueType: DURATION
       response.size:
         valueType: INT64
       response.time:
@@ -71,9 +69,6 @@ spec:
         valueType: TIMESTAMP
       context.time:
         valueType: TIMESTAMP
-      # DEPRECATED, to be removed. Use request.useragent instead.
-      request.user-agent:
-        valueType: STRING
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest

--- a/testdata/config/metrics.yaml
+++ b/testdata/config/metrics.yaml
@@ -20,7 +20,7 @@ metadata:
   name: requestduration
   namespace: istio-config-default
 spec:
-  value: response.latency | response.duration | "0ms"
+  value: response.duration | "0ms"
   dimensions:
     source: source.labels["app"] | "unknown"
     target: target.service | "unknown"

--- a/testdata/config/stackdriver.yaml
+++ b/testdata/config/stackdriver.yaml
@@ -133,7 +133,7 @@ metadata:
   name: stackdriverrequestduration
   namespace: istio-config-default
 spec:
-  value: response.latency | response.duration | "0ms"
+  value: response.duration | "0ms"
   dimensions:
     source: source.labels["app"] | "unknown"
     target: target.service | "unknown"

--- a/testdata/configroot/scopes/global/descriptors.yml
+++ b/testdata/configroot/scopes/global/descriptors.yml
@@ -79,8 +79,6 @@ manifests:
         valueType: DURATION
       response.headers:
         valueType: STRING_MAP
-      response.latency:
-        valueType: DURATION
       response.size:
         valueType: INT64
       response.time:
@@ -109,9 +107,6 @@ manifests:
         valueType: TIMESTAMP
       context.time:
         valueType: TIMESTAMP
-      # DEPRECATED, to be removed. Use request.useragent instead.
-      request.user-agent:
-        valueType: STRING
 quotas:
   - name: RequestCount
     rate_limit: true


### PR DESCRIPTION
Use of `response.latency` is filling up logs with warnings that it isn't the global or local attribute lists, and the official attribute is `response.duration`.

This PR removes all references inside of the Mixer repo.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1268)
<!-- Reviewable:end -->
