### PR TITLE
Remove target naming from k8s adapter

### DIFF
--- a/adapter/kubernetes/config/config.proto
+++ b/adapter/kubernetes/config/config.proto
@@ -31,7 +31,7 @@ option (gogoproto.gostring_all) = false;
 // The adapter works by looking up pod information by UIDs (of the
 // form: "kubernetes://pod.namespace"). It expects that the UIDs will be
 // supplied in an input map for three distinct traffic classes (source,
-// target, and origin).
+// destination, and origin).
 //
 // For all valid UIDs supplied, this adapter generates a map of output
 // values containing information about the related pods. The generated map
@@ -68,11 +68,11 @@ message Params {
     // Default: sourceUID
     string source_uid_input_name = 3;
 
-    // Configures how the UID for the target pod for traffic is identified
+    // Configures how the UID for the destination pod for traffic is identified
     // in the input map.
     //
-    // Default: targetUID
-    string target_uid_input_name = 4;
+    // Default: destinationUID
+    string destination_uid_input_name = 4;
 
     // Configures how the UID for the origin pod for traffic is identified
     // in the input map.
@@ -86,11 +86,11 @@ message Params {
     // Default: sourceIP
     string source_ip_input_name = 20;
 
-    // Configures how the IP for the target pod for traffic is identified
+    // Configures how the IP for the destination pod for traffic is identified
     // in the input map.
     //
-    // Default: targetIP
-    string target_ip_input_name = 21;
+    // Default: destinationIP
+    string destination_ip_input_name = 21;
 
     // Configures how the IP for the origin pod for traffic is identified
     // in the input map.
@@ -103,14 +103,14 @@ message Params {
     // Default: svc.cluster.local
     string cluster_domain_name = 18;
 
-    // In order to extract the service associated with a source, target, or
+    // In order to extract the service associated with a source, destination, or
     // origin, this adapter relies on pod labels. In particular, it looks for
     // the value of a specific label, as specified by this parameter.
     //
     // Default: app
     string pod_label_for_service = 6;
 
-    // In order to extract the service associated with a source, target, or
+    // In order to extract the service associated with a source, destination, or
     // origin, this adapter relies on pod labels. In particular, it looks for
     // the value of a specific label for istio component services, as specified 
     // by this parameter.
@@ -123,10 +123,10 @@ message Params {
     // Default: source
     string source_prefix = 7;
 
-    // The prefix used for target pod output value names.
+    // The prefix used for destination pod output value names.
     //
-    // Default: target
-    string target_prefix = 8;
+    // Default: destination
+    string destination_prefix = 8;
 
     // The prefix used for origin pod output value names.
     //

--- a/adapter/kubernetes/kubernetes.go
+++ b/adapter/kubernetes/kubernetes.go
@@ -69,13 +69,13 @@ const (
 
 	// input/output naming
 	sourceUID         = "sourceUID"
-	targetUID         = "targetUID"
+	destinationUID    = "destinationUID"
 	originUID         = "originUID"
 	sourceIP          = "sourceIP"
-	targetIP          = "targetIP"
+	destinationIP     = "destinationIP"
 	originIP          = "originIP"
 	sourcePrefix      = "source"
-	targetPrefix      = "target"
+	destinationPrefix = "destination"
 	originPrefix      = "origin"
 	labelsVal         = "Labels"
 	podNameVal        = "PodName"
@@ -100,16 +100,16 @@ var (
 		KubeconfigPath:                   "",
 		CacheRefreshDuration:             defaultRefreshPeriod,
 		SourceUidInputName:               sourceUID,
-		TargetUidInputName:               targetUID,
+		DestinationUidInputName:          destinationUID,
 		OriginUidInputName:               originUID,
 		SourceIpInputName:                sourceIP,
-		TargetIpInputName:                targetIP,
+		DestinationIpInputName:           destinationIP,
 		OriginIpInputName:                originIP,
 		ClusterDomainName:                clusterDomain,
 		PodLabelForService:               podServiceLabel,
 		PodLabelForIstioComponentService: istioPodServiceLabel,
 		SourcePrefix:                     sourcePrefix,
-		TargetPrefix:                     targetPrefix,
+		DestinationPrefix:                destinationPrefix,
 		OriginPrefix:                     originPrefix,
 		LabelsValueName:                  labelsVal,
 		PodNameValueName:                 podNameVal,
@@ -148,8 +148,8 @@ func (*builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	if len(params.SourceUidInputName) == 0 {
 		ce = ce.Appendf("sourceUidInputName", "field must be populated")
 	}
-	if len(params.TargetUidInputName) == 0 {
-		ce = ce.Appendf("targetUidInputName", "field must be populated")
+	if len(params.DestinationUidInputName) == 0 {
+		ce = ce.Appendf("destinationUidInputName", "field must be populated")
 	}
 	if len(params.OriginUidInputName) == 0 {
 		ce = ce.Appendf("originUidInputName", "field must be populated")
@@ -157,8 +157,8 @@ func (*builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	if len(params.SourceIpInputName) == 0 {
 		ce = ce.Appendf("sourceIpInputName", "field must be populated")
 	}
-	if len(params.TargetIpInputName) == 0 {
-		ce = ce.Appendf("targetIpInputName", "field must be populated")
+	if len(params.DestinationIpInputName) == 0 {
+		ce = ce.Appendf("destinationIpInputName", "field must be populated")
 	}
 	if len(params.OriginIpInputName) == 0 {
 		ce = ce.Appendf("originIpInputName", "field must be populated")
@@ -166,8 +166,8 @@ func (*builder) ValidateConfig(c adapter.Config) (ce *adapter.ConfigErrors) {
 	if len(params.SourcePrefix) == 0 {
 		ce = ce.Appendf("sourcePrefix", "field must be populated")
 	}
-	if len(params.TargetPrefix) == 0 {
-		ce = ce.Appendf("targetPrefix", "field must be populated")
+	if len(params.DestinationPrefix) == 0 {
+		ce = ce.Appendf("destinationPrefix", "field must be populated")
 	}
 	if len(params.OriginPrefix) == 0 {
 		ce = ce.Appendf("originPrefix", "field must be populated")
@@ -267,8 +267,8 @@ func (k *kubegen) Generate(inputs map[string]interface{}) (map[string]interface{
 	if id, found := serviceIdentifier(inputs, k.params.SourceUidInputName, k.params.SourceIpInputName); found && len(id) > 0 {
 		k.addValues(values, id, k.params.SourcePrefix)
 	}
-	if id, found := serviceIdentifier(inputs, k.params.TargetUidInputName, k.params.TargetIpInputName); found && len(id) > 0 {
-		k.addValues(values, id, k.params.TargetPrefix)
+	if id, found := serviceIdentifier(inputs, k.params.DestinationUidInputName, k.params.DestinationIpInputName); found && len(id) > 0 {
+		k.addValues(values, id, k.params.DestinationPrefix)
 	}
 	if id, found := serviceIdentifier(inputs, k.params.OriginUidInputName, k.params.OriginIpInputName); found && len(id) > 0 {
 		k.addValues(values, id, k.params.OriginPrefix)

--- a/adapter/kubernetes/kubernetes_test.go
+++ b/adapter/kubernetes/kubernetes_test.go
@@ -235,9 +235,9 @@ func TestKubegen_Generate(t *testing.T) {
 	kg := &kubegen{log: test.NewEnv(t).Logger(), params: *conf, pods: fakeCache{pods: pods}}
 
 	sourceUIDIn := map[string]interface{}{
-		"sourceUID": "kubernetes://test-pod.testns",
-		"targetUID": "kubernetes://badsvcuid",
-		"originUID": "kubernetes://badsvcuid",
+		"sourceUID":      "kubernetes://test-pod.testns",
+		"destinationUID": "kubernetes://badsvcuid",
+		"originUID":      "kubernetes://badsvcuid",
 	}
 
 	sourceUIDOut := map[string]interface{}{
@@ -286,60 +286,60 @@ func TestKubegen_Generate(t *testing.T) {
 		"sourcePodName":   "long-pod",
 	}
 
-	emptySvcIn := map[string]interface{}{"targetUID": "kubernetes://empty.testns"}
+	emptySvcIn := map[string]interface{}{"destinationUID": "kubernetes://empty.testns"}
 
 	emptyServiceOut := map[string]interface{}{
-		"targetLabels": map[string]string{
+		"destinationLabels": map[string]string{
 			"app": "",
 		},
-		"targetNamespace": "testns",
-		"targetPodName":   "empty",
+		"destinationNamespace": "testns",
+		"destinationPodName":   "empty",
 	}
 
-	badTargetSvcIn := map[string]interface{}{"targetUID": "kubernetes://bad-svc-pod.testns"}
+	baddestinationSvcIn := map[string]interface{}{"destinationUID": "kubernetes://bad-svc-pod.testns"}
 
-	badTargetOut := map[string]interface{}{
-		"targetLabels": map[string]string{
+	baddestinationOut := map[string]interface{}{
+		"destinationLabels": map[string]string{
 			"app": ":",
 		},
-		"targetNamespace": "testns",
-		"targetPodName":   "bad-svc-pod",
+		"destinationNamespace": "testns",
+		"destinationPodName":   "bad-svc-pod",
 	}
 
-	ipTargetSvcIn := map[string]interface{}{"targetIP": []uint8(net.ParseIP("192.168.234.3"))}
+	ipdestinationSvcIn := map[string]interface{}{"destinationIP": []uint8(net.ParseIP("192.168.234.3"))}
 
-	ipTargetOut := map[string]interface{}{
-		"targetLabels": map[string]string{
+	ipdestinationOut := map[string]interface{}{
+		"destinationLabels": map[string]string{
 			"app": "ipAddr",
 		},
-		"targetNamespace": "testns",
-		"targetPodName":   "ip-svc-pod",
-		"targetService":   "ipAddr.testns.svc.cluster.local",
+		"destinationNamespace": "testns",
+		"destinationPodName":   "ip-svc-pod",
+		"destinationService":   "ipAddr.testns.svc.cluster.local",
 	}
 
-	istioTargetSvcIn := map[string]interface{}{
-		"targetUID": "kubernetes://istio-ingress.testns",
+	istiodestinationSvcIn := map[string]interface{}{
+		"destinationUID": "kubernetes://istio-ingress.testns",
 	}
 
-	istioTargetOut := map[string]interface{}{
-		"targetLabels": map[string]string{
+	istiodestinationOut := map[string]interface{}{
+		"destinationLabels": map[string]string{
 			"istio": "ingress",
 		},
-		"targetNamespace": "testns",
-		"targetPodName":   "istio-ingress",
-		"targetService":   "ingress.testns.svc.cluster.local",
+		"destinationNamespace": "testns",
+		"destinationPodName":   "istio-ingress",
+		"destinationService":   "ingress.testns.svc.cluster.local",
 	}
 
 	ipAppSvcIn := map[string]interface{}{
-		"targetUID": "kubernetes://ipApp.testns",
+		"destinationUID": "kubernetes://ipApp.testns",
 	}
 
-	ipAppTargetOut := map[string]interface{}{
-		"targetLabels": map[string]string{
+	ipAppdestinationOut := map[string]interface{}{
+		"destinationLabels": map[string]string{
 			"app": "10.1.10.1",
 		},
-		"targetNamespace": "testns",
-		"targetPodName":   "ipApp",
+		"destinationNamespace": "testns",
+		"destinationPodName":   "ipApp",
 	}
 
 	tests := []struct {
@@ -347,15 +347,15 @@ func TestKubegen_Generate(t *testing.T) {
 		inputs map[string]interface{}
 		want   map[string]interface{}
 	}{
-		{"source pod and target service", sourceUIDIn, sourceUIDOut},
+		{"source pod and destination service", sourceUIDIn, sourceUIDOut},
 		{"alternate service canonicalization (namespace)", nsAppLabelIn, nsAppLabelOut},
 		{"alternate service canonicalization (svc cluster)", svcClusterIn, svcClusterOut},
 		{"alternate service canonicalization (long svc)", longSvcClusterIn, longSvcClusterOut},
 		{"empty service", emptySvcIn, emptyServiceOut},
-		{"bad target service", badTargetSvcIn, badTargetOut},
-		{"target ip pod", ipTargetSvcIn, ipTargetOut},
-		{"istio service", istioTargetSvcIn, istioTargetOut},
-		{"ip app", ipAppSvcIn, ipAppTargetOut},
+		{"bad destination service", baddestinationSvcIn, baddestinationOut},
+		{"destination ip pod", ipdestinationSvcIn, ipdestinationOut},
+		{"istio service", istiodestinationSvcIn, istiodestinationOut},
+		{"ip app", ipAppSvcIn, ipAppdestinationOut},
 	}
 
 	for _, v := range tests {

--- a/testdata/configroot/scopes/global/subjects/global/rules.yml
+++ b/testdata/configroot/scopes/global/subjects/global/rules.yml
@@ -11,19 +11,16 @@ rules:
       input_expressions:
         sourceUID: source.uid | ""
         sourceIP: source.ip | ip("0.0.0.0") # default to unspecified ip addr
-        targetUID: destination.uid | ""
-        targetIP: destination.ip | ip("0.0.0.0") # default to unspecified ip addr
+        destinationUID: destination.uid | ""
+        destinationIP: destination.ip | ip("0.0.0.0") # default to unspecified ip addr
       attribute_bindings:
         source.ip: sourcePodIp
         source.labels: sourceLabels
-        source.name: sourcePodName
         source.namespace: sourceNamespace
         source.service: sourceService
         source.serviceAccount: sourceServiceAccountName
-        destination.ip: targetPodIp
-        destination.labels: targetLabels
-        destination.name: targetPodName
-        destination.namespace: targetNamespace
-        destination.service: targetService
-        destination.serviceAccount: targetServiceAccountName
-        
+        destination.ip: destinationPodIp
+        destination.labels: destinationLabels
+        destination.namespace: destinationNamespace
+        destination.service: destinationService
+        destination.serviceAccount: destinationServiceAccountName


### PR DESCRIPTION
This PR converts all of the internal k8s adapter config to use `destination` instead of `target`.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Convert k8s to use destination namespace
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1308)
<!-- Reviewable:end -->
