### PR TITLE
Legacy rules: only keep k8s adapter and related config locally

### DIFF
--- a/testdata/configroot/scopes/global/adapters.yml
+++ b/testdata/configroot/scopes/global/adapters.yml
@@ -1,10 +1,6 @@
 subject: global
 adapters:
   - name: default
-    kind: quotas
-    impl: memQuota
-    params:
-  - name: default
     kind: attributes
     impl: kubernetes
     params:

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -26,10 +26,4 @@ rules:
         destination.namespace: targetNamespace
         destination.service: targetService
         destination.serviceAccount: targetServiceAccountName
-  - kind: quotas
-    params:
-      quotas:
-      - descriptorName: RequestCount
-        maxAmount: 5000
-        expiration: 1s
 


### PR DESCRIPTION
This PR removes all config other than k8s preprocess adapter.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1301)
<!-- Reviewable:end -->
