### PR TITLE
Prevent debug logging from affecting referenced attributes

### DIFF
--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -314,10 +314,7 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 
 		if glog.V(2) {
 			glog.Info("Dispatching to main adapters after running processors")
-			for _, name := range preprocResponseBag.Names() {
-				v, _ := preprocResponseBag.Get(name)
-				glog.Infof("  %s: %v", name, v)
-			}
+			glog.Infof("Attribute Bag: \n%s", preprocResponseBag)
 		}
 
 		glog.V(1).Infof("Dispatching Report %d out of %d", i, len(req.Attributes))

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -89,8 +89,8 @@ type compatBag struct {
 	parent attribute.Bag
 }
 
-func (c *compatBag) String() string {
-	return c.parent.String()
+func (c *compatBag) DebugString() string {
+	return c.parent.DebugString()
 }
 
 // if a destination.* attribute is missing, check the corresponding target.* attribute.
@@ -149,7 +149,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 
 	if glog.V(2) {
 		glog.Info("Dispatching to main adapters after running processors")
-		glog.Infof("Attribute Bag: \n%s", preprocResponseBag)
+		glog.Infof("Attribute Bag: \n%s", preprocResponseBag.DebugString())
 	}
 	dest, _ := compatRespBag.Get("destination.service")
 
@@ -314,7 +314,7 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 
 		if glog.V(2) {
 			glog.Info("Dispatching to main adapters after running processors")
-			glog.Infof("Attribute Bag: \n%s", preprocResponseBag)
+			glog.Infof("Attribute Bag: \n%s", preprocResponseBag.DebugString())
 		}
 
 		glog.V(1).Infof("Dispatching Report %d out of %d", i, len(req.Attributes))

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -89,6 +89,10 @@ type compatBag struct {
 	parent attribute.Bag
 }
 
+func (c *compatBag) String() string {
+	return c.parent.String()
+}
+
 // if a destination.* attribute is missing, check the corresponding target.* attribute.
 func (c *compatBag) Get(name string) (v interface{}, found bool) {
 	v, found = c.parent.Get(name)
@@ -145,10 +149,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 
 	if glog.V(2) {
 		glog.Info("Dispatching to main adapters after running processors")
-		for _, name := range preprocResponseBag.Names() {
-			v, _ := preprocResponseBag.Get(name)
-			glog.Infof("  %s: %v", name, v)
-		}
+		glog.Infof("Attribute Bag: \n%s", preprocResponseBag)
 	}
 	dest, _ := compatRespBag.Get("destination.service")
 

--- a/pkg/aspect/test/bag.go
+++ b/pkg/aspect/test/bag.go
@@ -78,4 +78,6 @@ func (t *Bag) StringMap(name string) (map[string]string, bool) {
 	return nil, false
 }
 
+// DebugString returns the empty string.
+// TODO: use attribute.GetMutableBagForTest
 func (t *Bag) DebugString() string { return "" }

--- a/pkg/aspect/test/bag.go
+++ b/pkg/aspect/test/bag.go
@@ -77,3 +77,5 @@ func (t *Bag) Bytes(name string) ([]uint8, bool) {
 func (t *Bag) StringMap(name string) (map[string]string, bool) {
 	return nil, false
 }
+
+func (t *Bag) DebugString() string { return "" }

--- a/pkg/attribute/bag.go
+++ b/pkg/attribute/bag.go
@@ -25,7 +25,7 @@ type Bag interface {
 	// Done indicates the bag can be reclaimed.
 	Done()
 
-	// String provides fmt.Stringer interface implementation that does not affect
+	// DebugString provides a dump of an attribute Bag that avoids affecting the
 	// calculation of referenced attributes.
-	String() string
+	DebugString() string
 }

--- a/pkg/attribute/bag.go
+++ b/pkg/attribute/bag.go
@@ -24,4 +24,8 @@ type Bag interface {
 
 	// Done indicates the bag can be reclaimed.
 	Done()
+
+	// String provides fmt.Stringer interface implementation that does not affect
+	// calculation of referenced attributes.
+	String() string
 }

--- a/pkg/attribute/emptyBag.go
+++ b/pkg/attribute/emptyBag.go
@@ -24,4 +24,4 @@ var emptySlice = []string{}
 func (eb *emptyBag) Get(name string) (interface{}, bool) { return nil, false }
 func (eb *emptyBag) Names() []string                     { return emptySlice }
 func (eb *emptyBag) Done()                               {}
-func (eb *emptyBag) String() string                      { return "" }
+func (eb *emptyBag) DebugString() string                 { return "" }

--- a/pkg/attribute/emptyBag.go
+++ b/pkg/attribute/emptyBag.go
@@ -24,3 +24,4 @@ var emptySlice = []string{}
 func (eb *emptyBag) Get(name string) (interface{}, bool) { return nil, false }
 func (eb *emptyBag) Names() []string                     { return emptySlice }
 func (eb *emptyBag) Done()                               {}
+func (eb *emptyBag) String() string                      { return "" }

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -392,3 +392,13 @@ func lookup(index int32, err error, globalWordList []string, messageWordList []s
 
 	return "", me.Append(err, fmt.Errorf("attribute index %d is not defined in the available dictionaries", index))
 }
+
+func (b *MutableBag) String() string {
+	var buf bytes.Buffer
+	buf.WriteString(b.parent.String())
+	buf.WriteString("\n")
+	for k, v := range b.values {
+		buf.WriteString(fmt.Sprintf("%-20s: %v\n", k, v))
+	}
+	return buf.String()
+}

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -393,9 +393,9 @@ func lookup(index int32, err error, globalWordList []string, messageWordList []s
 	return "", me.Append(err, fmt.Errorf("attribute index %d is not defined in the available dictionaries", index))
 }
 
-func (b *MutableBag) String() string {
+func (b *MutableBag) DebugString() string {
 	var buf bytes.Buffer
-	buf.WriteString(b.parent.String())
+	buf.WriteString(b.parent.DebugString())
 	buf.WriteString("\n")
 	for k, v := range b.values {
 		buf.WriteString(fmt.Sprintf("%-20s: %v\n", k, v))

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -17,6 +17,7 @@ package attribute
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -396,11 +397,22 @@ func lookup(index int32, err error, globalWordList []string, messageWordList []s
 // DebugString prints out the attributes from the parent bag, then
 // walks through the local changes and prints them as well.
 func (mb *MutableBag) DebugString() string {
+	if len(mb.values) == 0 {
+		return mb.parent.DebugString()
+	}
+
 	var buf bytes.Buffer
 	buf.WriteString(mb.parent.DebugString())
-	buf.WriteString("\n")
-	for k, v := range mb.values {
-		buf.WriteString(fmt.Sprintf("%-20s: %v\n", k, v))
+	buf.WriteString("---\n")
+
+	keys := make([]string, 0, len(mb.values))
+	for key := range mb.values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		buf.WriteString(fmt.Sprintf("%-30s: %v\n", key, mb.values[key]))
 	}
 	return buf.String()
 }

--- a/pkg/attribute/mutableBag.go
+++ b/pkg/attribute/mutableBag.go
@@ -393,11 +393,13 @@ func lookup(index int32, err error, globalWordList []string, messageWordList []s
 	return "", me.Append(err, fmt.Errorf("attribute index %d is not defined in the available dictionaries", index))
 }
 
-func (b *MutableBag) DebugString() string {
+// DebugString prints out the attributes from the parent bag, then
+// walks through the local changes and prints them as well.
+func (mb *MutableBag) DebugString() string {
 	var buf bytes.Buffer
-	buf.WriteString(b.parent.DebugString())
+	buf.WriteString(mb.parent.DebugString())
 	buf.WriteString("\n")
-	for k, v := range b.values {
+	for k, v := range mb.values {
 		buf.WriteString(fmt.Sprintf("%-20s: %v\n", k, v))
 	}
 	return buf.String()

--- a/pkg/attribute/protoBag.go
+++ b/pkg/attribute/protoBag.go
@@ -17,6 +17,7 @@ package attribute
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/golang/glog"
@@ -311,7 +312,11 @@ func (pb *ProtoBag) Done() {
 // and prints them to a string.
 func (pb *ProtoBag) DebugString() string {
 	var buf bytes.Buffer
-	for _, name := range pb.Names() {
+
+	names := pb.Names()
+	sort.Strings(names)
+
+	for _, name := range names {
 		// find the dictionary index for the given string
 		index, ok := pb.getIndex(name)
 		if !ok {
@@ -320,7 +325,7 @@ func (pb *ProtoBag) DebugString() string {
 		}
 
 		if result, ok := pb.internalGet(name, index); ok {
-			buf.WriteString(fmt.Sprintf("%-20s: %v\n", name, result))
+			buf.WriteString(fmt.Sprintf("%-30s: %v\n", name, result))
 		}
 	}
 	return buf.String()

--- a/pkg/attribute/protoBag.go
+++ b/pkg/attribute/protoBag.go
@@ -15,6 +15,7 @@
 package attribute
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 
@@ -304,4 +305,21 @@ func (pb *ProtoBag) Names() []string {
 // Done indicates the bag can be reclaimed.
 func (pb *ProtoBag) Done() {
 	// NOP
+}
+
+func (pb *ProtoBag) String() string {
+	var buf bytes.Buffer
+	for _, name := range pb.Names() {
+		// find the dictionary index for the given string
+		index, ok := pb.getIndex(name)
+		if !ok {
+			glog.Warningf("Attribute '%s' not in either global or message dictionaries", name)
+			continue
+		}
+
+		if result, ok := pb.internalGet(name, index); ok {
+			buf.WriteString(fmt.Sprintf("%-20s: %v\n", name, result))
+		}
+	}
+	return buf.String()
 }

--- a/pkg/attribute/protoBag.go
+++ b/pkg/attribute/protoBag.go
@@ -307,7 +307,7 @@ func (pb *ProtoBag) Done() {
 	// NOP
 }
 
-func (pb *ProtoBag) String() string {
+func (pb *ProtoBag) DebugString() string {
 	var buf bytes.Buffer
 	for _, name := range pb.Names() {
 		// find the dictionary index for the given string

--- a/pkg/attribute/protoBag.go
+++ b/pkg/attribute/protoBag.go
@@ -307,6 +307,8 @@ func (pb *ProtoBag) Done() {
 	// NOP
 }
 
+// DebugString runs through the named attributes, looks up their values,
+// and prints them to a string.
 func (pb *ProtoBag) DebugString() string {
 	var buf bytes.Buffer
 	for _, name := range pb.Names() {

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -491,5 +491,6 @@ func (b *bag) Names() []string {
 	return []string{}
 }
 
-func (b *bag) Done() {
-}
+func (b *bag) Done() {}
+
+func (b *bag) DebugString() string { return "" }

--- a/pkg/il/compiler/BUILD
+++ b/pkg/il/compiler/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//pkg/config/descriptor:go_default_library",
         "//pkg/config/proto:go_default_library",
         "//pkg/il/interpreter:go_default_library",
+        "//pkg/il/testing:go_default_library",
         "//pkg/il/text:go_default_library",
         "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
     ],

--- a/pkg/il/compiler/compiler_test.go
+++ b/pkg/il/compiler/compiler_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/mixer/pkg/config/descriptor"
 	pb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/il/interpreter"
+	iltest "istio.io/mixer/pkg/il/testing"
 	"istio.io/mixer/pkg/il/text"
 )
 
@@ -1091,7 +1092,9 @@ func TestCompile(t *testing.T) {
 					return
 				}
 			}
-			b := bag{attrs: te.input}
+
+			// TODO: replace with GetMutableBagForTesting()
+			b := iltest.FakeBag{Attrs: te.input}
 
 			ipExtern := interpreter.ExternFromFn("ip", func(in string) []byte {
 				if ip := net.ParseIP(in); ip != nil {
@@ -1165,21 +1168,4 @@ func TestCompile_TypeError(t *testing.T) {
 	if err.Error() != "EQ($ai, true) arg 2 (true) typeError got BOOL, expected INT64" {
 		t.Fatalf("error is not as expected: '%v'", err)
 	}
-}
-
-// fake bag
-type bag struct {
-	attrs map[string]interface{}
-}
-
-func (b *bag) Get(name string) (interface{}, bool) {
-	c, found := b.attrs[name]
-	return c, found
-}
-
-func (b *bag) Names() []string {
-	return []string{}
-}
-
-func (b *bag) Done() {
 }

--- a/pkg/il/testing/fakebag.go
+++ b/pkg/il/testing/fakebag.go
@@ -35,5 +35,7 @@ func (b *FakeBag) Names() []string {
 }
 
 // Done indicates the bag can be reclaimed.
-func (b *FakeBag) Done() {
-}
+func (b *FakeBag) Done() {}
+
+// DebugString is needed to implement the Bag interface.
+func (b *FakeBag) DebugString() string { return "" }

--- a/template/sample/template.gen_test.go
+++ b/template/sample/template.gen_test.go
@@ -117,6 +117,7 @@ type fakeBag struct{}
 func (f fakeBag) Get(name string) (value interface{}, found bool) { return nil, false }
 func (f fakeBag) Names() []string                                 { return []string{} }
 func (f fakeBag) Done()                                           {}
+func (f fakeBag) DebugString() string                             { return "" }
 
 func TestGeneratedFields(t *testing.T) {
 	for _, tst := range []struct {


### PR DESCRIPTION
This PR alters mixer debug logging behavior to stop using `Get()` calls into a bag to print out attributes. Instead, `DebugString()` is introduced to bags to allow printing of a bag without updating referenced attributes, etc.

New logs look like:

```
I0912 12:42:13.467309   46254 grpcServer.go:152] Attribute Bag:
destination.port              : 200
destination.uid               : kubernetes://istio-mixer-1945455803-mqpch.default
request.headers               : map[source:abc clnt:abc]
request.time                  : 2006-01-12 13:45:45 +0000 UTC
response.size                 : 1024
source.ip                     : [10 12 3 6]
---
destination.labels            : map[istio:mixer pod-template-hash:1945455803]
destination.name              : istio-mixer-1945455803-mqpch
destination.namespace         : default
destination.service           : mixer.default.svc.cluster.local
destination.serviceAccount    : default
source.labels                 : map[istio:mixer pod-template-hash:1945455803]
source.name                   : istio-mixer-1945455803-mqpch
source.namespace              : default
source.service                : mixer.default.svc.cluster.local
source.serviceAccount         : default
```

Mixer debug logging should *NOT* impact cache behavior.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Mixer debug logging will NOT impact cache behavior
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1281)
<!-- Reviewable:end -->
