### PR TITLE
rename deprecated files property in bazel

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -6,10 +6,10 @@ load(":cacerts.bzl", "cacerts")
 
 pkg_tar(
     name = "mixer_tar",
-    extension = "tar.gz",
-    files = [
+    srcs = [
         "//cmd/server:mixs",
     ],
+    extension = "tar.gz",
     mode = "0755",
     package_dir = "/usr/local/bin/",
     tags = ["manual"],

--- a/example/servicegraph/docker/BUILD
+++ b/example/servicegraph/docker/BUILD
@@ -5,10 +5,10 @@ load("//docker:mixer_docker.bzl", "mixer_docker_build")
 
 pkg_tar(
     name = "mixer_servicegraph_tar",
-    extension = "tar.gz",
-    files = [
+    srcs = [
         "//example/servicegraph/cmd/server:servicegraph",
     ],
+    extension = "tar.gz",
     mode = "0755",
     package_dir = "/usr/local/bin/",
     tags = ["manual"],

--- a/example/servicegraph/js/BUILD
+++ b/example/servicegraph/js/BUILD
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "js_tar",
-    extension = "tar.gz",
-    files = glob(
+    srcs = glob(
         ["**"],
         exclude = ["BUILD"],
     ),
+    extension = "tar.gz",
     mode = "0755",
     package_dir = "/example/servicegraph/js",
     strip_prefix = "./",

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "configs_tar",
-    extension = "tar.gz",
-    files = glob([
+    srcs = glob([
         "**/*.yml",
     ]),
+    extension = "tar.gz",
     mode = "0755",
     package_dir = "/etc/opt/mixer",
     strip_prefix = "./",


### PR DESCRIPTION
**Release note**: rename deprecated 'files' property in bazel to 'srcs'
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1283)
<!-- Reviewable:end -->
