### PR TITLE
Enable :9093/config endpoint to get status of runtime config resources

### DIFF
--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	_ "expvar" // For /debug/vars registration. Note: temporary, NOT for general use
 	"fmt"
 	"io/ioutil"
@@ -59,6 +60,7 @@ import (
 const (
 	metricsPath = "/metrics"
 	versionPath = "/version"
+	configPath  = "/config/"
 )
 
 type serverArgs struct {
@@ -122,6 +124,11 @@ type ServerContext struct {
 	GP        *pool.GoroutinePool
 	AdapterGP *pool.GoroutinePool
 	Server    *grpc.Server
+}
+
+// ConfigGetter gives access to Mixer config snapshot.
+type ConfigGetter interface {
+	ConfigGet(path string) *store.Resource
 }
 
 func serverCmd(info map[string]template.Info, adapters []adptr.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
@@ -272,6 +279,7 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 	}
 
 	var dispatcher mixerRuntime.Dispatcher
+	var configGetter ConfigGetter
 
 	if sa.configStore2URL == "" {
 		printf("configStore2URL is not specified, assuming inCluster Kubernetes")
@@ -283,7 +291,7 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 	if err != nil {
 		fatalf("Failed to connect to the configuration server. %v", err)
 	}
-	dispatcher, err = mixerRuntime.New(eval, gp, adapterGP,
+	dispatcher, configGetter, err = mixerRuntime.New(eval, gp, adapterGP,
 		sa.configIdentityAttribute, sa.configDefaultNamespace,
 		store2, adapterMap, info,
 	)
@@ -408,17 +416,39 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 		fatalf("Unable to listen on socket: %v", err)
 	}
 
+	sm := http.NewServeMux()
 	// NOTE: this is a temporary solution for provide bare-bones debug functionality
 	// for mixer. a full design / implementation of self-monitoring and reporting
 	// is coming. that design will include proper coverage of statusz/healthz type
 	// functionality, in addition to how mixer reports its own metrics.
-	http.Handle(metricsPath, promhttp.Handler())
-	http.HandleFunc(versionPath, func(out http.ResponseWriter, req *http.Request) {
+	sm.Handle(metricsPath, promhttp.Handler())
+	sm.HandleFunc(versionPath, func(out http.ResponseWriter, req *http.Request) {
 		if _, verErr := out.Write([]byte(version.Info.String())); verErr != nil {
 			printf("error printing version info: %v", verErr)
 		}
 	})
-	monitoring := &http.Server{Addr: fmt.Sprintf(":%d", sa.monitoringPort)}
+	sm.HandleFunc(configPath, func(out http.ResponseWriter, req *http.Request) {
+		path := req.URL.Path[len(configPath):len(req.URL.Path)]
+		cfg := configGetter.ConfigGet(path)
+		if cfg == nil {
+			out.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		var ba []byte
+		var verr error
+
+		if ba, verr = json.Marshal(cfg); err != nil {
+			printf("error converting %v: %v", cfg, verr)
+			out.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		out.Header().Add("content-type", "application/json")
+		if _, verr = out.Write(ba); verr != nil {
+			printf("error printing version info: %v", verr)
+		}
+	})
+	monitoring := &http.Server{Addr: fmt.Sprintf(":%d", sa.monitoringPort), Handler: sm}
 	printf("Starting self-monitoring on port %d", sa.monitoringPort)
 	go func() {
 		if monErr := monitoring.Serve(monitoringListener.(*net.TCPListener)); monErr != nil {

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -60,7 +60,7 @@ import (
 const (
 	metricsPath = "/metrics"
 	versionPath = "/version"
-	configPath  = "/config/"
+	configPath  = "/debug/config/resources/"
 )
 
 type serverArgs struct {

--- a/pkg/config/store/store2.go
+++ b/pkg/config/store/store2.go
@@ -67,6 +67,7 @@ type Resource struct {
 	Status   Status        `json:"status"`
 }
 
+// Code is textual status code in Status.
 type Code string
 
 const (

--- a/pkg/config/store/store2.go
+++ b/pkg/config/store/store2.go
@@ -47,11 +47,11 @@ type BackendEvent struct {
 
 // ResourceMeta is the standard metadata associated with a resource.
 type ResourceMeta struct {
-	Name        string
-	Namespace   string
-	Labels      map[string]string
-	Annotations map[string]string
-	Revision    string
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Revision    string            `json:"revision"`
 }
 
 // BackEndResource represents a resources with a raw spec
@@ -62,8 +62,30 @@ type BackEndResource struct {
 
 // Resource represents a resources with converted spec.
 type Resource struct {
-	Metadata ResourceMeta
-	Spec     proto.Message
+	Metadata ResourceMeta  `json:"metadata"`
+	Spec     proto.Message `json:"spec"`
+	Status   Status        `json:"status"`
+}
+
+type Code string
+
+const (
+	// Active - the resource is active.
+	Active Code = "active"
+	// PendingUpdate - the resource is pending updation.
+	PendingUpdate Code = "pendingUpdate"
+	// PendingDelete - the resource is pending deletion.
+	PendingDelete Code = "pendingDelete"
+	// InError - the resource is in error.
+	InError Code = "error"
+)
+
+// Status is the current status of a resource.
+type Status struct {
+	// Code for this status.
+	Code Code `json:"code"`
+	// Errors
+	Errors []string `json:"errors,omitempty"`
 }
 
 // String is the Istio compatible string representation of the resource.

--- a/pkg/config/store/store2.go
+++ b/pkg/config/store/store2.go
@@ -62,29 +62,29 @@ type BackEndResource struct {
 
 // Resource represents a resources with converted spec.
 type Resource struct {
-	Metadata ResourceMeta  `json:"metadata"`
-	Spec     proto.Message `json:"spec"`
-	Status   Status        `json:"status"`
+	Metadata ResourceMeta   `json:"metadata"`
+	Spec     proto.Message  `json:"spec"`
+	Status   ResourceStatus `json:"status"`
 }
 
-// Code is textual status code in Status.
-type Code string
+// ResourcePhase is the phase of a Resource.
+type ResourcePhase string
 
 const (
-	// Active - the resource is active.
-	Active Code = "active"
-	// PendingUpdate - the resource is pending updation.
-	PendingUpdate Code = "pendingUpdate"
-	// PendingDelete - the resource is pending deletion.
-	PendingDelete Code = "pendingDelete"
-	// InError - the resource is in error.
-	InError Code = "error"
+	// ResourceActive - the resource is active.
+	ResourceActive ResourcePhase = "active"
+	// ResourcePendingUpdate - the resource is pending an update.
+	ResourcePendingUpdate ResourcePhase = "pendingUpdate"
+	// ResourcePendingDelete - the resource is pending deletion.
+	ResourcePendingDelete ResourcePhase = "pendingDelete"
+	// ResourceInError - the resource is in error.
+	ResourceInError ResourcePhase = "error"
 )
 
-// Status is the current status of a resource.
-type Status struct {
-	// Code for this status.
-	Code Code `json:"code"`
+// ResourceStatus is the current status of a resource.
+type ResourceStatus struct {
+	// Phase for this resource.
+	Phase ResourcePhase `json:"phase"`
 	// Errors
 	Errors []string `json:"errors,omitempty"`
 }

--- a/pkg/runtime/controller_test.go
+++ b/pkg/runtime/controller_test.go
@@ -125,7 +125,7 @@ func TestController_ConfigGet(t *testing.T) {
 		path string
 		key  *store.Key
 		res  *store.Resource
-		st   *store.Status
+		st   *store.ResourceStatus
 		want *store.Resource
 	}{
 		{
@@ -136,8 +136,8 @@ func TestController_ConfigGet(t *testing.T) {
 			},
 			want: &store.Resource{
 				Spec: &wrappers.StringValue{"This String1"},
-				Status: store.Status{
-					Code: store.Active,
+				Status: store.ResourceStatus{
+					Phase: store.ResourceActive,
 				},
 			},
 		},
@@ -150,8 +150,8 @@ func TestController_ConfigGet(t *testing.T) {
 			},
 			want: &store.Resource{
 				Spec: &wrappers.StringValue{"This String2"},
-				Status: store.Status{
-					Code: store.Active,
+				Status: store.ResourceStatus{
+					Phase: store.ResourceActive,
 				},
 			},
 		},
@@ -160,7 +160,7 @@ func TestController_ConfigGet(t *testing.T) {
 		{
 			desc: "deleted resource",
 			key:  &store.Key{"k1", "ns1", "res1"},
-			st:   &store.Status{Code: store.PendingDelete},
+			st:   &store.ResourceStatus{Phase: store.ResourcePendingDelete},
 			want: &store.Resource{
 				Metadata: store.ResourceMeta{
 					Name:      "res1",
@@ -171,7 +171,7 @@ func TestController_ConfigGet(t *testing.T) {
 		{
 			desc: "updated resource",
 			key:  &store.Key{"k1", "ns1", "res1"},
-			st:   &store.Status{Code: store.PendingUpdate},
+			st:   &store.ResourceStatus{Phase: store.ResourcePendingUpdate},
 			res: &store.Resource{
 				Spec: &wrappers.StringValue{"This String"},
 			},

--- a/pkg/runtime/controller_test.go
+++ b/pkg/runtime/controller_test.go
@@ -119,6 +119,102 @@ func checkRulesInvariants(t *testing.T, rules rulesListByNamespace) {
 	}
 }
 
+func TestController_ConfigGet(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		path string
+		key  *store.Key
+		res  *store.Resource
+		st   *store.Status
+		want *store.Resource
+	}{
+		{
+			desc: "good resource",
+			key:  &store.Key{"k1", "ns1", "res1"},
+			res: &store.Resource{
+				Spec: &wrappers.StringValue{"This String1"},
+			},
+			want: &store.Resource{
+				Spec: &wrappers.StringValue{"This String1"},
+				Status: store.Status{
+					Code: store.Active,
+				},
+			},
+		},
+		{
+			desc: "good resource with dot path",
+			key:  &store.Key{"k1", "ns1", "res1"},
+			path: store.Key{"k1", "ns1", "res1"}.String(),
+			res: &store.Resource{
+				Spec: &wrappers.StringValue{"This String2"},
+			},
+			want: &store.Resource{
+				Spec: &wrappers.StringValue{"This String2"},
+				Status: store.Status{
+					Code: store.Active,
+				},
+			},
+		},
+		{desc: "bad path",
+			path: "/abcd"},
+		{
+			desc: "deleted resource",
+			key:  &store.Key{"k1", "ns1", "res1"},
+			st:   &store.Status{Code: store.PendingDelete},
+			want: &store.Resource{
+				Metadata: store.ResourceMeta{
+					Name:      "res1",
+					Namespace: "ns1",
+				},
+			},
+		},
+		{
+			desc: "updated resource",
+			key:  &store.Key{"k1", "ns1", "res1"},
+			st:   &store.Status{Code: store.PendingUpdate},
+			res: &store.Resource{
+				Spec: &wrappers.StringValue{"This String"},
+			},
+		},
+		{
+			desc: "missing resource",
+			key:  &store.Key{"k1", "ns1", "res1"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			sm := make(StatusMap)
+			cs := make(map[store.Key]*store.Resource)
+
+			if tc.res != nil {
+				cs[*tc.key] = tc.res
+			}
+
+			if tc.st != nil {
+				sm[tc.key.String()] = tc.st
+			}
+			c := &Controller{
+				configStatus: sm,
+				configState:  cs,
+			}
+			path := tc.path
+			if path == "" && tc.key != nil {
+				path = tc.key.Namespace + "/" + tc.key.Kind + "/" + tc.key.Name
+			}
+			res := c.ConfigGet(path)
+			if tc.want == nil && tc.res != nil {
+				tc.want = tc.res
+			}
+
+			if tc.want != nil && tc.st != nil {
+				tc.want.Status = *tc.st
+			}
+			if !reflect.DeepEqual(res, tc.want) {
+				t.Fatalf("got %v, want %v", res, tc.want)
+			}
+		})
+	}
+}
+
 func TestController_workflow(t *testing.T) {
 	mcd := maxCleanupDuration
 	defer func() { maxCleanupDuration = mcd }()
@@ -165,6 +261,7 @@ func TestController_workflow(t *testing.T) {
 			df expr.AttributeDescriptorFinder, builderInfo map[string]*adapter.Info) HandlerFactory {
 			return fb
 		},
+		configStatus: make(StatusMap),
 	}
 
 	go func() {
@@ -444,7 +541,8 @@ func TestController_Resolve2(t *testing.T) {
 		}, 1},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, n := generateResolvedRules(rc(), tc.ht)
+			sm := make(StatusMap)
+			_, n := generateResolvedRules(rc(), tc.ht, sm)
 			if n != tc.numRules {
 				t.Fatalf("nrules got: %d, want %d", n, tc.numRules)
 			}


### PR DESCRIPTION
This PR adds `/config/` endpoint to Mixer to query mixer current runtime state for config resources.
It addresses lack of problem determination tools for mixer. If a rule or handler is not taking affect, an operator can use this endpoint to query mixer.

example when an error had occurred.
```
mjog-macbookpro:~ mjog$ curl http://localhost:9093/config/istio-config-default/rule/promtcp  | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   686  100   686    0     0   112k      0 --:--:-- --:--:-- --:--:--  133k
{
  "metadata": {
    "name": "promtcp",
    "namespace": "istio-config-default",
    "labels": {
      "istio-protocol": "tcp"
    },
    "revision": ""
  },
  "spec": {
    "actions": [
      {
        "handler": "handler.prometheus.istio-config-default",
        "instances": [
          "tcpbytesent.metric.istio-config-default",
          "tcpbytereceived.metric.istio-config-default"
        ]
      }
    ]
  },
  "status": {
    "code": "error",
    "errors": [
      "Filtering action from rule istio-config-default/promtcp. Handler handler.prometheus.istio-config-default could not be initialized due to cannot infer type information from params in instance 'requestsize.metric.istio-config-default': OR($request.size, \"abcd\") arg 2 (\"abcd\") typeError got STRING, expected INT64.",
      "Purging rule promtcp with no actions"
    ]
  }
}

```

```release-note
A config endpoint is available on the mixer self monitoring port. 
curl mixer:9093/config/$full_name_of_config_resource

If resource is not present, returns 404
If resource is present, resource.status field contains status.
If status.code == "error", status.errors contains a list of textual errors.

status codes: [ "active", "pendingUpdate", "pendingDelete", "error" ]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1325)
<!-- Reviewable:end -->
