### PR TITLE
Remove dependency of //cmd/server/cmd on //adapters

### DIFF
--- a/cmd/collateral/cmd/root.go
+++ b/cmd/collateral/cmd/root.go
@@ -55,7 +55,7 @@ func GetRootCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 func work(printf, fatalf shared.FormatFn, outputDir string) {
 	roots := []*cobra.Command{
 		mixc.GetRootCmd(nil, nil, nil),
-		mixs.GetRootCmd(nil, nil, nil, nil, nil),
+		mixs.GetRootCmd(nil, nil, nil, nil, nil, nil),
 	}
 
 	printf("Outputting Mixer CLI collateral files to %s", outputDir)

--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//test/testenv:__subpackages__",
     ],
     deps = [
-        "//adapter:go_default_library",
         "//cmd/shared:go_default_library",
         "//pkg/adapter:go_default_library",
         "//pkg/adapterManager:go_default_library",

--- a/cmd/server/cmd/inventory.go
+++ b/cmd/server/cmd/inventory.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 
-	"istio.io/mixer/adapter"
 	"istio.io/mixer/cmd/shared"
 	pkgadapter "istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/adapterManager"
@@ -28,7 +27,7 @@ import (
 	"istio.io/mixer/pkg/config"
 )
 
-func adapterCmd(printf shared.FormatFn) *cobra.Command {
+func adapterCmd(legacyAdapters []pkgadapter.RegisterFn, printf shared.FormatFn) *cobra.Command {
 	adapterCmd := cobra.Command{
 		Use:   "inventory",
 		Short: "InventoryLegacy of available adapters and aspects in Mixer",
@@ -38,7 +37,7 @@ func adapterCmd(printf shared.FormatFn) *cobra.Command {
 		Use:   "adapter",
 		Short: "List available adapter builders",
 		Run: func(cmd *cobra.Command, args []string) {
-			listBuilders(printf)
+			listBuilders(legacyAdapters, printf)
 		},
 	})
 
@@ -70,8 +69,8 @@ func listAspects(printf shared.FormatFn) {
 	}
 }
 
-func listBuilders(printf shared.FormatFn) {
-	builderMap := adapterManager.BuilderMap(adapter.InventoryLegacy())
+func listBuilders(legacyAdapters []pkgadapter.RegisterFn, printf shared.FormatFn) {
+	builderMap := adapterManager.BuilderMap(legacyAdapters)
 	keys := []string{}
 	for k := range builderMap {
 		keys = append(keys, k)

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -27,7 +27,8 @@ import (
 )
 
 // GetRootCmd returns the root of the cobra command-tree.
-func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter.InfoFn, legacyAdapters []adapter.RegisterFn, printf, fatalf shared.FormatFn) *cobra.Command {
+func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter.InfoFn,
+	legacyAdapters []adapter.RegisterFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "mixs",
 		Short: "Mixer is Istio's abstraction on top of infrastructure backends.",

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -27,7 +27,7 @@ import (
 )
 
 // GetRootCmd returns the root of the cobra command-tree.
-func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
+func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter.InfoFn, legacyAdapters []adapter.RegisterFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "mixs",
 		Short: "Mixer is Istio's abstraction on top of infrastructure backends.",
@@ -51,8 +51,8 @@ func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter
 	flag.CommandLine = fs
 
 	// template.NewRepository(info)
-	rootCmd.AddCommand(adapterCmd(printf))
-	rootCmd.AddCommand(serverCmd(info, adapters, printf, fatalf))
+	rootCmd.AddCommand(adapterCmd(legacyAdapters, printf))
+	rootCmd.AddCommand(serverCmd(info, adapters, legacyAdapters, printf, fatalf))
 	rootCmd.AddCommand(crdCmd(info, adapters, printf, fatalf))
 	rootCmd.AddCommand(shared.VersionCmd(printf))
 

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -230,7 +230,8 @@ func configStore(url, serviceConfigFile, globalConfigFile string, printf, fatalf
 	return s
 }
 
-func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr.InfoFn, legacyAdapters []adptr.RegisterFn, printf, fatalf shared.FormatFn) *ServerContext {
+func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr.InfoFn,
+	legacyAdapters []adptr.RegisterFn, printf, fatalf shared.FormatFn) *ServerContext {
 	var err error
 	apiPoolSize := sa.apiWorkerPoolSize
 	adapterPoolSize := sa.adapterWorkerPoolSize

--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -39,7 +39,6 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	mixerpb "istio.io/api/mixer/v1"
-	"istio.io/mixer/adapter"
 	"istio.io/mixer/cmd/shared"
 	adptr "istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/adapterManager"
@@ -124,7 +123,7 @@ type ServerContext struct {
 	Server    *grpc.Server
 }
 
-func serverCmd(info map[string]template.Info, adapters []adptr.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
+func serverCmd(info map[string]template.Info, adapters []adptr.InfoFn, legacyAdapters []adptr.RegisterFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	sa := &serverArgs{}
 	serverCmd := cobra.Command{
 		Use:   "server",
@@ -141,7 +140,7 @@ func serverCmd(info map[string]template.Info, adapters []adptr.InfoFn, printf, f
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			runServer(sa, info, adapters, printf, fatalf)
+			runServer(sa, info, adapters, legacyAdapters, printf, fatalf)
 		},
 	}
 
@@ -231,7 +230,7 @@ func configStore(url, serviceConfigFile, globalConfigFile string, printf, fatalf
 	return s
 }
 
-func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr.InfoFn, printf, fatalf shared.FormatFn) *ServerContext {
+func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr.InfoFn, legacyAdapters []adptr.RegisterFn, printf, fatalf shared.FormatFn) *ServerContext {
 	var err error
 	apiPoolSize := sa.apiWorkerPoolSize
 	adapterPoolSize := sa.adapterWorkerPoolSize
@@ -294,7 +293,7 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 	// Legacy Runtime
 	repo := template.NewRepository(info)
 	store := configStore(sa.configStoreURL, sa.serviceConfigFile, sa.globalConfigFile, printf, fatalf)
-	adapterMgr := adapterManager.NewManager(adapter.InventoryLegacy(), aspect.Inventory(), evalForLegacy, gp, adapterGP)
+	adapterMgr := adapterManager.NewManager(legacyAdapters, aspect.Inventory(), evalForLegacy, gp, adapterGP)
 	configManager := config.NewManager(evalForLegacy, adapterMgr.AspectValidatorFinder, adapterMgr.BuilderValidatorFinder, adapters,
 		adapterMgr.SupportedKinds,
 		repo, store, time.Second*time.Duration(sa.configFetchIntervalSec),
@@ -434,9 +433,9 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 	return &ServerContext{GP: gp, AdapterGP: adapterGP, Server: gs}
 }
 
-func runServer(sa *serverArgs, info map[string]template.Info, adapters []adptr.InfoFn, printf, fatalf shared.FormatFn) {
+func runServer(sa *serverArgs, info map[string]template.Info, adapters []adptr.InfoFn, legacyAdapters []adptr.RegisterFn, printf, fatalf shared.FormatFn) {
 	printf("Mixer started with\n%s", sa)
-	context := setupServer(sa, info, adapters, printf, fatalf)
+	context := setupServer(sa, info, adapters, legacyAdapters, printf, fatalf)
 	defer context.GP.Close()
 	defer context.AdapterGP.Close()
 

--- a/cmd/server/cmd/test_server.go
+++ b/cmd/server/cmd/test_server.go
@@ -45,7 +45,7 @@ var defaultSeverArgs = serverArgs{
 }
 
 // SetupTestServer sets up a test server environment
-func SetupTestServer(info map[string]template.Info, adapters []adapter.InfoFn, configStoreURL string, configStore2URL string,
+func SetupTestServer(info map[string]template.Info, adapters []adapter.InfoFn, legacyAdapters []adapter.RegisterFn, configStoreURL string, configStore2URL string,
 	configDefaultNamespace string, configIdentityAttribute, configIdentityAttributeDomain string, useAst bool) *ServerContext {
 	sa := defaultSeverArgs
 	sa.configStoreURL = configStoreURL
@@ -54,5 +54,5 @@ func SetupTestServer(info map[string]template.Info, adapters []adapter.InfoFn, c
 	sa.configIdentityAttribute = configIdentityAttribute
 	sa.configIdentityAttributeDomain = configIdentityAttributeDomain
 	sa.useAst = useAst
-	return setupServer(&sa, info, adapters, shared.Printf, shared.Fatalf)
+	return setupServer(&sa, info, adapters, legacyAdapters, shared.Printf, shared.Fatalf)
 }

--- a/cmd/server/cmd/test_server.go
+++ b/cmd/server/cmd/test_server.go
@@ -45,8 +45,9 @@ var defaultSeverArgs = serverArgs{
 }
 
 // SetupTestServer sets up a test server environment
-func SetupTestServer(info map[string]template.Info, adapters []adapter.InfoFn, legacyAdapters []adapter.RegisterFn, configStoreURL string, configStore2URL string,
-	configDefaultNamespace string, configIdentityAttribute, configIdentityAttributeDomain string, useAst bool) *ServerContext {
+func SetupTestServer(info map[string]template.Info, adapters []adapter.InfoFn, legacyAdapters []adapter.RegisterFn,
+	configStoreURL string, configStore2URL string, configDefaultNamespace string, configIdentityAttribute,
+	configIdentityAttributeDomain string, useAst bool) *ServerContext {
 	sa := defaultSeverArgs
 	sa.configStoreURL = configStoreURL
 	sa.configStore2URL = configStore2URL

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,8 +33,12 @@ func supportedAdapters() []adptr.InfoFn {
 	return adapter.Inventory()
 }
 
+func supportedLegacyAdapters() []adptr.RegisterFn {
+	return adapter.InventoryLegacy()
+}
+
 func main() {
-	rootCmd := cmd.GetRootCmd(os.Args[1:], supportedTemplates(), supportedAdapters(), shared.Printf, shared.Fatalf)
+	rootCmd := cmd.GetRootCmd(os.Args[1:], supportedTemplates(), supportedAdapters(), supportedLegacyAdapters(), shared.Printf, shared.Fatalf)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -44,7 +44,7 @@ func NewEnv(args *Args, info map[string]template.Info, adapters []adapter.InfoFn
 		return nil, err
 	}
 
-	context := cmd.SetupTestServer(info, adapters, args.ConfigStoreURL, args.ConfigStore2URL,
+	context := cmd.SetupTestServer(info, adapters, []adapter.RegisterFn{}, args.ConfigStoreURL, args.ConfigStore2URL,
 		args.ConfigDefaultNamespace, args.ConfigIdentityAttribute, args.ConfigIdentityAttributeDomain, args.UseAstEvaluator)
 	shutdown := make(chan struct{})
 


### PR DESCRIPTION
Fixes issue #1343 

**Why fix this for 0.2**
Without this Adapter developers will have a hard time testing their code. We created a e2e testing library and we want adapter devs to use it to make their lives easier.

**Risk**
Change is purely at compile time, so 99% no risk.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
release-note-none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1346)
<!-- Reviewable:end -->
