### PR TITLE
fix perftests

### DIFF
--- a/bin/perftest.sh
+++ b/bin/perftest.sh
@@ -8,7 +8,7 @@ cd $ROOT
 
 
 echo "Perf test"
-DIRS="pkg/expr pkg/attribute pkg/adapterManager"
+DIRS="pkg/api pkg/expr pkg/il/interpreter"
 cd $ROOT
 for pkgdir in ${DIRS}; do
     cd ${ROOT}/${pkgdir} 

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -56,7 +56,7 @@ func (l *legacyDispatcher) Preprocess(_ context.Context, requestBag attribute.Ba
 	return l.preproc(requestBag, responseBag)
 }
 
-func (l *legacyDispatcher) Quota(ctx context.Context, requestBag attribute.Bag,
+func (l *legacyDispatcher) Quota(_ context.Context, requestBag attribute.Bag,
 	qma *aspect.QuotaMethodArgs) (*aspect.QuotaMethodResp, rpc.Status) {
 	return l.quota(requestBag, qma)
 }

--- a/pkg/il/interpreter/BUILD
+++ b/pkg/il/interpreter/BUILD
@@ -1,4 +1,3 @@
-# gazelle:ignore
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
@@ -25,20 +24,8 @@ go_test(
     size = "small",
     srcs = [
         "extern_test.go",
-        "interpreter_test.go",
-    ],
-    library = ":go_default_library",
-    deps = [
-        "//pkg/il/testing:go_default_library",
-        "@com_github_gogo_protobuf//types:go_default_library",
-    ],
-)
-
-go_test(
-    name = "benchmark_tests",
-    size = "small",
-    srcs = [
         "interpreterBenchmark_test.go",
+        "interpreter_test.go",
         "result_test.go",
     ],
     library = ":go_default_library",

--- a/pkg/il/interpreter/interpreterBenchmark_test.go
+++ b/pkg/il/interpreter/interpreterBenchmark_test.go
@@ -60,14 +60,14 @@ var programs = map[string]benchmarkProgram{
 		code: `
 fn eval() bool
   resolve_i "a"
-  ieq_i 20
+  aeq_i 20
   jz L0
-  ipush_b true
+  apush_b true
   ret
 L0:
-  resolve_r "request.header"
-  ilookup "host"
-  ieq_s "abc"
+  resolve_f "request.header"
+  anlookup "host"
+  aeq_s "abc"
   ret
 end`,
 	},


### PR DESCRIPTION
- pkg/attributes and pkg/adapterManager do not have benchmarks anymore
- pkg/api and pkg/il/interpreter are missing in preftest
- fix pkg/api/perf_test.go's panic by adding the new dispatcher
- fix interpreterBenchmark_test.go by fixing the IL opcodes

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1280)
<!-- Reviewable:end -->
