### PR TITLE
increase the target of buildifier a bit

### DIFF
--- a/adapter/inventory.bzl
+++ b/adapter/inventory.bzl
@@ -14,7 +14,6 @@ def _inventory_gen(name, packages, out):
 
 DEPS = [
     "//pkg/adapter:go_default_library",
-
 ]
 
 def inventory_library(name, packages, deps):
@@ -25,4 +24,3 @@ def inventory_library(name, packages, deps):
       srcs = ["inventory.gen.go"],      
       deps = deps + DEPS,
   )
- 

--- a/adapter/stackdriver/metric/metric.go
+++ b/adapter/stackdriver/metric/metric.go
@@ -22,7 +22,7 @@ import (
 
 	monitoring "cloud.google.com/go/monitoring/apiv3"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/googleapis/gax-go"
+	gax "github.com/googleapis/gax-go"
 	xcontext "golang.org/x/net/context"
 	labelpb "google.golang.org/genproto/googleapis/api/label"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"

--- a/adapter/stackdriver/metric/metric_test.go
+++ b/adapter/stackdriver/metric/metric_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/genproto/googleapis/api/distribution"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -26,7 +26,6 @@ goimports -w -local istio.io ${GO_FILES}
 
 bazel build @com_github_bazelbuild_buildtools//buildifier
 buildifier=$(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/buildifier
-$buildifier -mode=fix $(find . \( -name BUILD -o -name BUILD.bazel \) -type f)
-$buildifier -mode=fix ./*.bzl
+$buildifier -mode=fix $(find . \( -name BUILD -o -name BUILD.bazel -o -name '*.bzl' \) -type f)
 $buildifier -mode=fix ./BUILD.ubuntu
 $buildifier -mode=fix ./WORKSPACE

--- a/test/repositories.bzl
+++ b/test/repositories.bzl
@@ -20,9 +20,8 @@ load("@com_github_istio_mixer//:x_tools_imports.bzl", "go_x_tools_imports_reposi
 load("@com_github_istio_mixer//:googleapis.bzl", "go_googleapis_repositories")
 load("@com_github_istio_mixer//:istio_api.bzl", "go_istio_api_repositories")
 
-
 # This function should be used by others to use mock mixer.
-# Before loading this bzl file, following repositoies should be loaded. 
+# Before loading this bzl file, following repositoies should be loaded.
 #
 # Usage:
 #

--- a/tools/codegen/generate.bzl
+++ b/tools/codegen/generate.bzl
@@ -7,19 +7,25 @@ MIXER_DEPS = [
     "@com_github_istio_api//:mixer/v1/template",
     "@com_github_istio_api//:mixer/v1/config/descriptor",  # keep
 ]
+
 MIXER_INPUTS = [
     "@com_github_istio_api//:mixer/v1/template_protos",
     "@com_github_istio_api//:mixer/v1/config/descriptor_protos",  # keep
 ]
+
 MIXER_IMPORT_MAP = {
     "mixer/v1/config/descriptor/value_type.proto": "istio.io/api/mixer/v1/config/descriptor",
     "mixer/v1/template/extensions.proto": "istio.io/api/mixer/v1/template",
 }
+
 # TODO: develop better approach to import management.
 # including the "../.." is an ugly workaround for differing exec ctx for bazel rules
 # depending on whether or not we are building within mixer proper or in a third-party repo
 # that depends on mixer proper.
-MIXER_IMPORTS = ["external/com_github_istio_api", "../../external/com_github_istio_api",]
+MIXER_IMPORTS = [
+    "external/com_github_istio_api",
+    "../../external/com_github_istio_api",
+]
 
 # TODO: fill in with complete set of GOGO DEPS and IMPORT MAPPING
 GOGO_DEPS = [
@@ -27,6 +33,7 @@ GOGO_DEPS = [
     "@com_github_gogo_protobuf//types:go_default_library",
     "@com_github_gogo_protobuf//sortkeys:go_default_library",
 ]
+
 GOGO_IMPORT_MAP = {
     "gogoproto/gogo.proto": "github.com/gogo/protobuf/gogoproto",
     "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
@@ -36,8 +43,12 @@ GOGO_IMPORT_MAP = {
 # including the "../.." is an ugly workaround for differing exec ctx for bazel rules
 # depending on whether or not we are building within mixer proper or in a third-party repo
 # that depends on mixer proper.
-PROTO_IMPORTS = [ "external/com_github_google_protobuf/src", "../../external/com_github_google_protobuf/src"]
-PROTO_INPUTS = [ "@com_github_google_protobuf//:well_known_protos" ]
+PROTO_IMPORTS = [
+    "external/com_github_google_protobuf/src",
+    "../../external/com_github_google_protobuf/src",
+]
+
+PROTO_INPUTS = ["@com_github_google_protobuf//:well_known_protos"]
 
 def _gen_template_and_handler(name, importmap = {}):
    m = ""


### PR DESCRIPTION
The existing fmt.sh does not capture *.bzl files in subdirectories.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1380)
<!-- Reviewable:end -->
