### PR TITLE
 Port Mixer to build on CentOS systems

### DIFF
--- a/BUILD.centos
+++ b/BUILD.centos
@@ -1,0 +1,9 @@
+# build base docker centos image
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+
+docker_build(
+    name = "centos",
+    tars = ["centos-7.4.1708-docker.tar.xz"],
+    visibility = ["//visibility:public"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,12 +121,31 @@ new_http_archive(
 
 DEBUG_BASE_IMAGE_SHA = "3f57ae2aceef79e4000fb07ec850bbf4bce811e6f81dc8cfd970e16cdf33e622"
 
+# Official CentOS Cloud Sig Docker images for CentOS 7.4.1708 - Sep 11th, 2017
+new_http_archive(
+    name = "docker_centos",
+    build_file = "BUILD.centos",
+    sha256 = "ae5a842b3bbdfa00e0dda7cb076c9e8040191737e36513dd8fe0a9b7d569abe1",
+    type = "xz",
+    url = "https://github.com/CentOS/sig-cloud-instance-images/raw/CentOS-7.4.1708/docker/centos-7.4.1708-docker.tar.xz",
+)
+
 # See github.com/istio/manager/blob/master/docker/debug/build-and-publish-debug-image.sh
 # for instructions on how to re-build and publish this base image layer.
 http_file(
     name = "ubuntu_xenial_debug",
     sha256 = DEBUG_BASE_IMAGE_SHA,
     url = "https://storage.googleapis.com/istio-build/manager/ubuntu_xenial_debug-" + DEBUG_BASE_IMAGE_SHA + ".tar.gz",
+)
+
+# TODO(sdake) Need to sort out how to get a centos_74_debug image into istio-build
+# Official CentOS Cloud Sig Docker images for CentOS 7.4.1708 - Sep 11th, 2017
+new_http_archive(
+    name = "docker_centos_debug",
+    build_file = "BUILD.centos",
+    sha256 = "ae5a842b3bbdfa00e0dda7cb076c9e8040191737e36513dd8fe0a9b7d569abe1",
+    type = "xz",
+    url = "https://github.com/CentOS/sig-cloud-instance-images/raw/CentOS-7.4.1708/docker/centos-7.4.1708-docker.tar.xz",
 )
 
 go_repository(

--- a/bin/publish-docker-images.sh
+++ b/bin/publish-docker-images.sh
@@ -25,7 +25,7 @@ function docker_push() {
   fi
 }
 
-BAZEL_IMAGES=('mixer' 'mixer_debug')
+BAZEL_IMAGES=('mixer_ubuntu' 'mixer_ubuntu_debug' 'mixer_centos' 'mixer_centos_debug')
 IMAGES=()
 TAGS=''
 HUBS=''

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -42,12 +42,49 @@ mixer_docker_build(
     ],
     images = [
         {
-            "name": "mixer",
+            "name": "mixer_ubuntu",
             "base": "@docker_ubuntu//:xenial",
         },
         {
-            "name": "mixer_debug",
+            "name": "mixer_ubuntu_debug",
             "base": "@ubuntu_xenial_debug//file",
+        },
+    ],
+    ports = [
+        "9091",
+        "9093",
+        "9094",
+        "42422",
+    ],
+    repository = "istio",
+    tags = ["manual"],
+    tars = [
+        ":mixer_tar",
+        "//testdata:configs_tar",
+        ":cacerts.tar",
+    ],
+)
+
+mixer_docker_build(
+    cmd = [
+        "--configStoreURL=fs:///etc/opt/mixer/configroot",
+        "--configStore2URL=k8s://",
+        "--logtostderr",
+        "--v=2",
+        "--traceOutput=http://zipkin:9411/api/v1/spans",
+    ],
+    entrypoint = [
+        "/usr/local/bin/mixs",
+        "server",
+    ],
+    images = [
+        {
+            "name": "mixer_centos",
+            "base": "@docker_centos//:centos",
+        },
+        {
+            "name": "mixer_centos_debug",
+            "base": "@docker_centos_debug//:centos",
         },
     ],
     ports = [


### PR DESCRIPTION
 Port Mixer to build on CentOS systems
    
Fixes (#1347)
    
This change uses the CentOS 7.4 upstream docker image to
build mixer against.  This naturally requires changes to
the istio repository to work with the way images are tagged
Today          Post Change
                    +-> mixer_ubuntu:SHA
mixer:SHA -|
                    +-> mixer_centos:SHA
    
This naturally requires changes to the istio repository to
work correctly.  I have istio/istio changes ready to go,
but don't know how to submit a prow cross-repository dependency
requirement (to block this patch on the istio changes for that
change to the manifest templates and updateTemplate.sh to all
merge as one unit).


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
NONE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1348)
<!-- Reviewable:end -->
