### PR TITLE
Replacement for istio-protocol == "tcp" by processing for context.protocol 

### DIFF
--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -421,6 +421,7 @@ func extractEQMatches(ex *Expression, eqMap map[string]interface{}) {
 	if ex.Fn.Name != "LAND" && ex.Fn.Name != "EQ" {
 		return
 	}
+	//TODO remove collected equality expression from AST
 	recordEQ(ex.Fn, eqMap)
 	for _, arg := range ex.Fn.Args {
 		extractEQMatches(arg, eqMap)

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -390,12 +390,14 @@ func Parse(src string) (ex *Expression, err error) {
 	return ex, nil
 }
 
-// ExtractEQMatches returns a list of attribute <names, values>
-// in literal equality comparisons. The invariant is that if
-// **any* of these comparisons is False, the expression will evaluate to false.
-// For example `destination.service` == "abc"
-// context.protocol == "TCP"
-// can be preprocessed for static equality matches.
+// ExtractEQMatches extracts equality sub expressions from the match expression.
+// It only extracts `attribute == literal` type equality matches.
+// It returns a list of  <attribute name, value> such that
+// if **any** of these comparisons is false, the expression will evaluate to false.
+// These sub expressions can be hoisted out of the match clause and evaluated separately.
+// For example
+// destination.service == "abc"  -- Used to index rules by destination service.
+// context.protocol == "tcp"  -- Used to filter rules by context
 func ExtractEQMatches(src string) (map[string]interface{}, error) {
 	ex, err := Parse(src)
 	if err != nil {

--- a/pkg/expr/expr_test.go
+++ b/pkg/expr/expr_test.go
@@ -94,8 +94,15 @@ func TestExtractMatches(t *testing.T) {
 			m:    map[string]interface{}{},
 		},
 		{
+			desc: "yoda",
+			src:  `"d" == c`,
+			m: map[string]interface{}{
+				"c": "d",
+			},
+		},
+		{
 			desc: "only top level ANDS",
-			src:  `a.b == 3.14 && c == "d" && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
+			src:  `a.b == 3.14 && "d" == c && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
 			m: map[string]interface{}{
 				"a.b": 3.14,
 				"c":   "d",

--- a/pkg/expr/expr_test.go
+++ b/pkg/expr/expr_test.go
@@ -48,7 +48,8 @@ func TestGoodParse(t *testing.T) {
 		{`request.header["X-FORWARDED-HOST"] == "aaa"`, `EQ(INDEX($request.header, "X-FORWARDED-HOST"), "aaa")`},
 		{`source.ip | ip("0.0.0.0")`, `OR($source.ip, ip("0.0.0.0"))`},
 		{`match(service.name, "cluster1.ns.*")`, `match($service.name, "cluster1.ns.*")`},
-		{`a.b == 3.14 && c == "d" && r.h["abc"] == "pqr" || r.h["abc"] == "xyz"`, `EQ($a.b, 3.14)`},
+		{`a.b == 3.14 && c == "d" && r.h["abc"] == "pqr" || r.h["abc"] == "xyz"`,
+			`LOR(LAND(LAND(EQ($a.b, 3.14), EQ($c, "d")), EQ(INDEX($r.h, "abc"), "pqr")), EQ(INDEX($r.h, "abc"), "xyz"))`},
 	}
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.src), func(t *testing.T) {

--- a/pkg/expr/expr_test.go
+++ b/pkg/expr/expr_test.go
@@ -48,6 +48,7 @@ func TestGoodParse(t *testing.T) {
 		{`request.header["X-FORWARDED-HOST"] == "aaa"`, `EQ(INDEX($request.header, "X-FORWARDED-HOST"), "aaa")`},
 		{`source.ip | ip("0.0.0.0")`, `OR($source.ip, ip("0.0.0.0"))`},
 		{`match(service.name, "cluster1.ns.*")`, `match($service.name, "cluster1.ns.*")`},
+		{`a.b == 3.14 && c == "d" && r.h["abc"] == "pqr" || r.h["abc"] == "xyz"`, `EQ($a.b, 3.14)`},
 	}
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.src), func(t *testing.T) {
@@ -58,6 +59,74 @@ func TestGoodParse(t *testing.T) {
 			}
 			if tt.postfix != ex.String() {
 				t.Errorf("got %s\nwant: %s", ex.String(), tt.postfix)
+			}
+		})
+	}
+}
+
+func TestExtractMatches(t *testing.T) {
+	for _, tc := range []struct {
+		src string
+		m   map[string]interface{}
+	}{
+		{
+			src: `a || b || "c" || ( a && b )`,
+			m:   map[string]interface{}{},
+		},
+		{
+			src: `substring(a, 5) == "abc"`,
+			m:   map[string]interface{}{},
+		},
+		{
+			src: `origin.host == "9.0.10.1"`,
+			m: map[string]interface{}{
+				"origin.host": "9.0.10.1",
+			},
+		},
+		{
+			src: `a.b == 3.14 && c == "d" && r.h["abc"] == "pqr" || r.h["abc"] == "xyz"`,
+			m:   map[string]interface{}{},
+		},
+		{
+			src: `a.b == 3.14 && c == "d" && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
+			m: map[string]interface{}{
+				"a.b": 3.14,
+				"c":   "d",
+			},
+		},
+		{
+			src: `a.b == 3.14 && c == d && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
+			m: map[string]interface{}{
+				"a.b": 3.14,
+			},
+		},
+		{
+			src: `c == d && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz") && a.b == 3.14`,
+			m: map[string]interface{}{
+				"a.b": 3.14,
+			},
+		},
+		{ // c == d is not included because it is an attribute to attribute comparison.
+			src: `c == d && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz") && a.b == 3.14 && context.protocol == "TCP"`,
+			m: map[string]interface{}{
+				"context.protocol": "TCP",
+				"a.b":              3.14,
+			},
+		},
+		{
+			src: `destination.service == "mysvc.FQDN" && request.headers["x-id"] == "AAA"`,
+			m: map[string]interface{}{
+				"destination.service": "mysvc.FQDN",
+			},
+		},
+	} {
+		t.Run(tc.src, func(t *testing.T) {
+			m, err := ExtractEQMatches(tc.src)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(m, tc.m) {
+				t.Fatalf("got %v, want %v", m, tc.m)
 			}
 		})
 	}

--- a/pkg/expr/expr_test.go
+++ b/pkg/expr/expr_test.go
@@ -67,36 +67,43 @@ func TestGoodParse(t *testing.T) {
 
 func TestExtractMatches(t *testing.T) {
 	for _, tc := range []struct {
-		src string
-		m   map[string]interface{}
+		desc string
+		src  string
+		m    map[string]interface{}
 	}{
 		{
-			src: `a || b || "c" || ( a && b )`,
-			m:   map[string]interface{}{},
+			desc: "no ANDS",
+			src:  `a || b || "c" || ( a && b )`,
+			m:    map[string]interface{}{},
 		},
 		{
-			src: `substring(a, 5) == "abc"`,
-			m:   map[string]interface{}{},
+			desc: "EQ check with function",
+			src:  `substring(a, 5) == "abc"`,
+			m:    map[string]interface{}{},
 		},
 		{
-			src: `origin.host == "9.0.10.1"`,
+			desc: "single EQ check",
+			src:  `origin.host == "9.0.10.1"`,
 			m: map[string]interface{}{
 				"origin.host": "9.0.10.1",
 			},
 		},
 		{
-			src: `a.b == 3.14 && c == "d" && r.h["abc"] == "pqr" || r.h["abc"] == "xyz"`,
-			m:   map[string]interface{}{},
+			desc: "top level OR --> cannot extract equality subexpressions",
+			src:  `a.b == 3.14 && c == "d" && r.h["abc"] == "pqr" || r.h["abc"] == "xyz"`,
+			m:    map[string]interface{}{},
 		},
 		{
-			src: `a.b == 3.14 && c == "d" && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
+			desc: "only top level ANDS",
+			src:  `a.b == 3.14 && c == "d" && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
 			m: map[string]interface{}{
 				"a.b": 3.14,
 				"c":   "d",
 			},
 		},
 		{
-			src: `a.b == 3.14 && c == d && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
+			desc: "only top level ANDS, attribute to attribute comparison excluded",
+			src:  `a.b == 3.14 && c == d && (r.h["abc"] == "pqr" || r.h["abc"] == "xyz")`,
 			m: map[string]interface{}{
 				"a.b": 3.14,
 			},
@@ -121,7 +128,7 @@ func TestExtractMatches(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.src, func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			m, err := ExtractEQMatches(tc.src)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/pkg/runtime/controller.go
+++ b/pkg/runtime/controller.go
@@ -331,8 +331,12 @@ const (
 	istioProtocol = "istio-protocol"
 )
 
+func buildRule(labels map[string]string, r *cpb.Rule) {
+
+}
+
 // resourceType maps labels to rule types.
-func resourceType(labels map[string]string) ResourceType {
+func resourceType(labels map[string]string, match string) ResourceType {
 	ip := labels[istioProtocol]
 	rt := defaultResourcetype()
 	if ip == "tcp" {
@@ -358,10 +362,16 @@ func (c *Controller) processRules(handlerConfig map[string]*cpb.Handler,
 
 		cfg := obj.Spec
 		rulec := cfg.(*cpb.Rule)
+		if rulec.Match != "" {
+			m, err := expr.ExtractEQMatches(rulec.Match)
+			if err != nil {
+
+			}
+		}
 		rule := &Rule{
 			selector: rulec.Match,
 			name:     k.Name,
-			rtype:    resourceType(obj.Metadata.Labels),
+			rtype:    resourceType(obj.Metadata.Labels, rulec.Match),
 		}
 		acts := c.processActions(rulec.Actions, handlerConfig, instanceConfig, ht, k.Namespace)
 

--- a/pkg/runtime/dispatcher.go
+++ b/pkg/runtime/dispatcher.go
@@ -111,7 +111,7 @@ func newDispatcher(mapper expr.Evaluator, rt Resolver, gp *pool.GoroutinePool) *
 // dispatcher is responsible for dispatching incoming API calls
 // to the configured adapters. It implements the Dispatcher interface.
 type dispatcher struct {
-	// mapper is the selector and expression evaluator.
+	// mapper is the match and expression evaluator.
 	// It is not directly used by dispatcher.
 	mapper expr.Evaluator
 

--- a/pkg/runtime/resolver.go
+++ b/pkg/runtime/resolver.go
@@ -32,18 +32,20 @@ import (
 
 // Rule represents a runtime view of cpb.Rule.
 type Rule struct {
-	// Selector from the original rule.
-	selector string
+	// Match condition from the original rule.
+	match string
 	// Actions are stored in runtime format.
 	actions map[adptTmpl.TemplateVariety][]*Action
 	// Rule is a top level config object and it has a unique name.
 	// It is used here for informational purposes.
 	name string
-	// destination shortname of this service.
-	// destination.namespace.domain is the FQDN of the service.
-	destination string
 	// rtype is gathered from labels.
 	rtype ResourceType
+}
+
+func (r Rule) String() string {
+	return fmt.Sprintf("[name:<%s>, match:<%s>, type:%s, actions: %v",
+		r.name, r.match, r.rtype, r.actions)
 }
 
 // resolver is the runtime view of the configuration database.
@@ -84,17 +86,22 @@ func newResolver(evaluator expr.PredicateEvaluator, identityAttribute string, de
 	}
 }
 
-// DefaultConfigNamespace holds istio wide configuration.
-const DefaultConfigNamespace = "istio-config-default"
+const (
+	// DefaultConfigNamespace holds istio wide configuration.
+	DefaultConfigNamespace = "istio-config-default"
 
-// DefaultIdentityAttribute is attribute that defines config scopes.
-const DefaultIdentityAttribute = "target.service"
+	// DefaultIdentityAttribute is attribute that defines config scopes.
+	DefaultIdentityAttribute = "destination.service"
 
-// ContextProtocolAttributeName is the attribute that defines the protocol context.
-const ContextProtocolAttributeName = "context.protocol"
+	// ContextProtocolAttributeName is the attribute that defines the protocol context.
+	ContextProtocolAttributeName = "context.protocol"
 
-// expectedResolvedActionsCount is used to preallocate slice for actions.
-const expectedResolvedActionsCount = 10
+	// ContextProtocolTCP defines constant for tcp protocol.
+	ContextProtocolTCP = "tcp"
+
+	// expectedResolvedActionsCount is used to preallocate slice for actions.
+	expectedResolvedActionsCount = 10
+)
 
 // Resolve resolves the in memory configuration to a set of actions based on request attributes.
 // Resolution is performed in the following order
@@ -199,12 +206,12 @@ func (r *resolver) filterActions(rulesArr [][]*Rule, attrs attribute.Bag,
 	nselected := 0
 	var err error
 	ctxProtocol, _ := attrs.Get(ContextProtocolAttributeName)
-	tcp := ctxProtocol == "tcp"
+	tcp := ctxProtocol == ContextProtocolTCP
 
 	for _, rules := range rulesArr {
 		for _, rule := range rules {
 			act := rule.actions[variety]
-			if act == nil { // do not evaluate selector if there is no variety specific action there.
+			if act == nil { // do not evaluate match if there is no variety specific action there.
 				continue
 			}
 			// default rtype is HTTP + Check|Report|Preprocess
@@ -216,8 +223,8 @@ func (r *resolver) filterActions(rulesArr [][]*Rule, attrs attribute.Bag,
 			}
 
 			// do not evaluate empty predicates.
-			if len(rule.selector) != 0 {
-				if selected, err = r.evaluator.EvalPredicate(rule.selector, attrs); err != nil {
+			if len(rule.match) != 0 {
+				if selected, err = r.evaluator.EvalPredicate(rule.match, attrs); err != nil {
 					return nil, 0, err
 				}
 				if !selected {

--- a/pkg/runtime/resolver.go
+++ b/pkg/runtime/resolver.go
@@ -39,6 +39,9 @@ type Rule struct {
 	// Rule is a top level config object and it has a unique name.
 	// It is used here for informational purposes.
 	name string
+	// destination shortname of this service.
+	// destination.namespace.domain is the FQDN of the service.
+	destination string
 	// rtype is gathered from labels.
 	rtype ResourceType
 }

--- a/pkg/runtime/resolver_test.go
+++ b/pkg/runtime/resolver_test.go
@@ -127,7 +127,7 @@ func TestResolver_Resolve(t *testing.T) {
 			err:  "identity not found",
 		},
 		{
-			desc: "failure selector error",
+			desc: "failure match error",
 			bag: map[string]interface{}{
 				ia: "myservice.myns",
 			},
@@ -135,8 +135,8 @@ func TestResolver_Resolve(t *testing.T) {
 				{ns, 5},
 				{"myns", 3},
 			},
-			selectError: "invalid selector syntax",
-			err:         "invalid selector",
+			selectError: "invalid match syntax",
+			err:         "invalid match",
 			nactions:    0,
 		},
 	}
@@ -209,7 +209,7 @@ func assertResolverError(t *testing.T, got error, want string) {
 
 func newFakeRule(vr adptTmpl.TemplateVariety, length int) *Rule {
 	return &Rule{
-		selector: "request.size=2000",
+		match: "request.size=2000",
 		actions: map[adptTmpl.TemplateVariety][]*Action{
 			vr: make([]*Action, length),
 		},

--- a/testdata/config/prometheus.yaml
+++ b/testdata/config/prometheus.yaml
@@ -92,9 +92,8 @@ kind: rule
 metadata:
   name: promtcp
   namespace: istio-config-default
-  labels:
-    istio-protocol: tcp # needed so that mixer will only execute when context.protocol == TCP 
 spec:
+  match: context.protocol == "tcp"
   actions:
   - handler: handler.prometheus
     instances:    

--- a/testdata/config/tcpMetrics.yaml
+++ b/testdata/config/tcpMetrics.yaml
@@ -3,8 +3,6 @@ kind: metric
 metadata:
   name: tcpbytesent
   namespace: istio-config-default
-  labels:
-    istio-protocol: tcp # needed so that mixer will only generate when context.protocol == tcp
 spec:
   value: connection.sent.bytes | 0
   dimensions:
@@ -19,8 +17,6 @@ kind: metric
 metadata:
   name: tcpbytereceived
   namespace: istio-config-default
-  labels:
-    istio-protocol: tcp # needed so that mixer will only generate when context.protocol == tcp 
 spec:
   value: connection.received.bytes | 0
   dimensions:


### PR DESCRIPTION
Why do we need this PR:
This PR replaces [Label Filter](https://docs.google.com/document/d/1fGZpgFWJZhNRlQoBlCW815aOFR-ewfxKhla0CcPRsBM/edit#heading=h.bbyxh2ohz3mt) processing with standard `match` expressions.  Label filter was a new feature proposed in the linked document, and it was implemented for 0.2. However K8s labels are not to be used for this purpose. This PR replaces that feature with match selectors. We should get this into 0.2 because we don't want to start writing configs based on label filters.

1. `context.protocol` is extracted from expression so that effectively it will always be evaluated first regardless of where it appears in the expression.

    for example ordinarily 
```yaml
match: connection.connection.sent.bytes > 1000 && context.protocol == "tcp"
``` 
will result in an error because connection.connection.sent.bytes is not available in any other context.

specifying `match: context.protocol == "tcp"` is identical to 
```yaml
labels:
  istio-protocol: tcp
```
2. Add equality check extractor to expr.

```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1327)
<!-- Reviewable:end -->
