### PR TITLE
fsstore2: do not complain about empty documents

### DIFF
--- a/pkg/config/store/fsstore2.go
+++ b/pkg/config/store/fsstore2.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"time"
 
@@ -90,6 +91,14 @@ func parseFile(path string, data []byte) []*resource {
 			glog.Errorf("Failed to parse %d-th part in file %s: %v", i, path, err)
 			continue
 		}
+
+		if empty(r) {
+			// can be empty because
+			// There is just white space
+			// There are just comments
+			continue
+		}
+
 		if r.Kind == "" || r.Metadata.Namespace == "" || r.Metadata.Name == "" {
 			glog.Errorf("Key elements are empty. Extracted as %s", r.Key())
 			continue
@@ -98,6 +107,13 @@ func parseFile(path string, data []byte) []*resource {
 		resources = append(resources, r)
 	}
 	return resources
+}
+
+var emptyResource = &resource{}
+
+// Check if the parsed resource is empty
+func empty(r *resource) bool {
+	return reflect.DeepEqual(*r, *emptyResource)
 }
 
 func (s *fsStore2) readFiles() map[Key]*resource {

--- a/pkg/config/store/fsstore2.go
+++ b/pkg/config/store/fsstore2.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -86,27 +87,35 @@ func parseFile(path string, data []byte) []*resource {
 	chunks := bytes.Split(data, []byte("\n---\n"))
 	resources := make([]*resource, 0, len(chunks))
 	for i, chunk := range chunks {
-		r := &resource{}
-		if err := yaml.Unmarshal(chunk, r); err != nil {
-			glog.Errorf("Failed to parse %d-th part in file %s: %v", i, path, err)
+		r, err := parseChunk(chunk)
+		if err != nil {
+			glog.Errorf("Error processing %s[%d]: %v", path, i, err)
 			continue
 		}
-
-		if empty(r) {
-			// can be empty because
-			// There is just white space
-			// There are just comments
+		if r == nil {
 			continue
 		}
-
-		if r.Kind == "" || r.Metadata.Namespace == "" || r.Metadata.Name == "" {
-			glog.Errorf("Key elements are empty. Extracted as %s", r.Key())
-			continue
-		}
-		r.sha = sha1.Sum(chunk)
 		resources = append(resources, r)
 	}
 	return resources
+}
+
+func parseChunk(chunk []byte) (*resource, error) {
+	r := &resource{}
+	if err := yaml.Unmarshal(chunk, r); err != nil {
+		return nil, err
+	}
+	if empty(r) {
+		// can be empty because
+		// There is just white space
+		// There are just comments
+		return nil, nil
+	}
+	if r.Kind == "" || r.Metadata.Namespace == "" || r.Metadata.Name == "" {
+		return nil, fmt.Errorf("key elements are empty. Extracted as %s from\n <<%s>>", r.Key(), string(chunk))
+	}
+	r.sha = sha1.Sum(chunk)
+	return r, nil
 }
 
 var emptyResource = &resource{}

--- a/pkg/config/store/fsstore2_test.go
+++ b/pkg/config/store/fsstore2_test.go
@@ -242,11 +242,55 @@ spec:
 			0,
 			bad + "\n---\n" + bad,
 		},
+		{
+			"trailing white space",
+			1,
+			good + "\n---\n\n    \n",
+		},
 	} {
 		t.Run(c.title, func(tt *testing.T) {
 			resources := parseFile(c.title, []byte(c.data))
 			if len(resources) != c.resourceCount {
 				tt.Errorf("Got %d, Want %d", len(resources), c.resourceCount)
+			}
+		})
+	}
+}
+
+func TestFsStore2_ParseChunk(t *testing.T) {
+	const good = `
+kind: Foo
+apiVersion: testing
+metadata:
+  namespace: ns
+  name: foo
+spec:
+`
+	const bad = "abc"
+	for _, c := range []struct {
+		title string
+		isNil bool
+		data  string
+	}{
+		{
+			"whitespace only",
+			true,
+			"      \n",
+		},
+		{
+			"whitespace with comments",
+			true,
+			"   \n#This is a comments\n",
+		},
+	} {
+		t.Run(c.title, func(t *testing.T) {
+			r, err := parseChunk([]byte(c.data))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if (r == nil) != c.isNil {
+				t.Fatalf("want Got %v, Want %t", r, c.isNil)
 			}
 		})
 	}

--- a/pkg/config/store/fsstore2_test.go
+++ b/pkg/config/store/fsstore2_test.go
@@ -258,15 +258,6 @@ spec:
 }
 
 func TestFsStore2_ParseChunk(t *testing.T) {
-	const good = `
-kind: Foo
-apiVersion: testing
-metadata:
-  namespace: ns
-  name: foo
-spec:
-`
-	const bad = "abc"
 	for _, c := range []struct {
 		title string
 		isNil bool


### PR DESCRIPTION
Fixes: fsstore2.go:102] Key elements are empty. Extracted as ..

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1275)
<!-- Reviewable:end -->
