### PR TITLE
Use the extensions.proto from istio.io/api/mixer/v1/template

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,22 +105,11 @@ load("//:x_tools_imports.bzl", "go_x_tools_imports_repositories")
 load("//:googleapis.bzl", "go_googleapis_repositories")
 load("//:istio_api.bzl", "go_istio_api_repositories")
 
-local_repository(
-   name = "com_github_guptasu_report",
-   path = "/Users/guptasu/go/src/github.com/guptasu/report",
-)
-
-local_repository(
-   name = "com_github_guptasu_remote_adapter",
-   path = "/Users/guptasu/go/src/github.com/guptasu/foo/mixer-noop-reporter",
-)
-
-
 go_x_tools_imports_repositories()
 
 go_googleapis_repositories()
 
-go_istio_api_repositories(True)
+go_istio_api_repositories()
 
 new_http_archive(
     name = "docker_ubuntu",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,11 +105,22 @@ load("//:x_tools_imports.bzl", "go_x_tools_imports_repositories")
 load("//:googleapis.bzl", "go_googleapis_repositories")
 load("//:istio_api.bzl", "go_istio_api_repositories")
 
+local_repository(
+   name = "com_github_guptasu_report",
+   path = "/Users/guptasu/go/src/github.com/guptasu/report",
+)
+
+local_repository(
+   name = "com_github_guptasu_remote_adapter",
+   path = "/Users/guptasu/go/src/github.com/guptasu/foo/mixer-noop-reporter",
+)
+
+
 go_x_tools_imports_repositories()
 
 go_googleapis_repositories()
 
-go_istio_api_repositories(False)
+go_istio_api_repositories(True)
 
 new_http_archive(
     name = "docker_ubuntu",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,7 +109,7 @@ go_x_tools_imports_repositories()
 
 go_googleapis_repositories()
 
-go_istio_api_repositories()
+go_istio_api_repositories(False)
 
 new_http_archive(
     name = "docker_ubuntu",

--- a/adapter/BUILD
+++ b/adapter/BUILD
@@ -29,7 +29,6 @@ inventory_library(
         "stdio": "istio.io/mixer/adapter/stdio",
         "svcctrl": "istio.io/mixer/adapter/svcctrl",
         "memquota": "istio.io/mixer/adapter/memquota2",
-        "remoteReport": "github.com/guptasu/foo/mixer-noop-reporter",
     },
     deps = [
         "//adapter/denier:go_default_library",
@@ -41,6 +40,5 @@ inventory_library(
         "//adapter/statsd:go_default_library",
         "//adapter/stdio:go_default_library",
         "//adapter/svcctrl:go_default_library",
-        "@com_github_guptasu_remote_adapter//:go_default_library"
     ],
 )

--- a/adapter/BUILD
+++ b/adapter/BUILD
@@ -29,6 +29,7 @@ inventory_library(
         "stdio": "istio.io/mixer/adapter/stdio",
         "svcctrl": "istio.io/mixer/adapter/svcctrl",
         "memquota": "istio.io/mixer/adapter/memquota2",
+        "remoteReport": "github.com/guptasu/foo/mixer-noop-reporter",
     },
     deps = [
         "//adapter/denier:go_default_library",
@@ -40,5 +41,6 @@ inventory_library(
         "//adapter/statsd:go_default_library",
         "//adapter/stdio:go_default_library",
         "//adapter/svcctrl:go_default_library",
+        "@com_github_guptasu_remote_adapter//:go_default_library"
     ],
 )

--- a/adapter_author_deps.bzl
+++ b/adapter_author_deps.bzl
@@ -2,16 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 
 def mixer_adapter_repositories():
 
-    native.local_repository(
+    native.git_repository(
         name = "org_pubref_rules_protobuf",
-        path = "/Users/guptasu/go/src/github.com/guptasu/rules_protobuf",
+        commit = "eafd42ce6471ce3ea265729c85e18e6180dea620",  # Sept 22, 2017 (genfiles path calculation fix)
+        remote = "https://github.com/pubref/rules_protobuf",
     )
-
-    #native.git_repository(
-    #    name = "org_pubref_rules_protobuf",
-    #    commit = "439c57e42dd4edf488644871ee0e0ec3b7c83b6e",  # Sept 1, 2017 (genfiles fix)
-    #    remote = "https://github.com/pubref/rules_protobuf",
-    #)
 
     native.git_repository(
         name = "com_github_google_protobuf",

--- a/adapter_author_deps.bzl
+++ b/adapter_author_deps.bzl
@@ -1,11 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 
 def mixer_adapter_repositories():
-    native.git_repository(
+
+    native.local_repository(
         name = "org_pubref_rules_protobuf",
-        commit = "439c57e42dd4edf488644871ee0e0ec3b7c83b6e",  # Sept 1, 2017 (genfiles fix)
-        remote = "https://github.com/pubref/rules_protobuf",
+        path = "/Users/guptasu/go/src/github.com/guptasu/rules_protobuf",
     )
+
+    #native.git_repository(
+    #    name = "org_pubref_rules_protobuf",
+    #    commit = "439c57e42dd4edf488644871ee0e0ec3b7c83b6e",  # Sept 1, 2017 (genfiles fix)
+    #    remote = "https://github.com/pubref/rules_protobuf",
+    #)
 
     native.git_repository(
         name = "com_github_google_protobuf",
@@ -15,6 +21,11 @@ def mixer_adapter_repositories():
 
     native.bind(
         name = "protoc",
+        actual = "@com_github_google_protobuf//:protoc",
+    )
+
+    native.bind(
+        name = "protocol_compiler",
         actual = "@com_github_google_protobuf//:protoc",
     )
 

--- a/bazel.rc
+++ b/bazel.rc
@@ -1,2 +1,2 @@
 # Always include the version information in the build
-build --workspace_status_command=./bin/build_stamp.sh --action_env=ISTIO_VERSION --output_filter=^gogo
+build --workspace_status_command=./bin/build_stamp.sh --action_env=ISTIO_VERSION

--- a/istio_api.bzl
+++ b/istio_api.bzl
@@ -101,6 +101,36 @@ gogo_proto_compile(
     with_grpc = False,
 )
 
+
+gogoslick_proto_library(
+    name = "mixer/v1/template",
+    importmap = {
+        "google/protobuf/descriptor.proto": "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
+    },
+    imports = [
+        "../../external/com_github_google_protobuf/src",
+        "external/com_github_google_protobuf/src",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
+    protos = ["mixer/v1/template/extensions.proto"],
+    verbose = 0,
+    with_grpc = False,
+    deps = [
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor:go_default_library",
+        "@com_github_gogo_protobuf//sortkeys:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "mixer/v1/template_protos",
+    srcs = ["mixer/v1/template/extensions.proto"],
+    visibility = ["//visibility:public"],
+)
+
 gogoslick_proto_library(
     name = "mixer/v1/config/descriptor",
     importmap = {
@@ -150,7 +180,7 @@ filegroup(
         native.new_local_repository(
             name = "com_github_istio_api",
             build_file_content = ISTIO_API_BUILD_FILE,
-            path = "../api",
+            path = "/Users/guptasu/go/src/istio.io/api",
         )
     else:
       native.new_git_repository(

--- a/istio_api.bzl
+++ b/istio_api.bzl
@@ -180,7 +180,7 @@ filegroup(
         native.new_local_repository(
             name = "com_github_istio_api",
             build_file_content = ISTIO_API_BUILD_FILE,
-            path = "/Users/guptasu/go/src/istio.io/api",
+            path = "../api",
         )
     else:
       native.new_git_repository(

--- a/pkg/runtime/BUILD.bazel
+++ b/pkg/runtime/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/adapter:go_default_library",
-        "//pkg/adapter/template:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/config/descriptor:go_default_library",
@@ -32,6 +31,7 @@ go_library(
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
+        "@com_github_istio_api//:mixer/v1/template",
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_opentracing_opentracing_go//log:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
@@ -49,7 +49,6 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//pkg/adapter:go_default_library",
-        "//pkg/adapter/template:go_default_library",
         "//pkg/aspect:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/config/proto:go_default_library",
@@ -62,5 +61,6 @@ go_test(
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_istio_api//:mixer/v1/template",
     ],
 )

--- a/pkg/runtime/controller.go
+++ b/pkg/runtime/controller.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/golang/glog"
 
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/config/store"
 	"istio.io/mixer/pkg/expr"

--- a/pkg/runtime/controller_test.go
+++ b/pkg/runtime/controller_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
 	cpb "istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/config/store"
 	"istio.io/mixer/pkg/expr"

--- a/pkg/runtime/dispatcher.go
+++ b/pkg/runtime/dispatcher.go
@@ -31,8 +31,8 @@ import (
 	tracelog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	cpb "istio.io/mixer/pkg/config/proto"

--- a/pkg/runtime/dispatcher_test.go
+++ b/pkg/runtime/dispatcher_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	google_rpc "github.com/googleapis/googleapis/google/rpc"
 
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
 	"istio.io/mixer/pkg/aspect"
 	"istio.io/mixer/pkg/attribute"
 	cpb "istio.io/mixer/pkg/config/proto"

--- a/pkg/runtime/resolver.go
+++ b/pkg/runtime/resolver.go
@@ -25,7 +25,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 )

--- a/pkg/runtime/resolver_test.go
+++ b/pkg/runtime/resolver_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/attribute"
 )
 

--- a/pkg/template/BUILD
+++ b/pkg/template/BUILD
@@ -10,12 +10,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/adapter:go_default_library",
-        "//pkg/adapter/template:go_default_library",
         "//pkg/attribute:go_default_library",
         "//pkg/expr:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
+        "@com_github_istio_api//:mixer/v1/template",
     ],
 )
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -22,8 +22,8 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 
 	pb "istio.io/api/mixer/v1/config/descriptor"
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 )

--- a/template/BUILD
+++ b/template/BUILD
@@ -11,7 +11,6 @@ mixer_supported_template_library(
         "//template/quota:go_default_library_proto.descriptor_set": "istio.io/mixer/template/quota",
         "//template/reportnothing:go_default_library_proto.descriptor_set": "istio.io/mixer/template/reportnothing",
         "//template/checknothing:go_default_library_proto.descriptor_set": "istio.io/mixer/template/checknothing",
-        "@com_github_guptasu_report//:go_default_library_proto.descriptor_set": "github.com/guptasu/report",
     },
     deps = [
         "//template/checknothing:go_default_library",
@@ -20,6 +19,5 @@ mixer_supported_template_library(
         "//template/metric:go_default_library",
         "//template/quota:go_default_library",
         "//template/reportnothing:go_default_library",
-        "@com_github_guptasu_report//:go_default_library"
     ],
 )

--- a/template/BUILD
+++ b/template/BUILD
@@ -11,6 +11,7 @@ mixer_supported_template_library(
         "//template/quota:go_default_library_proto.descriptor_set": "istio.io/mixer/template/quota",
         "//template/reportnothing:go_default_library_proto.descriptor_set": "istio.io/mixer/template/reportnothing",
         "//template/checknothing:go_default_library_proto.descriptor_set": "istio.io/mixer/template/checknothing",
+        "@com_github_guptasu_report//:go_default_library_proto.descriptor_set": "github.com/guptasu/report",
     },
     deps = [
         "//template/checknothing:go_default_library",
@@ -19,5 +20,6 @@ mixer_supported_template_library(
         "//template/metric:go_default_library",
         "//template/quota:go_default_library",
         "//template/reportnothing:go_default_library",
+        "@com_github_guptasu_report//:go_default_library"
     ],
 )

--- a/template/checknothing/template.proto
+++ b/template/checknothing/template.proto
@@ -16,9 +16,9 @@ syntax = "proto3";
 
 package checkNothing;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 // CheckNothing represents an empty block of data that is used for Check-capable
 // adapters which don't require any parameters. This is primarily intended for testing

--- a/template/listentry/template.proto
+++ b/template/listentry/template.proto
@@ -16,9 +16,9 @@ syntax = "proto3";
 
 package listEntry;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 // ListEntry is used to verify the presence/absence of a string
 // within a list.

--- a/template/logentry/template.proto
+++ b/template/logentry/template.proto
@@ -18,9 +18,9 @@ package logEntry;
 
 import "google/protobuf/timestamp.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 // LogEntry represents an individual entry within a log.
 message Template {

--- a/template/metric/template.proto
+++ b/template/metric/template.proto
@@ -17,9 +17,9 @@ syntax = "proto3";
 package metric;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 // Metric represents a single piece of data to report.
 message Template {

--- a/template/quota/template.proto
+++ b/template/quota/template.proto
@@ -17,9 +17,9 @@ syntax = "proto3";
 package quota;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 
 message Template {
     // The unique identity of the particular quota to manipulate.

--- a/template/reportnothing/template.proto
+++ b/template/reportnothing/template.proto
@@ -16,9 +16,9 @@ syntax = "proto3";
 
 package reportNothing;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 // ReportNothing represents an empty block of data that is used for Report-capable
 // adapters which don't require any parameters. This is primarily intended for testing

--- a/template/sample/BUILD
+++ b/template/sample/BUILD
@@ -25,7 +25,6 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "//pkg/adapter/template:go_default_library",
         "//pkg/expr:go_default_library",
         "//template/sample/check:go_default_library",
         "//template/sample/quota:go_default_library",
@@ -36,5 +35,6 @@ go_test(
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
         "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
+        "@com_github_istio_api//:mixer/v1/template",
     ],
 )

--- a/template/sample/check/CheckTesterTemplate.proto
+++ b/template/sample/check/CheckTesterTemplate.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package istio.mixer.adapter.sample.check;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 message Template {
     string check_expression = 1;

--- a/template/sample/quota/QuotaTesterTemplate.proto
+++ b/template/sample/quota/QuotaTesterTemplate.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package istio.mixer.adapter.sample.quota;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 
 message Template {
     map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 1;

--- a/template/sample/report/ReportTesterTemplate.proto
+++ b/template/sample/report/ReportTesterTemplate.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package istio.mixer.adapter.sample.report;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 message Template {
     istio.mixer.v1.config.descriptor.ValueType value = 1;

--- a/template/sample/template.gen_test.go
+++ b/template/sample/template.gen_test.go
@@ -30,8 +30,8 @@ import (
 	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	pb "istio.io/api/mixer/v1/config/descriptor"
+	adpTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
-	adpTmpl "istio.io/mixer/pkg/adapter/template"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 	sample_check "istio.io/mixer/template/sample/check"

--- a/test/template/report/reporttmpl.proto
+++ b/test/template/report/reporttmpl.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package SampleReport;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 message Template {
     istio.mixer.v1.config.descriptor.ValueType value = 1;

--- a/tools/codegen/generate.bzl
+++ b/tools/codegen/generate.bzl
@@ -36,7 +36,7 @@ GOGO_IMPORT_MAP = {
 # including the "../.." is an ugly workaround for differing exec ctx for bazel rules
 # depending on whether or not we are building within mixer proper or in a third-party repo
 # that depends on mixer proper.
-PROTO_IMPORTS = [ "external/com_github_google_protobuf/src", "../../external/com_github_google_protobuf/src", "../external/com_github_google_protobuf/src" ]
+PROTO_IMPORTS = [ "external/com_github_google_protobuf/src", "../../external/com_github_google_protobuf/src"]
 PROTO_INPUTS = [ "@com_github_google_protobuf//:well_known_protos" ]
 
 def _gen_template_and_handler(name, importmap = {}):

--- a/tools/codegen/generate.bzl
+++ b/tools/codegen/generate.bzl
@@ -3,23 +3,23 @@ load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogoslick_proto_library", "g
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 MIXER_DEPS = [
-    "//pkg/adapter:go_default_library",
-    "//pkg/adapter/template:go_default_library",
+    "@com_github_istio_mixer//pkg/adapter:go_default_library",
+    "@com_github_istio_api//:mixer/v1/template",
     "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
 ]
 MIXER_INPUTS = [
-    "@com_github_istio_mixer//pkg/adapter/template:protos",
+    "@com_github_istio_api//:mixer/v1/template_protos",
     "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
 ]
 MIXER_IMPORT_MAP = {
     "mixer/v1/config/descriptor/value_type.proto": "istio.io/api/mixer/v1/config/descriptor",
-    "pkg/adapter/template/TemplateExtensions.proto": "istio.io/mixer/pkg/adapter/template",
+    "mixer/v1/template/extensions.proto": "istio.io/api/mixer/v1/template",
 }
 # TODO: develop better approach to import management.
 # including the "../.." is an ugly workaround for differing exec ctx for bazel rules
 # depending on whether or not we are building within mixer proper or in a third-party repo
-# that depends on mixer proper. 
-MIXER_IMPORTS = [ "external/com_github_istio_api", "../../external/com_github_istio_api", "external/com_github_istio_mixer" ]
+# that depends on mixer proper.
+MIXER_IMPORTS = ["external/com_github_istio_api", "../../external/com_github_istio_api",]
 
 # TODO: fill in with complete set of GOGO DEPS and IMPORT MAPPING
 GOGO_DEPS = [
@@ -35,11 +35,11 @@ GOGO_IMPORT_MAP = {
 # TODO: develop better approach to import management.
 # including the "../.." is an ugly workaround for differing exec ctx for bazel rules
 # depending on whether or not we are building within mixer proper or in a third-party repo
-# that depends on mixer proper. 
-PROTO_IMPORTS = [ "external/com_github_google_protobuf/src", "../../external/com_github_google_protobuf/src" ]
+# that depends on mixer proper.
+PROTO_IMPORTS = [ "external/com_github_google_protobuf/src", "../../external/com_github_google_protobuf/src", "../external/com_github_google_protobuf/src" ]
 PROTO_INPUTS = [ "@com_github_google_protobuf//:well_known_protos" ]
 
-def _gen_template_and_handler(name, importmap = {}):   
+def _gen_template_and_handler(name, importmap = {}):
    m = ""
    for k, v in importmap.items():
       m += " -m %s:%s" % (k, v)
@@ -52,9 +52,9 @@ def _gen_template_and_handler(name, importmap = {}):
        "name": name + "_handler",
        "srcs": [ src_desc ],
        "outs": [ gen_handler, gen_tmpl ],
-       "tools": [ "//tools/codegen/cmd/mixgenproc" ],
+       "tools": [ "@com_github_istio_mixer//tools/codegen/cmd/mixgenproc" ],
        "message": "Generating handler code from descriptor",
-       "cmd": "$(location //tools/codegen/cmd/mixgenproc) " 
+       "cmd": "$(location @com_github_istio_mixer//tools/codegen/cmd/mixgenproc) "
             + "$(location %s) -o=$(location %s) -t=$(location %s) %s" % (src_desc, gen_handler, gen_tmpl, m)
    }
 
@@ -125,16 +125,16 @@ def _mixer_supported_template_gen(name, packages, out):
       name = name+"_gen",
       srcs = descriptors,
       outs = [out],
-      cmd = "$(location //tools/codegen/cmd/mixgenbootstrap) " + args + " -o $(location %s)" % (out),
-      tools = ["//tools/codegen/cmd/mixgenbootstrap"],
+      cmd = "$(location @com_github_istio_mixer//tools/codegen/cmd/mixgenbootstrap) " + args + " -o $(location %s)" % (out),
+      tools = ["@com_github_istio_mixer//tools/codegen/cmd/mixgenbootstrap"],
   )
 
 DEPS_FOR_ALL_TMPLS = [
-    "//pkg/adapter:go_default_library",
-    "//pkg/adapter/template:go_default_library",
-    "//pkg/attribute:go_default_library",
-    "//pkg/expr:go_default_library",
-    "//pkg/template:go_default_library",
+    "@com_github_istio_mixer//pkg/adapter:go_default_library",
+    "@com_github_istio_api//:mixer/v1/template",
+    "@com_github_istio_mixer//pkg/attribute:go_default_library",
+    "@com_github_istio_mixer//pkg/expr:go_default_library",
+    "@com_github_istio_mixer//pkg/template:go_default_library",
     "@com_github_gogo_protobuf//proto:go_default_library",
     "@com_github_golang_glog//:go_default_library",
     "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep

--- a/tools/codegen/pkg/bootstrapgen/generator_test.go
+++ b/tools/codegen/pkg/bootstrapgen/generator_test.go
@@ -28,10 +28,10 @@ type logFn func(string, ...interface{})
 // and compares them against the golden files.
 func TestGenerator_Generate(t *testing.T) {
 	importmap := map[string]string{
-		"mixer/v1/config/descriptor/value_type.proto":   "istio.io/api/mixer/v1/config/descriptor",
-		"pkg/adapter/template/TemplateExtensions.proto": "istio.io/mixer/pkg/adapter/template",
-		"gogoproto/gogo.proto":                          "github.com/gogo/protobuf/gogoproto",
-		"google/protobuf/duration.proto":                "github.com/gogo/protobuf/types",
+		"mixer/v1/config/descriptor/value_type.proto": "istio.io/api/mixer/v1/config/descriptor",
+		"mixer/v1/template/extensions.proto":          "istio.io/api/mixer/v1/template",
+		"gogoproto/gogo.proto":                        "github.com/gogo/protobuf/gogoproto",
+		"google/protobuf/duration.proto":              "github.com/gogo/protobuf/types",
 	}
 
 	tests := []struct {

--- a/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -44,7 +44,7 @@ import (
 	"istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/template"
 	"github.com/golang/glog"
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"errors"
 	{{range .TemplateModels}}
 		"{{.PackageImportPath}}"

--- a/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
+++ b/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
@@ -25,8 +25,8 @@ import (
 	"github.com/golang/glog"
 
 	"istio.io/api/mixer/v1/config/descriptor"
+	adptTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
-	adptTmpl "istio.io/mixer/pkg/adapter/template"
 	"istio.io/mixer/pkg/attribute"
 	"istio.io/mixer/pkg/expr"
 	"istio.io/mixer/pkg/template"

--- a/tools/codegen/pkg/bootstrapgen/testdata/CheckTmpl.proto
+++ b/tools/codegen/pkg/bootstrapgen/testdata/CheckTmpl.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package istio.mixer.template.list;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 message Template {
     // value is ...

--- a/tools/codegen/pkg/bootstrapgen/testdata/QuotaTemplate.proto
+++ b/tools/codegen/pkg/bootstrapgen/testdata/QuotaTemplate.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package istio.mixer.template.quota;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 option (istio.mixer.v1.config.template.template_name) = "Quota";
 
 

--- a/tools/codegen/pkg/bootstrapgen/testdata/QuotaTmpl.proto
+++ b/tools/codegen/pkg/bootstrapgen/testdata/QuotaTmpl.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package istio.mixer.template.quota;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 
 
 message Template {

--- a/tools/codegen/pkg/bootstrapgen/testdata/Report1Tmpl.proto
+++ b/tools/codegen/pkg/bootstrapgen/testdata/Report1Tmpl.proto
@@ -5,11 +5,11 @@ syntax = "proto3";
 package istio.mixer.template.log;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 // Defines the format of a single log entry.
 message Template {

--- a/tools/codegen/pkg/bootstrapgen/testdata/Report2Tmpl.proto
+++ b/tools/codegen/pkg/bootstrapgen/testdata/Report2Tmpl.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package istio.mixer.template.metric;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 message Template {
     // value is ...

--- a/tools/codegen/pkg/interfacegen/generator_test.go
+++ b/tools/codegen/pkg/interfacegen/generator_test.go
@@ -30,10 +30,10 @@ type logFn func(string, ...interface{})
 // and compares them against the golden files.
 func TestGenerator_Generate(t *testing.T) {
 	importmap := map[string]string{
-		"mixer/v1/config/descriptor/value_type.proto":   "istio.io/api/mixer/v1/config/descriptor",
-		"pkg/adapter/template/TemplateExtensions.proto": "istio.io/mixer/pkg/adapter/template",
-		"gogoproto/gogo.proto":                          "github.com/gogo/protobuf/gogoproto",
-		"google/protobuf/duration.proto":                "github.com/gogo/protobuf/types",
+		"mixer/v1/config/descriptor/value_type.proto": "istio.io/api/mixer/v1/config/descriptor",
+		"mixer/v1/template/extensions.proto":          "istio.io/api/mixer/v1/template",
+		"gogoproto/gogo.proto":                        "github.com/gogo/protobuf/gogoproto",
+		"google/protobuf/duration.proto":              "github.com/gogo/protobuf/types",
 	}
 
 	tests := []struct {

--- a/tools/codegen/pkg/interfacegen/template/templateproto.go
+++ b/tools/codegen/pkg/interfacegen/template/templateproto.go
@@ -21,10 +21,10 @@ syntax = "proto3";
 
 package {{.PackageName}};
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 $$additional_imports$$
 
-option (istio.mixer.v1.config.template.template_variety) = {{.VarietyName}};
+option (istio.mixer.v1.template.template_variety) = {{.VarietyName}};
 
 {{.Comment}}
 {{.TemplateMessage.Comment}}

--- a/tools/codegen/pkg/interfacegen/testdata/BUILD
+++ b/tools/codegen/pkg/interfacegen/testdata/BUILD
@@ -66,9 +66,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = ["ErrorTemplate.proto"],

--- a/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.golden.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.golden.proto
@@ -18,10 +18,10 @@ syntax = "proto3";
 
 package foo.bar.mylistchecker;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 
 

--- a/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package foo.bar.mylistChecker;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 message Template {
     string check_expression = 1;

--- a/tools/codegen/pkg/interfacegen/testdata/ErrorTemplate.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/ErrorTemplate.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 
 message NOTEMPLATEMESSAGE {

--- a/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.golden.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.golden.proto
@@ -18,10 +18,10 @@ syntax = "proto3";
 
 package istio.mixer.adapter.quota;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 
 
 

--- a/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package istio.mixer.adapter.quota;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 
 // template ...
 message Template {

--- a/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.golden.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.golden.proto
@@ -18,10 +18,10 @@ syntax = "proto3";
 
 package istio.mixer.adapter.metric;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 // 
 // Overview of what metric is etc..

--- a/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.proto
+++ b/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.proto
@@ -9,11 +9,11 @@ Additional overview of what metric is etc..
 package istio.mixer.adapter.metric;
 
 import "mixer/v1/config/descriptor/value_type.proto";
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_REPORT;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
 /* metric template is ..
    aso it is...

--- a/tools/codegen/pkg/modelgen/BUILD
+++ b/tools/codegen/pkg/modelgen/BUILD
@@ -11,9 +11,9 @@ go_library(
     ],
     visibility = ["//tools:__subpackages__"],
     deps = [
-        "//pkg/adapter/template:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor:go_default_library",
+        "@com_github_istio_api//:mixer/v1/template",
     ],
 )
 

--- a/tools/codegen/pkg/modelgen/model.go
+++ b/tools/codegen/pkg/modelgen/model.go
@@ -23,7 +23,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 
-	tmpl "istio.io/mixer/pkg/adapter/template"
+	tmpl "istio.io/api/mixer/v1/template"
 )
 
 const fullProtoNameOfValueTypeEnum = "istio.mixer.v1.config.descriptor.ValueType"

--- a/tools/codegen/pkg/modelgen/model_test.go
+++ b/tools/codegen/pkg/modelgen/model_test.go
@@ -32,7 +32,7 @@ func TestErrorInTemplate(t *testing.T) {
 	}{
 		{"testdata/missing_package_name.descriptor_set", "package name missing"},
 		{"testdata/missing_both_required.descriptor_set", "There has to be one proto file that has the " +
-			"extension istio.mixer.v1.config.template.template_variety"},
+			"extension istio.mixer.v1.template.template_variety"},
 		{"testdata/missing_template_message.descriptor_set", "message 'Template' not defined"},
 		{"testdata/reserved_field_in_template.descriptor_set", "proto:14: Template message must not contain the reserved filed name 'Name'"},
 		{"testdata/proto2_bad_syntax.descriptor_set", "Proto2BadSyntax.proto:3: Only proto3 template files are allowed."},

--- a/tools/codegen/pkg/modelgen/testdata/BUILD
+++ b/tools/codegen/pkg/modelgen/testdata/BUILD
@@ -15,7 +15,6 @@ proto_compile(
     ],
     inputs = [
         "@com_github_istio_api//:mixer/v1/template_protos",
-        #"@com_github_istio_api//:mixer/v1/template_extension_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [

--- a/tools/codegen/pkg/modelgen/testdata/BUILD
+++ b/tools/codegen/pkg/modelgen/testdata/BUILD
@@ -11,9 +11,11 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
+        #"@com_github_istio_api//:mixer/v1/template_extension_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -34,7 +36,7 @@ proto_compile(
         "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
         "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
     ],
@@ -56,7 +58,7 @@ proto_compile(
         "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
         "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
     ],
@@ -78,7 +80,7 @@ proto_compile(
         "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
         "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
     ],
@@ -100,7 +102,7 @@ proto_compile(
         "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
         "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
     ],
@@ -122,7 +124,7 @@ proto_compile(
         "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
         "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
     ],
@@ -141,9 +143,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -161,9 +164,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -181,9 +185,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -201,9 +206,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -221,9 +227,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -241,9 +248,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -261,9 +269,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [
@@ -281,9 +290,10 @@ proto_compile(
     ],
     imports = [
         "external/com_github_google_protobuf/src",
+        "external/com_github_istio_api",
     ],
     inputs = [
-        "//pkg/adapter/template:protos",
+        "@com_github_istio_api//:mixer/v1/template_protos",
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = [

--- a/tools/codegen/pkg/modelgen/testdata/BasicTopLevelFields.proto
+++ b/tools/codegen/pkg/modelgen/testdata/BasicTopLevelFields.proto
@@ -4,9 +4,9 @@ syntax = "proto3";
 // comment for package
 package foo.listChecker;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 // My Template comment
 message Template {}

--- a/tools/codegen/pkg/modelgen/testdata/MissingBothRequiredExt.proto
+++ b/tools/codegen/pkg/modelgen/testdata/MissingBothRequiredExt.proto
@@ -2,6 +2,6 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
 message Template {}

--- a/tools/codegen/pkg/modelgen/testdata/MissingPackageName.proto
+++ b/tools/codegen/pkg/modelgen/testdata/MissingPackageName.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 message Template {}

--- a/tools/codegen/pkg/modelgen/testdata/MissingTemplateMessage.proto
+++ b/tools/codegen/pkg/modelgen/testdata/MissingTemplateMessage.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 

--- a/tools/codegen/pkg/modelgen/testdata/MissingTemplateVarietyExt.proto
+++ b/tools/codegen/pkg/modelgen/testdata/MissingTemplateVarietyExt.proto
@@ -2,6 +2,6 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
 message Template {}

--- a/tools/codegen/pkg/modelgen/testdata/Proto2BadSyntax.proto
+++ b/tools/codegen/pkg/modelgen/testdata/Proto2BadSyntax.proto
@@ -4,8 +4,8 @@ syntax = "proto2";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 message Template {}

--- a/tools/codegen/pkg/modelgen/testdata/ReservedFieldInTemplate.proto
+++ b/tools/codegen/pkg/modelgen/testdata/ReservedFieldInTemplate.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 message Template {
     // Name field is a reserved field that will be inject in the Instance object. The user defined

--- a/tools/codegen/pkg/modelgen/testdata/SimpleTemplate.proto
+++ b/tools/codegen/pkg/modelgen/testdata/SimpleTemplate.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 
 message Template {

--- a/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypeAsMap.proto
+++ b/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypeAsMap.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 // NOT SUPPORTED field type for 'o'
 message Template {

--- a/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypeEnum.proto
+++ b/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypeEnum.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 // NOT SUPPORTED field type for 'o'
 message Template {

--- a/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypeMessage.proto
+++ b/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypeMessage.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 // NOT SUPPORTED field type for 'o'
 message Template {

--- a/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypePrimitive.proto
+++ b/tools/codegen/pkg/modelgen/testdata/UnsupportedFieldTypePrimitive.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package foo.bar;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 // NOT SUPPORTED field type for 'o'
 message Template {

--- a/tools/codegen/pkg/modelgen/testdata/WrongPkgName.proto
+++ b/tools/codegen/pkg/modelgen/testdata/WrongPkgName.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package foo.badStrNumbersNotAllowed123;
 
-import "pkg/adapter/template/TemplateExtensions.proto";
+import "mixer/v1/template/extensions.proto";
 
-option (istio.mixer.v1.config.template.template_variety) = TEMPLATE_VARIETY_CHECK;
+option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
 message Template {}


### PR DESCRIPTION
 Use the extensions.proto from istion.io/api/mixer/v1/template and remove the TemplateExtension from pkg/adapter/template.
- Add the filegroup + gogo library for the extension from in the istio_api.bzl
- Rest of the change is just rename of import statement.

NOTE: In order to support templates to be defined outside Mixer repo, we need to move out the TemplateExtension.proto from https://github.com/istio/mixer/blob/master/pkg/adapter/template/TemplateExtensions.proto into istio.io/api/mixer/v1/template. If the TemplateExtensions.proto is in Mixer repo, it was causing cyclic includes when trying to compile a Template outside Mixer repo that depends on Mixer.

**Details**
This PR changes the location of the TemplateExtensions.proto file that Mixer's template developers import. Earlier it use to be under mixer//pkg/adapter/template and now it will be under api//mixer/v1/template.

As mentioned in both the PRs, this change is essential so that Template developers can define their own custom Templates outside the Mixer repository. This make a cleaner story for Adapter developers who want to write their custom Adapters and need to author a custom Templates. We allow Adapters to be outside Mixer repo so we should also allow Templates to also be defined outside Mixer repo. PTAL, the change touches lots of files but most of them are test files and the change is mainly string replacement of the import path. 

**Risks:**
1. File is just moved from one location to another, so anything that can fail will be during compile time. There is no runtime risk due to the file move part of the change.

2. The above PRs work because it uses the latest fix from Doug in the pubref repository.
The risk here is, there has been other commits since the Sept1's SHA of pubref that current version of mixer depends on. However, since the pubref bzl files are used during compilation process, if there is any regression that affects Mixer, it should be caught during Compilation time. Therefore, 99% there should not be any runtime risk here if we make mixer's bazel rules to depend on the latest version on pubref repo.

**If we don't do it now**
- If we wait for 0.2 release and then make this change, every template that will be created will have to do a find replacement in their proto file whenever we fix this in the future.
- Also Adapters that need custom Template will work around for the time being by putting their custom Templates inside their fork of Mixer repo. This can make their build story and codebase ugly.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1329)
<!-- Reviewable:end -->
