### PR TITLE
in perf testing env, destination.labels isn't set

### DIFF
--- a/testdata/config/listcheck.yaml
+++ b/testdata/config/listcheck.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: istio-config-default
 spec:
   match: (destination.labels["app"]|"unknown") == "ratings"
-actions:
+  actions:
   - handler: staticversion.listchecker
     instances:
     - appversion.listentry

--- a/testdata/config/listcheck.yaml
+++ b/testdata/config/listcheck.yaml
@@ -24,8 +24,8 @@ metadata:
   name: checkwl
   namespace: istio-config-default
 spec:
-  match: destination.labels["app"] == "ratings"
-  actions:
+  match: (destination.labels["app"]|"unknown") == "ratings"
+actions:
   - handler: staticversion.listchecker
     instances:
     - appversion.listentry

--- a/testdata/config/listcheck.yaml
+++ b/testdata/config/listcheck.yaml
@@ -24,6 +24,9 @@ metadata:
   name: checkwl
   namespace: istio-config-default
 spec:
+  # If an attribute could be potentially absent, use the '|' operator
+  # to provide a default value. In the below example if 'destination.labels'
+  # is absent, "unknown" is used in its place (this happens in non kubernetes env).
   match: (destination.labels["app"]|"unknown") == "ratings"
   actions:
   - handler: staticversion.listchecker


### PR DESCRIPTION
in perf testing env, destination.labels isn't set and the whole evaluation errors out:
```
I0927 00:01:47.853915   26392 evaluator.go:121] evaluator.EvalPredicate failed expr:'destination.labels["app"] == "ratings"', err: lookup failed: 'destination.labels'
E0927 00:01:47.853959   26392 dispatcher.go:153] lookup failed: 'destination.labels'
E0927 00:01:47.853971   26392 grpcServer.go:181] Check returned with error : INTERNAL (lookup failed: 'destination.labels')
```

Personally I believe we shouldn't treat nil as a fatal error unless it's an attribute used in the wrong context (in which case | should not work and that would be caught at validation and not runtime) but that's for a different changes/discussion


```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1357)
<!-- Reviewable:end -->
