### PR TITLE
explicitly check if the identityAttributeDomain value is a string.

### DIFF
--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -155,7 +155,7 @@ func resolve(bag attribute.Bag, kindSet KindSet, rules map[rulesKey]*pb.ServiceC
 	} else {
 		attrStr, ok := attr.(string)
 		if !ok {
-			msg := fmt.Sprintf("%s attribute should be of type string", identityAttribute)
+			msg := fmt.Sprintf("%s attribute with value %v should be of type string", identityAttribute, attr)
 			glog.Warning(msg)
 			return nil, errors.New(msg)
 		}

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -155,9 +154,7 @@ func resolve(bag attribute.Bag, kindSet KindSet, rules map[rulesKey]*pb.ServiceC
 	} else {
 		attrStr, ok := attr.(string)
 		if !ok {
-			msg := fmt.Sprintf("%s attribute with value %v should be of type string", identityAttribute, attr)
-			glog.Warning(msg)
-			return nil, errors.New(msg)
+			return nil, fmt.Errorf("%s attribute with value %v should be of type string", identityAttribute, attr)
 		}
 		if scopes, err = GetScopes(attrStr, identityAttributeDomain, scopes); err != nil {
 			return nil, err

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -151,8 +152,16 @@ func resolve(bag attribute.Bag, kindSet KindSet, rules map[rulesKey]*pb.ServiceC
 			glog.Warningf("%s attribute not found in %p", identityAttribute, bag)
 			return nil, fmt.Errorf("%s attribute not found", identityAttribute)
 		}
-	} else if scopes, err = GetScopes(attr.(string), identityAttributeDomain, scopes); err != nil {
-		return nil, err
+	} else {
+		attrStr, ok := attr.(string)
+		if !ok {
+			msg := fmt.Sprintf("%s attribute should be of type string", identityAttribute)
+			glog.Warning(msg)
+			return nil, errors.New(msg)
+		}
+		if scopes, err = GetScopes(attrStr, identityAttributeDomain, scopes); err != nil {
+			return nil, err
+		}
 	}
 
 	dlist = make([]*pb.Combined, 0, resolveSize)

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	//"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -150,7 +151,7 @@ func fP(scope string, subject string, kinds ...string) *fakeRule { // nolint: un
 // TestResolve multi rules resolve
 func TestResolve(t *testing.T) {
 	table := []struct {
-		target       string
+		target       interface{}
 		rule         []*fakeRule
 		kinds        []string
 		makebag      bool
@@ -229,10 +230,19 @@ func TestResolve(t *testing.T) {
 				"metric0": "global/global",
 			}, false,
 		},
+		{1234, []*fakeRule{
+			fP("global", "global", "metric0", "metric1")},
+			[]string{"metric0"},
+			true,
+			errors.New("should be of type string"), errors.New("unable to resolve"),
+			map[string]string{
+				"metric0": "global/global",
+			}, false,
+		},
 	}
 
-	for _, tt := range table {
-		t.Run(tt.target, func(t1 *testing.T) {
+	for i, tt := range table {
+		t.Run(strconv.Itoa(i), func(t1 *testing.T) {
 			rules := buildRule(tt.rule)
 			attrs := map[string]interface{}{}
 			if tt.makebag {


### PR DESCRIPTION
when passing something like `--attributes=destination.service=f` auto detects the attribute value to be of type 'int'. This brings down mixer.

Mixers: Are there other such well known places where we can run into this issue ?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1342)
<!-- Reviewable:end -->
