### PR TITLE
Add example configuration for listchecker 

### DIFF
--- a/adapter/list/list.go
+++ b/adapter/list/list.go
@@ -240,7 +240,6 @@ func GetInfo() adapter.Info {
 		Description:        "Checks whether an entry is present in a list",
 		SupportedTemplates: []string{listentry.TemplateName},
 		DefaultConfig: &config.Params{
-			ProviderUrl:     "http://localhost",
 			RefreshInterval: 60 * time.Second,
 			Ttl:             300 * time.Second,
 			CachingInterval: 300 * time.Second,

--- a/testdata/config/listcheck.yaml
+++ b/testdata/config/listcheck.yaml
@@ -1,0 +1,30 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: listchecker
+metadata:
+  name: staticversion
+  namespace: istio-config-default
+spec:
+  # providerUrl: ordinarily black and white lists are maintained
+  # externally and fetched asynchronously using the providerUrl.
+  overrides: ["v1", "v2"]  # overrides provide a static list
+  blacklist: false
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: listentry
+metadata:
+  name: appversion
+  namespace: istio-config-default
+spec:
+  value: source.labels["version"]
+
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: checkwl
+  namespace: istio-config-default
+spec:
+  match: destination.labels["app"] == "ratings"
+  actions:
+  - handler: staticversion.listchecker
+    instances: [ appversion.listentry ]


### PR DESCRIPTION
1. Add whitelist config example
2. Remove default value for `ProviderUrl`, there is no reasonable default.

This example is used in docs.
**Release note**:
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1306)
<!-- Reviewable:end -->
