### PR TITLE
Fix release tag stamping

### DIFF
--- a/bin/build_stamp.sh
+++ b/bin/build_stamp.sh
@@ -33,7 +33,7 @@ fi
 echo "buildStatus ${tree_status}"
 
 # Check for version informatioqn
-RELEASE_TAG=$(git describe --match '[0-9]*\.[0-9]*\.[0-9]*' --exact-match 2> /dev/null || echo "")
+RELEASE_TAG=$(git describe --match '[0-9]*\.[0-9]*\.[0-9]*' 2> /dev/null || echo "")
 if [[ -n "${RELEASE_TAG}" ]]; then
   VERSION="${RELEASE_TAG}"
 elif [[ -n ${ISTIO_VERSION} ]]; then


### PR DESCRIPTION
From: `Istio Mixer: version: unknown (build: 2017-09-13-a4a5194, status: Modified)`
To: `Istio Mixer: version: 0.2.2-4-gee30dc0 (build: 2017-09-13-ee30dc0, status: Clean)`

This PR eliminates the `--exact-match` tag in the `git describe` command, which was preventing the command from ever returning any results.  This will allow us to more quickly assess the version of Mixer in use.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1292)
<!-- Reviewable:end -->
