### PR TITLE
Use recent gometalinter

### DIFF
--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -119,7 +119,11 @@ def makelink(target, linksrc):
     if not os.path.exists(target):
         print target, "Does not exist"
         return
-    os.symlink(target, linksrc)
+
+    # resolve target if it is a symlink
+    realpath = os.path.realpath(target)
+
+    os.symlink(realpath, linksrc)
 #    print "Linked ", linksrc, '-->', target
 
 def bazel_to_vendor(WKSPC):

--- a/bin/install_linters.sh
+++ b/bin/install_linters.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-echo "Installing or updating linters"
-go get -u gopkg.in/alecthomas/gometalinter.v1
-go get -u github.com/3rf/codecoroner
-gometalinter.v1 --update --install --vendored-linters >/dev/null
-
-echo Done installing linters

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -19,57 +19,23 @@ while getopts :c: arg; do
 done
 
 prep_linters() {
-    bin/install_linters.sh
     bin/bazel_to_go.py
 }
 
 go_metalinter() {
-    local parent_branch="${PARENT_BRANCH}"
-    echo parent_branch = "${parent_branch}"
-    if [[ ! -z ${TRAVIS_PULL_REQUEST} ]];then
-        # if travis pull request only lint changed code.
-        if [[ ${TRAVIS_PULL_REQUEST} != "false" ]]; then
-            LAST_GOOD_GITSHA=${TRAVIS_COMMIT_RANGE}
-        fi
-    elif [[ ! -z ${GITHUB_PR_TARGET_BRANCH} ]]; then
-        parent_branch='parent'
-        git fetch origin "refs/heads/${GITHUB_PR_TARGET_BRANCH}:${parent_branch}"
-    fi
-
-    if [[ -z ${LAST_GOOD_GITSHA} ]] && [[ -n "${parent_branch}" ]]; then
-        LAST_GOOD_GITSHA="$(git log ${parent_branch}.. --pretty="%H"|tail -1)"
-        [[ ! -z ${LAST_GOOD_GITSHA} ]] && LAST_GOOD_GITSHA="${LAST_GOOD_GITSHA}^"
-    fi
-
-    # default: lint everything. This runs on the main build
-    if [[ -z ${PKGS} ]];then
-        PKGS="./adapter/... ./cmd/... ./example/... ./pkg/... ./tools/codegen/..."
-
-        # convert LAST_GOOD_GITSHA to list of packages.
-        if [[ ! -z ${LAST_GOOD_GITSHA} ]];then
-            echo "Using ${LAST_GOOD_GITSHA} to compare files to."
-            list=""
-            for fn in $(git diff --name-only ${LAST_GOOD_GITSHA}); do
-                # Always skip testdata and bin
-                case ${fn} in
-                    testdata/* | bin/*) : ;;
-                    *) { fd="${fn%/*}"; if [[ -d ${fd} ]]; then list="${list}\n${fd}"; fi; } ;;
-                esac
-            done
-            PKGS=$(echo -e "${list}" | sort | uniq)
-            echo -e "Running linters on: ${PKGS}\n"
-        else
-            echo "Running linters on all files."
-        fi
-    fi
+    NUM_CPU=$(getconf _NPROCESSORS_ONLN)
 
     # Note: WriteHeaderAndJson excluded because the interface is defined in a 3rd party library.
-    gometalinter.v1\
-        --concurrency=4\
+    gometalinter="docker run \
+      -v $(bazel info output_base):$(bazel info output_base) \
+      -v $(pwd):/go/src/istio.io/mixer \
+      -w /go/src/istio.io/mixer \
+      gcr.io/istio-testing/linter:bfcc1d6942136fd86eb6f1a6fb328de8398fbd80"
+    $gometalinter \
+        --concurrency=${NUM_CPU}\
         --enable-gc\
         --vendored-linters\
         --deadline=1200s --disable-all\
-        --enable=gosimple\
         --enable=aligncheck\
         --enable=deadcode\
         --enable=errcheck\
@@ -77,24 +43,29 @@ go_metalinter() {
         --enable=goconst\
         --enable=gofmt\
         --enable=goimports\
-        --enable=golint --min-confidence=0 --exclude=vendor --exclude=.pb.go --exclude=pkg/config/proto/combined.go --exclude=.*.gen.go --exclude="should have a package comment"\
+        --enable=golint --min-confidence=0\
+        --enable=gotype\
+        --exclude=vendor\
+        --exclude=.pb.go\
+        --exclude=pkg/config/proto/combined.go\
+        --exclude=.*.gen.go\
+        --exclude="should have a package comment"\
         --exclude=".*pkg/config/apiserver_test.go:.* method WriteHeaderAndJson should be WriteHeaderAndJSON"\
         --enable=ineffassign\
         --enable=interfacer\
         --enable=lll --line-length=160\
+        --enable=megacheck\
         --enable=misspell\
-        --enable=staticcheck\
         --enable=structcheck\
         --enable=unconvert\
         --enable=unparam\
-        --enable=unused\
         --enable=varcheck\
         --enable=vet\
         --enable=vetshadow\
         --skip=testdata\
         --skip=vendor\
         --vendor\
-        $PKGS
+        ./...
 }
 
 run_linters() {

--- a/pkg/config/descriptor/descriptor_test.go
+++ b/pkg/config/descriptor/descriptor_test.go
@@ -280,6 +280,7 @@ func TestParseValid(t *testing.T) {
 var sepRegex = regexp.MustCompile(`\[|\]|\.`)
 
 // mutates the json at given path with val
+// nolint: unparam
 func mutate(m interface{}, path string, val interface{}) interface{} {
 	var idx int
 	var key string

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -264,14 +264,14 @@ func (a adapterKey) String() string {
 // compatfilterConfig
 // given a yaml file, filter specific keys from it
 // globalConfig contains descriptors and adapters which will be split shortly.
-func compatfilterConfig(cfg string, shouldSelect func(string) bool) ([]byte, map[string]interface{}, error) {
+func compatfilterConfig(cfg string, shouldSelect func(string) bool) ([]byte, error) {
 	//data []byte, m map[string]interface{}, err error
 	var m map[string]interface{}
 	var data []byte
 	var err error
 
 	if err = yaml.Unmarshal([]byte(cfg), &m); err != nil {
-		return data, nil, err
+		return data, err
 	}
 
 	for k := range m {
@@ -280,7 +280,7 @@ func compatfilterConfig(cfg string, shouldSelect func(string) bool) ([]byte, map
 		}
 	}
 	data, err = json.Marshal(m)
-	return data, m, err
+	return data, err
 }
 
 // validateDescriptors
@@ -320,7 +320,7 @@ func (p *validator) validateAdapters(key string, cfg string) (ce *adapter.Config
 	var ferr error
 	var data []byte
 
-	if data, _, ferr = compatfilterConfig(cfg, func(s string) bool {
+	if data, ferr = compatfilterConfig(cfg, func(s string) bool {
 		return s == "adapters"
 	}); ferr != nil {
 		return ce.Appendf("adapterConfig", "failed to unmarshal config into proto with err: %v", ferr)
@@ -409,6 +409,7 @@ func (p *validator) validateAspectRules(rules []*pb.AspectRule, path string, val
 	return numAspects, ce
 }
 
+// nolint: unparam
 func (p *validator) validateRules(rules []*pb.Rule, path string) (ce *adapter.ConfigErrors) {
 	for _, rule := range rules {
 		if err := p.validateSelector(rule.GetMatch(), p.descriptorFinder); err != nil {
@@ -707,7 +708,7 @@ func (p *validator) validateHandlers(cfg string) (ce *adapter.ConfigErrors) {
 	var ferr error
 	var data []byte
 
-	if data, _, ferr = compatfilterConfig(cfg, func(s string) bool {
+	if data, ferr = compatfilterConfig(cfg, func(s string) bool {
 		return s == "handlers"
 	}); ferr != nil {
 		return ce.Appendf("handlerConfig", "failed to unmarshal config into proto with err: %v", ferr)

--- a/pkg/runtime/controller_test.go
+++ b/pkg/runtime/controller_test.go
@@ -371,6 +371,7 @@ func Test_cleanupResolver(t *testing.T) {
 	cleanupSleepTime = cr
 }
 
+// nolint: unparam
 func waitFor(t *testing.T, tm time.Duration, done chan bool, msg string) bool {
 	tc := time.NewTimer(tm).C
 	ok := false

--- a/pkg/runtime/dispatcher.go
+++ b/pkg/runtime/dispatcher.go
@@ -250,7 +250,7 @@ func (m *dispatcher) Quota(ctx context.Context, requestBag attribute.Bag,
 					return nil
 				}
 				dispatched = true
-				return []dispatchFn{ // nolint: staticcheck
+				return []dispatchFn{ // nolint: megacheck
 					func(ctx context.Context) *result {
 						resp, err := call.processor.ProcessQuota(ctx, inst.Name,
 							inst.Params.(proto.Message), requestBag, m.mapper, call.handler,

--- a/template/sample/template.gen_test.go
+++ b/template/sample/template.gen_test.go
@@ -977,6 +977,7 @@ func InterfaceSlice(slice interface{}) []interface{} {
 	return ret
 }
 
+// nolint: unparam
 func fillProto(cfg string, o interface{}) error {
 	//data []byte, m map[string]interface{}, err error
 	var m map[string]interface{}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -78,7 +78,6 @@ func CmpSliceAndErr(t *testing.T, msg string, act, exp interface{}) {
 			return
 		}
 	}
-	return
 }
 
 // CmpMapAndErr compares two maps
@@ -99,7 +98,6 @@ func CmpMapAndErr(t *testing.T, msg string, act, exp interface{}) {
 			}
 		}
 	}
-	return
 }
 
 func interfaceSlice(slice interface{}) []interface{} {

--- a/tools/codegen/pkg/bootstrapgen/generator.go
+++ b/tools/codegen/pkg/bootstrapgen/generator.go
@@ -131,7 +131,7 @@ func (g *Generator) Generate(fdsFiles map[string]string) error {
 	bytesWithImpts := bytes.Replace(buf.Bytes(), []byte("$$additional_imports$$"), []byte(strings.Join(imprts, "\n")), 1)
 	fmtd, err := format.Source(bytesWithImpts)
 	if err != nil {
-		return fmt.Errorf("could not format generated code: %v. Source code is %s", err, string(buf.Bytes()))
+		return fmt.Errorf("could not format generated code: %v. Source code is %s", err, buf.String())
 	}
 
 	imports.LocalPrefix = "istio.io"

--- a/tools/codegen/pkg/interfacegen/generator.go
+++ b/tools/codegen/pkg/interfacegen/generator.go
@@ -151,7 +151,7 @@ func (g *Generator) getInterfaceGoContent(model *modelgen.Model) ([]byte, error)
 	bytesWithImpts := bytes.Replace(intfaceBuf.Bytes(), []byte("$$additional_imports$$"), []byte(strings.Join(imprts, "\n")), 1)
 	fmtd, err := format.Source(bytesWithImpts)
 	if err != nil {
-		return nil, fmt.Errorf("could not format generated code: %v : %s", err, string(intfaceBuf.Bytes()))
+		return nil, fmt.Errorf("could not format generated code: %v : %s", err, intfaceBuf.String())
 	}
 
 	imports.LocalPrefix = "istio.io"


### PR DESCRIPTION
Takes the time to run the linter from >20 minutes to 30s

- Eliminates indirection in vendor->genfiles link, since genfiles is also a symbolic link.
- Use docker run to run a frozen linter bunch
- Fix new linter errors

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1363)
<!-- Reviewable:end -->
