### PR TITLE
change deny ttl to 5 sec

### DIFF
--- a/adapter/denier/config/BUILD
+++ b/adapter/denier/config/BUILD
@@ -5,6 +5,7 @@ gogoslick_proto_library(
     importmap = {
         "gogoproto/gogo.proto": "github.com/gogo/protobuf/gogoproto",
         "google/rpc/status.proto": "github.com/googleapis/googleapis/google/rpc",
+        "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
     },
     imports = [
         "external/com_github_gogo_protobuf",
@@ -23,6 +24,7 @@ gogoslick_proto_library(
     visibility = ["//adapter/denier:__pkg__"],
     deps = [
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
     ],
 )

--- a/adapter/denier/config/config.proto
+++ b/adapter/denier/config/config.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package adapter.denier.config;
 
 import "gogoproto/gogo.proto";
+import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
 
 option go_package="config";
@@ -27,4 +28,10 @@ option (gogoproto.gostring_all) = false;
 message Params {
 	// The error to return when denying a request.
 	google.rpc.Status status = 1 [(gogoproto.nullable) = false];
+
+	// The duration for which the denial is valid.
+	google.protobuf.Duration valid_duration = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+
+	// The number of times the denial may be used.
+	int32 valid_use_count = 3;
 }

--- a/adapter/denier/denier.go
+++ b/adapter/denier/denier.go
@@ -31,25 +31,33 @@ import (
 )
 
 type handler struct {
-	status rpc.Status
+	result adapter.CheckResult
+}
+
+func defaultParam() *config.Params {
+	return &config.Params{
+		Status:        rpc.Status{Code: int32(rpc.FAILED_PRECONDITION)},
+		ValidDuration: 5 * time.Second,
+		ValidUseCount: 1000,
+	}
+}
+
+func newResult(c *config.Params) adapter.CheckResult {
+	return adapter.CheckResult{
+		Status:        c.Status,
+		ValidDuration: c.ValidDuration,
+		ValidUseCount: c.ValidUseCount,
+	}
 }
 
 ////////////////// Runtime Methods //////////////////////////
 
 func (h *handler) HandleCheckNothing(context.Context, *checknothing.Instance) (adapter.CheckResult, error) {
-	return adapter.CheckResult{
-		Status:        h.status,
-		ValidDuration: 5 * time.Second,
-		ValidUseCount: 1000,
-	}, nil
+	return h.result, nil
 }
 
 func (h *handler) HandleListEntry(context.Context, *listentry.Instance) (adapter.CheckResult, error) {
-	return adapter.CheckResult{
-		Status:        h.status,
-		ValidDuration: 5 * time.Second,
-		ValidUseCount: 1000,
-	}, nil
+	return h.result, nil
 }
 
 func (*handler) HandleQuota(context.Context, *quota.Instance, adapter.QuotaArgs) (adapter.QuotaResult, error) {
@@ -71,11 +79,8 @@ func GetInfo() adapter.Info {
 			listentry.TemplateName,
 			quota.TemplateName,
 		},
-		DefaultConfig: &config.Params{
-			Status: rpc.Status{Code: int32(rpc.FAILED_PRECONDITION)},
-		},
-
-		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
+		DefaultConfig: defaultParam(),
+		NewBuilder:    func() adapter.HandlerBuilder { return &builder{} },
 	}
 }
 
@@ -90,5 +95,7 @@ func (b *builder) SetAdapterConfig(cfg adapter.Config)              { b.adapterC
 func (*builder) Validate() (ce *adapter.ConfigErrors)               { return }
 
 func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handler, error) {
-	return &handler{status: b.adapterConfig.Status}, nil
+	return &handler{
+		result: newResult(b.adapterConfig),
+	}, nil
 }

--- a/adapter/denier/denier.go
+++ b/adapter/denier/denier.go
@@ -39,7 +39,7 @@ type handler struct {
 func (h *handler) HandleCheckNothing(context.Context, *checknothing.Instance) (adapter.CheckResult, error) {
 	return adapter.CheckResult{
 		Status:        h.status,
-		ValidDuration: 1000 * time.Second,
+		ValidDuration: 5 * time.Second,
 		ValidUseCount: 1000,
 	}, nil
 }
@@ -47,7 +47,7 @@ func (h *handler) HandleCheckNothing(context.Context, *checknothing.Instance) (a
 func (h *handler) HandleListEntry(context.Context, *listentry.Instance) (adapter.CheckResult, error) {
 	return adapter.CheckResult{
 		Status:        h.status,
-		ValidDuration: 1000 * time.Second,
+		ValidDuration: 5 * time.Second,
 		ValidUseCount: 1000,
 	}, nil
 }

--- a/adapter/denier/denier_test.go
+++ b/adapter/denier/denier_test.go
@@ -19,10 +19,8 @@ package denier
 
 import (
 	"context"
+	"reflect"
 	"testing"
-	"time"
-
-	rpc "github.com/googleapis/googleapis/google/rpc"
 
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/adapter/test"
@@ -58,16 +56,10 @@ func TestBasic(t *testing.T) {
 		t.Errorf("Got error %v, expecting success", err)
 	}
 
-	if result.Status.Code != int32(rpc.FAILED_PRECONDITION) {
-		t.Errorf("Got %v, expected %v", result.Status.Code, rpc.PERMISSION_DENIED)
-	}
+	want := newResult(defaultParam())
 
-	if result.ValidUseCount < 1000 {
-		t.Errorf("Got use count of %d, expecting at least 1000", result.ValidUseCount)
-	}
-
-	if result.ValidDuration < 1000*time.Second {
-		t.Errorf("Got duration of %v, expecting at least 1000 seconds", result.ValidDuration)
+	if !reflect.DeepEqual(want, result) {
+		t.Errorf("Got %v, expected %v", result, want)
 	}
 
 	listEntryHandler := handler.(listentry.Handler)
@@ -76,16 +68,8 @@ func TestBasic(t *testing.T) {
 		t.Errorf("Got error %v, expecting success", err)
 	}
 
-	if result.Status.Code != int32(rpc.FAILED_PRECONDITION) {
-		t.Errorf("Got %v, expecting %v", result.Status.Code, rpc.OK)
-	}
-
-	if result.ValidUseCount < 1000 {
-		t.Errorf("Got use count of %d, expecting at least 1000", result.ValidUseCount)
-	}
-
-	if result.ValidDuration < 1000*time.Second {
-		t.Errorf("Got duration of %v, expecting at least 1000 seconds", result.ValidDuration)
+	if !reflect.DeepEqual(want, result) {
+		t.Errorf("Got %v, expected %v", result, want)
 	}
 
 	quotaHandler := handler.(quota.Handler)


### PR DESCRIPTION
This PR addresses #1373 .

1. Make all denier options configurable :-) 
2. Change default ttl  to `5s` from `1000 s`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1378)
<!-- Reviewable:end -->
