### PR TITLE
Fully qualify mixer deps in generate.bzl

### DIFF
--- a/tools/codegen/generate.bzl
+++ b/tools/codegen/generate.bzl
@@ -3,8 +3,8 @@ load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogoslick_proto_library", "g
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 MIXER_DEPS = [
-    "//pkg/adapter:go_default_library",
-    "//pkg/adapter/template:go_default_library",
+    "@com_github_istio_mixer//pkg/adapter:go_default_library",
+    "@com_github_istio_mixer//pkg/adapter/template:go_default_library",
     "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
 ]
 MIXER_INPUTS = [
@@ -19,7 +19,7 @@ MIXER_IMPORT_MAP = {
 # including the "../.." is an ugly workaround for differing exec ctx for bazel rules
 # depending on whether or not we are building within mixer proper or in a third-party repo
 # that depends on mixer proper. 
-MIXER_IMPORTS = [ "external/com_github_istio_api", "../../external/com_github_istio_api", "external/com_github_istio_mixer" ]
+MIXER_IMPORTS = [ "external/com_github_istio_api", "../../external/com_github_istio_api", "external/com_github_istio_mixer" ] # [, "bazel-out/darwin_x86_64-fastbuild/genfiles/" ]
 
 # TODO: fill in with complete set of GOGO DEPS and IMPORT MAPPING
 GOGO_DEPS = [
@@ -52,9 +52,9 @@ def _gen_template_and_handler(name, importmap = {}):
        "name": name + "_handler",
        "srcs": [ src_desc ],
        "outs": [ gen_handler, gen_tmpl ],
-       "tools": [ "//tools/codegen/cmd/mixgenproc" ],
+       "tools": [ "@com_github_istio_mixer//tools/codegen/cmd/mixgenproc" ],
        "message": "Generating handler code from descriptor",
-       "cmd": "$(location //tools/codegen/cmd/mixgenproc) " 
+       "cmd": "$(location @com_github_istio_mixer//tools/codegen/cmd/mixgenproc) " 
             + "$(location %s) -o=$(location %s) -t=$(location %s) %s" % (src_desc, gen_handler, gen_tmpl, m)
    }
 
@@ -125,16 +125,16 @@ def _mixer_supported_template_gen(name, packages, out):
       name = name+"_gen",
       srcs = descriptors,
       outs = [out],
-      cmd = "$(location //tools/codegen/cmd/mixgenbootstrap) " + args + " -o $(location %s)" % (out),
-      tools = ["//tools/codegen/cmd/mixgenbootstrap"],
+      cmd = "$(location @com_github_istio_mixer//tools/codegen/cmd/mixgenbootstrap) " + args + " -o $(location %s)" % (out),
+      tools = ["@com_github_istio_mixer//tools/codegen/cmd/mixgenbootstrap"],
   )
 
 DEPS_FOR_ALL_TMPLS = [
-    "//pkg/adapter:go_default_library",
-    "//pkg/adapter/template:go_default_library",
-    "//pkg/attribute:go_default_library",
-    "//pkg/expr:go_default_library",
-    "//pkg/template:go_default_library",
+    "@com_github_istio_mixer//pkg/adapter:go_default_library",
+    "@com_github_istio_mixer//pkg/adapter/template:go_default_library",
+    "@com_github_istio_mixer//pkg/attribute:go_default_library",
+    "@com_github_istio_mixer//pkg/expr:go_default_library",
+    "@com_github_istio_mixer//pkg/template:go_default_library",
     "@com_github_gogo_protobuf//proto:go_default_library",
     "@com_github_golang_glog//:go_default_library",
     "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep


### PR DESCRIPTION
WIP. DO NOT SUBMIT.

This PR adds a few repo ids to imports and tool refs in the `generate.bzl` script. These will be necessary for use in 3rd party repos.

WARNING: Need to verify that this will not break the 3rd party adapter build scenario before this is merge-worthy.

However, I've validated this with a test repo for 3rd party templates.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1313)
<!-- Reviewable:end -->
