### PR TITLE
validator server as an independent http server

### DIFF
--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -10,6 +10,7 @@ go_library(
         "root.go",
         "server.go",
         "test_server.go",
+        "validator.go",
     ],
     visibility = [
         "//cmd:__subpackages__",
@@ -32,6 +33,7 @@ go_library(
         "//pkg/tracing/zipkin:go_default_library",
         "//pkg/version:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
         "@com_github_grpc_ecosystem_grpc_opentracing//go/otgrpc:go_default_library",

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -54,6 +54,7 @@ func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter
 	rootCmd.AddCommand(adapterCmd(printf))
 	rootCmd.AddCommand(serverCmd(info, adapters, printf, fatalf))
 	rootCmd.AddCommand(crdCmd(info, adapters, printf, fatalf))
+	rootCmd.AddCommand(validatorCmd(info, adapters, printf, fatalf))
 	rootCmd.AddCommand(shared.VersionCmd(printf))
 
 	return rootCmd

--- a/cmd/server/cmd/validator.go
+++ b/cmd/server/cmd/validator.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/spf13/cobra"
+
+	"istio.io/mixer/cmd/shared"
+	"istio.io/mixer/pkg/adapter"
+	"istio.io/mixer/pkg/config"
+	"istio.io/mixer/pkg/config/store"
+	"istio.io/mixer/pkg/runtime"
+	"istio.io/mixer/pkg/template"
+)
+
+type validatorConfig struct {
+	targetNamespaces []string
+	resources        map[string]proto.Message
+	port             uint16
+}
+
+func validatorCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
+	vc := &validatorConfig{
+		resources: runtime.KindMap(config.InventoryMap(adapters), info),
+	}
+	validatorCmd := &cobra.Command{
+		Use:   "validator",
+		Short: "Runs an https server for validations. Works as an external admission webhook for k8s",
+		Run: func(cmd *cobra.Command, args []string) {
+			runValidator(vc, printf, fatalf)
+		},
+	}
+	validatorCmd.PersistentFlags().StringArrayVar(&vc.targetNamespaces, "target-namespaces", []string{},
+		"the list of namespaces where changes should be validated. Empty means to validate everything.")
+	validatorCmd.PersistentFlags().Uint16VarP(&vc.port, "port", "p", 9099, "the port number of the server")
+	return validatorCmd
+}
+
+func createValidatorServer(vc *validatorConfig) (*store.ValidatorServer, error) {
+	// TODO: bind this with pkg/runtime for referential integrity.
+	return store.NewValidatorServer(vc.targetNamespaces, vc.resources, nil), nil
+}
+
+func runValidator(vc *validatorConfig, printf, fatalf shared.FormatFn) {
+	vs, err := createValidatorServer(vc)
+	if err != nil {
+		fatalf("Failed to create validator server: %v", err)
+	}
+	printf("Starting the validator server on port %d", vc.port)
+	if err = http.ListenAndServe(fmt.Sprintf(":%d", vc.port), vs); err != nil {
+		fatalf("Failed to start the validator server: %v", err)
+	}
+}

--- a/pkg/config/store/BUILD
+++ b/pkg/config/store/BUILD
@@ -13,6 +13,7 @@ go_library(
         "store.go",
         "store2.go",
         "testutil.go",
+        "validatorserver.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -20,6 +21,7 @@ go_library(
         "@com_github_gogo_protobuf//jsonpb:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
     ],
 )
 
@@ -33,11 +35,13 @@ go_test(
         "queue_test.go",
         "store2_test.go",
         "store_test.go",
+        "validatorserver_test.go",
     ],
     library = ":go_default_library",
     deps = [
         "//pkg/config/proto:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
     ],
 )

