### PR TITLE
Implement a purge algorithm for removing entries from the cache/StringTable

### DIFF
--- a/pkg/il/interpreter/interpreter.go
+++ b/pkg/il/interpreter/interpreter.go
@@ -78,6 +78,11 @@ func (i *Interpreter) EvalFnID(fnID uint32, bag attribute.Bag) (Result, error) {
 	return i.run(fn, bag, false)
 }
 
+// StringTableSize returns the number of entries in the StringTable.
+func (i *Interpreter) StringTableSize() int {
+	return i.program.Strings().Size()
+}
+
 func newIntr(p *il.Program, es map[string]Extern, s *Stepper) *Interpreter {
 	i := Interpreter{
 		program: p,

--- a/pkg/il/interpreter/interpreter_test.go
+++ b/pkg/il/interpreter/interpreter_test.go
@@ -84,6 +84,20 @@ func TestInterpreter_Eval_FunctionNotFound(t *testing.T) {
 	}
 }
 
+func TestInterpreter_StringTableSize(t *testing.T) {
+	p, _ := text.ReadText(`
+	fn main() bool
+		apush_b false
+		ret
+	end
+	`)
+
+	i := New(p, map[string]Extern{})
+	if i.StringTableSize() != p.Strings().Size() {
+		t.Fatalf("Size mismatch: %d != %d", i.StringTableSize(), p.Strings().Size())
+	}
+}
+
 func TestInterpreter_Eval(t *testing.T) {
 	duration20ms, _ := time.ParseDuration("20ms")
 

--- a/pkg/il/strings.go
+++ b/pkg/il/strings.go
@@ -96,3 +96,10 @@ func (t *StringTable) GetString(id uint32) string {
 	defer t.lock.RUnlock()
 	return t.idToString[id]
 }
+
+// Size returns the number of entries in the table.
+func (t *StringTable) Size() int {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return int(t.nextID)
+}

--- a/pkg/il/strings_test.go
+++ b/pkg/il/strings_test.go
@@ -117,3 +117,13 @@ func TestExpansion(t *testing.T) {
 		}
 	}
 }
+
+func TestSize(t *testing.T) {
+	s := newStringTable()
+
+	_ = s.GetID("AAA")
+
+	if s.Size() != int(s.nextID) {
+		t.Fatalf("Size mismatch")
+	}
+}


### PR DESCRIPTION
The expression cache holds on to an interned string table that captures runtime string data. This PR evicts the cached expressions when the interned strings count reaches a certain threshold.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1371)
<!-- Reviewable:end -->
