### PR TITLE
Implement a purge algorithm for removing entries from the cache/StringTable.

### DIFF
--- a/cmd/server/cmd/server.go
+++ b/cmd/server/cmd/server.go
@@ -83,6 +83,7 @@ type serverArgs struct {
 	configIdentityAttribute       string
 	configIdentityAttributeDomain string
 	useAst                        bool
+	stringTablePurgeLimit         int
 
 	// @deprecated
 	serviceConfigFile string
@@ -114,6 +115,7 @@ func (sa *serverArgs) String() string {
 	b.WriteString(fmt.Sprint("configIdentityAttribute: ", s.configIdentityAttribute, "\n"))
 	b.WriteString(fmt.Sprint("configIdentityAttributeDomain: ", s.configIdentityAttributeDomain, "\n"))
 	b.WriteString(fmt.Sprint("useAst: ", s.useAst, "\n"))
+	b.WriteString(fmt.Sprint("stringTablePurgeLimit: ", s.stringTablePurgeLimit, "\n"))
 	return b.String()
 }
 
@@ -200,7 +202,7 @@ func serverCmd(info map[string]template.Info, adapters []adptr.InfoFn, printf, f
 
 	serverCmd.PersistentFlags().BoolVarP(&sa.useAst, "useAst", "", false,
 		"Use AST instead of Mixer IL to evaluate configuration against the adapters.")
-
+	serverCmd.PersistentFlags().IntVar(&sa.stringTablePurgeLimit, "stringTablePurgeLimit", 1024, "Upper limit for String table size to purge at.")
 	// serviceConfig and gobalConfig are for compatibility only
 	serverCmd.PersistentFlags().StringVarP(&sa.serviceConfigFile, "serviceConfigFile", "", "", "Combined Service Config")
 	serverCmd.PersistentFlags().StringVarP(&sa.globalConfigFile, "globalConfigFile", "", "", "Global Config")
@@ -259,11 +261,11 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 			fatalf("Failed to create CEXL expression evaluator with cache size %d: %v", expressionEvalCacheSize, err)
 		}
 	} else {
-		eval, err = evaluator.NewILEvaluator(expressionEvalCacheSize)
+		eval, err = evaluator.NewILEvaluator(expressionEvalCacheSize, sa.stringTablePurgeLimit)
 		if err != nil {
 			fatalf("Failed to create IL expression evaluator with cache size %d: %v", expressionEvalCacheSize, err)
 		}
-		ilEvalForLegacy, err = evaluator.NewILEvaluator(expressionEvalCacheSize)
+		ilEvalForLegacy, err = evaluator.NewILEvaluator(expressionEvalCacheSize, sa.stringTablePurgeLimit)
 		if err != nil {
 			fatalf("Failed to create IL expression evaluator with cache size %d: %v", expressionEvalCacheSize, err)
 		}

--- a/pkg/il/evaluator/evaluator.go
+++ b/pkg/il/evaluator/evaluator.go
@@ -36,10 +36,11 @@ import (
 // IL is an implementation of expr.Evaluator that also exposes specific methods.
 // Specifically, it can listen to config change events.
 type IL struct {
-	cacheSize   int
-	context     *attrContext
-	contextLock sync.RWMutex
-	fMap        map[string]expr.FuncBase
+	cacheSize                  int
+	maxStringTableSizeForPurge int
+	context                    *attrContext
+	contextLock                sync.RWMutex
+	fMap                       map[string]expr.FuncBase
 }
 
 // attrContext captures the set of fields that needs to be kept & evicted together based on
@@ -126,9 +127,11 @@ func (e *IL) EvalPredicate(expr string, attrs attribute.Bag) (bool, error) {
 
 // EvalType evaluates expr using the attr attribute bag and returns the type of the result.
 func (e *IL) EvalType(expr string, finder expr.AttributeDescriptorFinder) (pb.ValueType, error) {
+	ctx := e.getAttrContext()
+
 	var entry cacheEntry
 	var err error
-	if entry, err = e.getOrCreateCacheEntry(expr); err != nil {
+	if entry, err = ctx.getOrCreateCacheEntry(expr); err != nil {
 		glog.Infof("evaluator.EvalType failed expr:'%s', err: %v", expr, err)
 		return pb.VALUE_TYPE_UNSPECIFIED, err
 	}
@@ -183,19 +186,29 @@ func (e *IL) getAttrContext() *attrContext {
 }
 
 func (e *IL) evalResult(expr string, attrs attribute.Bag) (interpreter.Result, error) {
+	ctx := e.getAttrContext()
+	return ctx.evalResult(expr, attrs, e.maxStringTableSizeForPurge)
+}
+
+func (ctx *attrContext) evalResult(
+	expr string, attrs attribute.Bag, maxStringTableSizeForPurge int) (interpreter.Result, error) {
+
 	var entry cacheEntry
 	var err error
-	if entry, err = e.getOrCreateCacheEntry(expr); err != nil {
+	if entry, err = ctx.getOrCreateCacheEntry(expr); err != nil {
 		glog.Infof("evaluator.evalResult failed expr:'%s', err: %v", expr, err)
 		return interpreter.Result{}, err
 	}
 
-	return entry.interpreter.Eval("eval", attrs)
+	r, err := entry.interpreter.Eval("eval", attrs)
+	if entry.interpreter.StringTableSize() > maxStringTableSizeForPurge {
+		ctx.cache.Remove(expr)
+	}
+	return r, err
 }
 
-func (e *IL) getOrCreateCacheEntry(expr string) (cacheEntry, error) {
+func (ctx *attrContext) getOrCreateCacheEntry(expr string) (cacheEntry, error) {
 	// TODO: add normalization for exprStr string, so that 'a | b' is same as 'a|b', and  'a == b' is same as 'b == a'
-	ctx := e.getAttrContext()
 	if entry, found := ctx.cache.Get(expr); found {
 		return entry.(cacheEntry), nil
 	}
@@ -227,7 +240,7 @@ func (e *IL) getOrCreateCacheEntry(expr string) (cacheEntry, error) {
 }
 
 // NewILEvaluator returns a new instance of IL.
-func NewILEvaluator(cacheSize int) (*IL, error) {
+func NewILEvaluator(cacheSize int, maxStringTableSizeForPurge int) (*IL, error) {
 	// check the cacheSize here, to ensure that we can ignore errors in lru.New calls.
 	// cacheSize restriction is the only reason lru.New returns an error.
 	if cacheSize <= 0 {
@@ -235,7 +248,8 @@ func NewILEvaluator(cacheSize int) (*IL, error) {
 	}
 
 	return &IL{
-		cacheSize: cacheSize,
-		fMap:      expr.FuncMap(),
+		cacheSize:                  cacheSize,
+		maxStringTableSizeForPurge: maxStringTableSizeForPurge,
+		fMap: expr.FuncMap(),
 	}, nil
 }

--- a/pkg/il/evaluator/evaluator_test.go
+++ b/pkg/il/evaluator/evaluator_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	pbv "istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/mixer/pkg/attribute"
@@ -27,6 +28,8 @@ import (
 	pb "istio.io/mixer/pkg/config/proto"
 	iltesting "istio.io/mixer/pkg/il/testing"
 )
+
+const maxStringTableSizeForPurge int = 1024
 
 func TestEval(t *testing.T) {
 	e := initEvaluator(t, configInt)
@@ -271,6 +274,70 @@ func TestConfigChange(t *testing.T) {
 	}
 }
 
+func Test_StringTableSizeBasedEviction(t *testing.T) {
+	src := rand.NewSource(time.Now().UnixNano())
+	rnd := rand.New(src)
+	e := initEvaluator(t, configString)
+
+	expr := `attr == "boo"`
+
+	for i := 0; i < maxStringTableSizeForPurge*10; i++ {
+		bag := initBag(generateRandomStr(rnd))
+		e.Eval(expr, bag)
+		entry, err := e.getAttrContext().getOrCreateCacheEntry(expr)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if entry.interpreter.StringTableSize() > maxStringTableSizeForPurge {
+			t.Fatalf("%d > %d", entry.interpreter.StringTableSize(), maxStringTableSizeForPurge)
+		}
+	}
+}
+
+func Test_Stress(t *testing.T) {
+	src := rand.NewSource(time.Now().UnixNano())
+	rnd := rand.New(src)
+
+	e := initEvaluator(t, configString)
+
+	exprs := []string{
+		`attr`,
+		`attr == "foo"`,
+		`attr != "bar"`,
+		`attr | "baz"`,
+	}
+
+	for i := 0; i < 1000000; i++ {
+
+		for j, exp := range exprs {
+			str := generateRandomStr(rnd)
+			bag := initBag(str)
+
+			r, err := e.Eval(exp, bag)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if j == 0 {
+				if r != str {
+					t.Fatalf("%v != %v", r, str)
+				}
+			}
+		}
+	}
+}
+
+func generateRandomStr(r *rand.Rand) string {
+	size := r.Intn(20) + 1
+	bytes := make([]byte, size)
+
+	for i := 0; i < size; i++ {
+		b := byte('a') + byte(r.Intn(26))
+		bytes[i] = b
+	}
+
+	return string(bytes)
+}
+
 func initBag(attrValue interface{}) attribute.Bag {
 	attrs := make(map[string]interface{})
 	attrs["attr"] = attrValue
@@ -279,7 +346,7 @@ func initBag(attrValue interface{}) attribute.Bag {
 }
 
 func initEvaluator(t *testing.T, config pb.GlobalConfig) *IL {
-	e, err := NewILEvaluator(10)
+	e, err := NewILEvaluator(10, maxStringTableSizeForPurge)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/pkg/il/interpreter/interpreter.go
+++ b/pkg/il/interpreter/interpreter.go
@@ -78,6 +78,11 @@ func (i *Interpreter) EvalFnID(fnID uint32, bag attribute.Bag) (Result, error) {
 	return i.run(fn, bag, false)
 }
 
+// StringTableSize returns the number of entries in the StringTable.
+func (i *Interpreter) StringTableSize() int {
+	return i.program.Strings().Size()
+}
+
 func newIntr(p *il.Program, es map[string]Extern, s *Stepper) *Interpreter {
 	i := Interpreter{
 		program: p,

--- a/pkg/il/interpreter/interpreter_test.go
+++ b/pkg/il/interpreter/interpreter_test.go
@@ -84,6 +84,20 @@ func TestInterpreter_Eval_FunctionNotFound(t *testing.T) {
 	}
 }
 
+func TestInterpreter_StringTableSize(t *testing.T) {
+	p, _ := text.ReadText(`
+	fn main() bool
+		apush_b false
+		ret
+	end
+	`)
+
+	i := New(p, map[string]Extern{})
+	if i.StringTableSize() != p.Strings().Size() {
+		t.Fatalf("Size mismatch: %d != %d", i.StringTableSize(), p.Strings().Size())
+	}
+}
+
 func TestInterpreter_Eval(t *testing.T) {
 	duration20ms, _ := time.ParseDuration("20ms")
 

--- a/pkg/il/strings.go
+++ b/pkg/il/strings.go
@@ -96,3 +96,8 @@ func (t *StringTable) GetString(id uint32) string {
 	defer t.lock.RUnlock()
 	return t.idToString[id]
 }
+
+// Size returns the number of entries in the table.
+func (t *StringTable) Size() int {
+	return int(t.nextID)
+}

--- a/pkg/il/strings_test.go
+++ b/pkg/il/strings_test.go
@@ -117,3 +117,13 @@ func TestExpansion(t *testing.T) {
 		}
 	}
 }
+
+func TestSize(t *testing.T) {
+	s := newStringTable()
+
+	_ = s.GetID("AAA")
+
+	if s.Size() != int(s.nextID) {
+		t.Fatalf("Size mismatch")
+	}
+}


### PR DESCRIPTION
The expression cache holds on to an interned string table that captures runtime string data. This PR evicts the cached expressions when the interned strings count reaches a certain threshold.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1370)
<!-- Reviewable:end -->