--- a/pkg/config/store/validatorserver.go
+++ b/pkg/config/store/validatorserver.go
@@ -1,0 +1,195 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/glog"
+	multierror "github.com/hashicorp/go-multierror"
+)
+
+type perKindValidateFunc func(br *BackEndResource) error
+
+type perKindValidator struct {
+	pbSpec   proto.Message
+	validate perKindValidateFunc
+}
+
+func (pv *perKindValidator) validateAndConvert(key Key, br *BackEndResource, res *Resource) error {
+	if pv.validate != nil {
+		if err := pv.validate(br); err != nil {
+			return err
+		}
+	}
+	res.Spec = proto.Clone(pv.pbSpec)
+	return convert(key, br.Spec, res.Spec)
+}
+
+func validateRule(br *BackEndResource) error {
+	_, matchExists := br.Spec[matchField]
+	_, selectorExists := br.Spec[selectorField]
+	if !matchExists && selectorExists {
+		return errors.New("field 'selector' is deprecated, use 'match' instead")
+	}
+	if selectorExists {
+		glog.Warningf("Deprecated field 'selector' used in %s. Use 'match' instead.", br.Metadata.Name)
+	}
+	return nil
+}
+
+type validateRequest struct {
+	Operation ChangeType
+	Resources []*BackEndResource
+}
+
+type validateResponse struct {
+	Allowed bool
+	Details []string
+}
+
+// ValidatorServer is an https server which triggers the validation of configs
+// through external admission webhook.
+type ValidatorServer struct {
+	targetNS          map[string]bool
+	externalValidator Validator
+	perKindValidators map[string]*perKindValidator
+}
+
+// NewValidatorServer creates a new ValidatorServer.
+func NewValidatorServer(
+	targetNamespaces []string,
+	kinds map[string]proto.Message,
+	validator Validator) *ValidatorServer {
+	vs := make(map[string]*perKindValidator, len(kinds))
+	for k, pb := range kinds {
+		var validateFunc perKindValidateFunc
+		if k == ruleKind {
+			validateFunc = validateRule
+		}
+		vs[k] = &perKindValidator{pb, validateFunc}
+	}
+	var targetNS map[string]bool
+	if len(targetNamespaces) > 0 {
+		targetNS = map[string]bool{}
+		for _, ns := range targetNamespaces {
+			targetNS[ns] = true
+		}
+	}
+	return &ValidatorServer{
+		targetNS:          targetNS,
+		externalValidator: validator,
+		perKindValidators: vs,
+	}
+}
+
+func errorToResponse(err error) validateResponse {
+	if err == nil {
+		return validateResponse{Allowed: true}
+	}
+	resp := validateResponse{Allowed: false}
+	if merr, ok := err.(*multierror.Error); !ok {
+		resp.Details = []string{err.Error()}
+	} else {
+		resp.Details = make([]string, len(merr.Errors))
+		for i, e := range merr.Errors {
+			resp.Details[i] = e.Error()
+		}
+	}
+	return resp
+}
+
+func (v *ValidatorServer) parseRequest(r *http.Request) (*validateRequest, error) {
+	// verify the content type is accurate
+	if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
+		return nil, fmt.Errorf("contentType=%s, expect application/json", contentType)
+	}
+	req := &validateRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func (v *ValidatorServer) validate(req *validateRequest) error {
+	evs := make([]*Event, 0, len(req.Resources))
+	keys := make(map[Key]bool, len(req.Resources))
+	var merr error
+	for _, resource := range req.Resources {
+		if v.targetNS != nil && !v.targetNS[resource.Metadata.Namespace] {
+			// Ignore resources which are not in the target namespaces.
+			continue
+		}
+		pkv, ok := v.perKindValidators[resource.Kind]
+		if !ok {
+			// Pass unrecognized kinds -- they should be validated by somewhere else.
+			glog.V(3).Infof("unrecognized kind %s is requested to validate", resource.Kind)
+			continue
+		}
+		ev := &Event{
+			Type: req.Operation,
+			Key:  resource.Key(),
+		}
+		if keys[ev.Key] {
+			if req.Operation == Update {
+				merr = multierror.Append(merr, fmt.Errorf("resource %s appears multiple times", ev.Key))
+			}
+			continue
+		}
+		keys[ev.Key] = true
+		if req.Operation == Update {
+			ev.Value = &Resource{Metadata: resource.Metadata}
+			if err := pkv.validateAndConvert(ev.Key, resource, ev.Value); err != nil {
+				merr = multierror.Append(merr, err)
+				continue
+			}
+		}
+		evs = append(evs, ev)
+	}
+	if merr != nil {
+		return merr
+	}
+	if len(evs) == 0 || v.externalValidator == nil {
+		return nil
+	}
+	return v.externalValidator.Validate(evs)
+}
+
+func (v *ValidatorServer) doValidate(r *http.Request) []byte {
+	if r.ContentLength == 0 {
+		return []byte(`{"allowed": true, "details":["nothing to be validated"]}`)
+	}
+	req, err := v.parseRequest(r)
+	if err == nil {
+		glog.V(7).Infof("received: %+v", req)
+		err = v.validate(req)
+	}
+	glog.V(7).Infof("response: %v", err)
+	resp, marshalErr := json.Marshal(errorToResponse(err))
+	if marshalErr != nil {
+		return []byte(fmt.Sprintf(`{"allowed": false, "details": ["%s"]}`, marshalErr.Error()))
+	}
+	return resp
+}
+
+func (v *ValidatorServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if _, err := w.Write(v.doValidate(r)); err != nil {
+		glog.Error(err)
+	}
+}

--- a/pkg/config/store/validatorserver_test.go
+++ b/pkg/config/store/validatorserver_test.go
@@ -1,0 +1,439 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	multierror "github.com/hashicorp/go-multierror"
+	cpb "istio.io/mixer/pkg/config/proto"
+)
+
+type fakeValidator struct {
+	err error
+}
+
+func (v *fakeValidator) Validate([]*Event) error {
+	return v.err
+}
+
+type countValidator int
+
+func (v countValidator) Validate(evs []*Event) error {
+	if len(evs) != int(v) {
+		return fmt.Errorf("want %d, got %d", v, len(evs))
+	}
+	return nil
+}
+
+const sampleResource = `{"kind": "rule", "apiVersion": "config.istio.io/v1alpha2", "metadata": {"name": "foo", "namespace": "bar"}, "spec": {"match": "foo"}}`
+
+func makeRequest(op string, reqs ...string) string {
+	return fmt.Sprintf(`{"operation": "%s", "resources": [%s]}`, op, strings.Join(reqs, ","))
+}
+
+func TestParseRequest(t *testing.T) {
+	v := &ValidatorServer{}
+	for _, c := range []struct {
+		title string
+		in    string
+		ctype string
+		want  *validateRequest
+	}{
+		{
+			"base",
+			makeRequest("update", sampleResource),
+			"application/json",
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:       "rule",
+						APIVersion: "config.istio.io/v1alpha2",
+						Metadata:   ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:       map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+		},
+		{
+			"delete",
+			makeRequest("delete", sampleResource),
+			"application/json",
+			&validateRequest{
+				Operation: Delete,
+				Resources: []*BackEndResource{
+					{
+						Kind:       "rule",
+						APIVersion: "config.istio.io/v1alpha2",
+						Metadata:   ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:       map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+		},
+		{
+			"multi",
+			makeRequest("update", sampleResource, sampleResource),
+			"application/json",
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:       "rule",
+						APIVersion: "config.istio.io/v1alpha2",
+						Metadata:   ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:       map[string]interface{}{"match": "foo"},
+					},
+					{
+						Kind:       "rule",
+						APIVersion: "config.istio.io/v1alpha2",
+						Metadata:   ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:       map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+		},
+		{
+			"invalid",
+			"}",
+			"application/json",
+			nil,
+		},
+		{
+			"unexpected-content-type",
+			makeRequest("update", sampleResource, sampleResource),
+			"text/plain",
+			nil,
+		},
+	} {
+		t.Run(c.title, func(tt *testing.T) {
+			var body io.Reader
+			if len(c.in) != 0 {
+				body = strings.NewReader(c.in)
+			}
+			r := httptest.NewRequest("POST", "/", body)
+			r.Header.Add("Content-Type", c.ctype)
+			got, err := v.parseRequest(r)
+			wantSuccess := c.want != nil
+			gotSuccess := err == nil
+			if wantSuccess != gotSuccess {
+				tt.Errorf("got %v(%v), want %v", gotSuccess, err, wantSuccess)
+			}
+			if c.want != nil && !reflect.DeepEqual(got, c.want) {
+				tt.Errorf("got %+v, want %+v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResponse(t *testing.T) {
+	for _, c := range []struct {
+		in   error
+		want validateResponse
+	}{
+		{nil, validateResponse{Allowed: true}},
+		{errors.New("dummy"), validateResponse{Allowed: false, Details: []string{"dummy"}}},
+		{
+			multierror.Append(nil, errors.New("dummy1"), errors.New("dummy2")),
+			validateResponse{Allowed: false, Details: []string{"dummy1", "dummy2"}},
+		},
+	} {
+		resp := errorToResponse(c.in)
+		if !reflect.DeepEqual(resp, c.want) {
+			t.Errorf("got %+v, want %+v", resp, c.want)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	for _, c := range []struct {
+		title     string
+		targetNS  []string
+		validator Validator
+		in        *validateRequest
+		ok        bool
+	}{
+		{
+			"success",
+			nil,
+			countValidator(1),
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"multi",
+			nil,
+			countValidator(2),
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bazz"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"conflict",
+			nil,
+			nil,
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "bar"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"multiple-deletes",
+			nil,
+			countValidator(1),
+			&validateRequest{
+				Operation: Delete,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "bar"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"fail-on-update",
+			nil,
+			&fakeValidator{errors.New("dummy")},
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"fail-on-delete",
+			nil,
+			&fakeValidator{errors.New("dummy")},
+			&validateRequest{
+				Operation: Delete,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     nil,
+					},
+				},
+			},
+			false,
+		},
+		{
+			"unrelated-ns",
+			[]string{"not-bar"},
+			&fakeValidator{errors.New("dummy")},
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"partially-unrelated",
+			[]string{"bar"},
+			countValidator(1),
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bazz"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"unknown-kinds",
+			nil,
+			&fakeValidator{errors.New("dummy")},
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     "unknown",
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"unknown-kinds",
+			nil,
+			countValidator(1),
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     "unknown",
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"match": "foo"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"deprecated field",
+			nil,
+			&fakeValidator{},
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"selector": "foo"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"deprecated field with new ones",
+			nil,
+			&fakeValidator{},
+			&validateRequest{
+				Operation: Update,
+				Resources: []*BackEndResource{
+					{
+						Kind:     ruleKind,
+						Metadata: ResourceMeta{Name: "foo", Namespace: "bar"},
+						Spec:     map[string]interface{}{"selector": "foo", "match": "foo"},
+					},
+				},
+			},
+			true,
+		},
+	} {
+		t.Run(c.title, func(tt *testing.T) {
+			v := NewValidatorServer(c.targetNS, map[string]proto.Message{ruleKind: &cpb.Rule{}}, c.validator)
+			err := v.validate(c.in)
+			gotSuccess := err == nil
+			if gotSuccess != c.ok {
+				tt.Errorf("got %v, want %v", err, c.ok)
+			}
+		})
+	}
+}
+
+func TestServeHTTP(t *testing.T) {
+	for _, c := range []struct {
+		title   string
+		body    string
+		allowed bool
+	}{
+		{
+			"base",
+			makeRequest("update", sampleResource),
+			true,
+		},
+		{
+			"empty",
+			"",
+			true,
+		},
+	} {
+		t.Run(c.title, func(tt *testing.T) {
+			v := NewValidatorServer(nil, map[string]proto.Message{"rule": &cpb.Rule{}}, nil)
+			req := httptest.NewRequest("POST", "/", strings.NewReader(c.body))
+			req.Header.Add("Content-Type", "application/json")
+			fmt.Printf("%+v\n", req)
+			recorder := httptest.NewRecorder()
+			v.ServeHTTP(recorder, req)
+			resp := &validateResponse{}
+			if err := json.NewDecoder(recorder.Body).Decode(&resp); err != nil {
+				tt.Error(err)
+			}
+			if resp.Allowed != c.allowed {
+				tt.Errorf("Got %+v, want %v", resp, c.allowed)
+			}
+		})
+	}
+}

--- a/pkg/runtime/controller_test.go
+++ b/pkg/runtime/controller_test.go
@@ -669,7 +669,7 @@ func TestController_KindMap(t *testing.T) {
 		},
 	}
 
-	km := kindMap(ai, ti)
+	km := KindMap(ai, ti)
 
 	want := map[string]proto.Message{
 		"t1":                  &cpb.Instance{},

--- a/pkg/runtime/init.go
+++ b/pkg/runtime/init.go
@@ -50,7 +50,7 @@ func New(eval expr.Evaluator, gp *pool.GoroutinePool, handlerPool *pool.Goroutin
 func startWatch(s store.Store2, adapterInfo map[string]*adapter.Info,
 	templateInfo map[string]template.Info) (map[store.Key]*store.Resource, <-chan store.Event, error) {
 	ctx := context.Background()
-	kindMap := kindMap(adapterInfo, templateInfo)
+	kindMap := KindMap(adapterInfo, templateInfo)
 	if err := s.Init(ctx, kindMap); err != nil {
 		return nil, nil, err
 	}
@@ -63,7 +63,7 @@ func startWatch(s store.Store2, adapterInfo map[string]*adapter.Info,
 }
 
 // kindMap generates a map from object kind to its proto message.
-func kindMap(adapterInfo map[string]*adapter.Info,
+func KindMap(adapterInfo map[string]*adapter.Info,
 	templateInfo map[string]template.Info) map[string]proto.Message {
 	kindMap := make(map[string]proto.Message)
 	// typed instances

--- a/pkg/runtime/init.go
+++ b/pkg/runtime/init.go
@@ -62,7 +62,7 @@ func startWatch(s store.Store2, adapterInfo map[string]*adapter.Info,
 	return s.List(), watchChan, nil
 }
 
-// kindMap generates a map from object kind to its proto message.
+// KindMap generates a map from object kind to its proto message.
 func KindMap(adapterInfo map[string]*adapter.Info,
 	templateInfo map[string]template.Info) map[string]proto.Message {
 	kindMap := make(map[string]proto.Message)


### PR DESCRIPTION
This is another approach of validator; it takes an http request
for a validation, which receives an operation over multiple
resources. This is different from the approach of external
admission webhook, because webhook only takes an operation of
a resource.

This webserver will be invoked by istioctl to validate the operations,
which typically contains multiple resources and the server
will validate all of them at once.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
validator server is added as a custom webserver. Currently structural validations only; referential validation will come in another PR.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1401)
<!-- Reviewable:end -->
