### PR TITLE
WIP: Experimentation with grpc middleware for logging

### DIFF
--- a/cmd/server/cmd/BUILD
+++ b/cmd/server/cmd/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "crd.go",
         "inventory.go",
+        "logs.go",
         "root.go",
         "server.go",
         "test_server.go",
@@ -32,6 +33,8 @@ go_library(
         "//pkg/version:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_middleware//logging/zap:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_middleware//tags:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
         "@com_github_grpc_ecosystem_grpc_opentracing//go/otgrpc:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
@@ -42,6 +45,8 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//grpclog/glogger:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 

--- a/cmd/server/cmd/logs.go
+++ b/cmd/server/cmd/logs.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var Level *zapcore.Level
+var Logger *zap.Logger
+var zapConfig zap.Config
+
+func init() {
+	Level = zap.LevelFlag("logLevel", zapcore.InfoLevel, "set logging level")
+
+	zapConfig = zap.NewProductionConfig()
+	zapConfig.Encoding = "console"
+	// config.DisableCaller = true
+	zapConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	zapConfig.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
+	zapConfig.Level = zap.NewAtomicLevelAt(*Level)
+
+	logger, err := zapConfig.Build()
+	if err != nil {
+		log.Fatalf("Building logging config broke: %v", err)
+	}
+
+	Logger = logger.Named("mixer-log")
+}
+
+func logsConfigFn(out http.ResponseWriter, req *http.Request) {
+
+	if level := req.URL.Query().Get("level"); len(level) > 0 {
+		zapConfig.Level.UnmarshalText([]byte(level))
+	}
+
+	out.Write([]byte(fmt.Sprintf("%#v", zapConfig)))
+}

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -16,12 +16,17 @@ go_library(
         "//pkg/status:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_googleapis_googleapis//:google/rpc",
+        "@com_github_grpc_ecosystem_go_grpc_middleware//logging/zap:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_middleware//tags:go_default_library",
+        "@com_github_istio_api//:mixer/v1",  # keep
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_opentracing_opentracing_go//log:go_default_library",
         "@io_istio_api//:mixer/v1",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_x_net//context:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 


### PR DESCRIPTION
DO NOT MERGE!

Recently, we started talking about having a few bits of functionality related to logging. This PR is just playing around with some of that using readily available, existing tooling to give a flavor for what is possible. It includes:

- barebones handler for updating log level dynamically
- tags and logging grpc middleware setup (with some basic tags extraction)
- update of grpcServer.go to use the new style of logging/logger and tagging
- different examples of how to format / use the zap logger (as we try to figure out appropriate styles, etc.)

There are a lot of rough edges in this PR, as I've not tried to optimize or clean up anything.


Check:
```
2017-10-11T10:19:09.599-0700	info	mixer-log	api/grpcServer.go:165	Preprocess Check returned with: OK	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Check", "grpc.request.words.local": 14, "grpc.request.quotas": 1, "grpc.request.dedup.id": "187460532", "grpc.request.attributes": 8, "grpc.request.words.global": 0, "request.id": "adsfasdfadsf", "peer.address": "[::1]:58105"}
2017-10-11T10:19:09.599-0700	info	mixer-log	api/grpcServer.go:177	Dispatching Check	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Check", "grpc.request.words.local": 14, "grpc.request.quotas": 1, "grpc.request.dedup.id": "187460532", "grpc.request.attributes": 8, "grpc.request.words.global": 0, "request.id": "adsfasdfadsf", "peer.address": "[::1]:58105", "destination.service": "ingress.istio-system.svc.cluster.local"}
...
2017-10-11T10:19:09.599-0700	info	mixer-log	api/grpcServer.go:268	Dispatching Quota	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Check", "grpc.request.words.local": 14, "grpc.request.quotas": 1, "grpc.request.dedup.id": "187460532", "grpc.request.attributes": 8, "grpc.request.words.global": 0, "request.id": "adsfasdfadsf", "destination.service": "ingress.istio-system.svc.cluster.local", "peer.address": "[::1]:58105", "quota": "RequestCount"}
...
2017-10-11T10:19:09.600-0700	debug	mixer-log.quota	api/grpcServer.go:247	Quota Allocated	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Check", "grpc.request.words.local": 14, "grpc.request.quotas": 1, "grpc.request.dedup.id": "187460532", "grpc.request.attributes": 8, "grpc.request.words.global": 0, "request.id": "adsfasdfadsf", "peer.address": "[::1]:58105", "destination.service": "ingress.istio-system.svc.cluster.local", "quota.result.granted": 1, "quota.result.validity": "1s"}
2017-10-11T10:19:09.600-0700	info	mixer-log	zap/server_interceptors.go:36	finished unary call	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Check", "grpc.request.words.local": 14, "grpc.request.quotas": 1, "grpc.request.dedup.id": "187460532", "grpc.request.attributes": 8, "grpc.request.words.global": 0, "request.id": "adsfasdfadsf", "destination.service": "ingress.istio-system.svc.cluster.local", "peer.address": "[::1]:58105", "grpc.code": "OK", "grpc.time_ms": 409}
```

Report:
```
2017-10-11T10:18:36.243-0700	info	mixer-log	api/grpcServer.go:349	Preprocess successful	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Report", "grpc.request.reports": 1, "grpc.request.words.global": 0, "grpc.request.words.default": 0, "peer.address": "[::1]:58083", "report.id": 0, "request.id": "asdfasdfasdf", "handler.response.code": "OK", "handler.response.details": null}
...
2017-10-11T10:18:36.243-0700	info	mixer-log	api/grpcServer.go:357	Dispatching Report	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Report", "grpc.request.reports": 1, "grpc.request.words.global": 0, "grpc.request.words.default": 0, "peer.address": "[::1]:58083", "report.id": 0, "request.id": "asdfasdfasdf"}
...
2017-10-11T10:18:36.243-0700	info	mixer-log	api/grpcServer.go:373	Report finished	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Report", "grpc.request.reports": 1, "grpc.request.words.global": 0, "grpc.request.words.default": 0, "peer.address": "[::1]:58083", "report.id": 0, "request.id": "asdfasdfasdf", "handler.response.code": "OK", "handler.response.details": null}
2017-10-11T10:18:36.243-0700	info	mixer-log	zap/server_interceptors.go:36	finished unary call	{"system": "grpc", "span.kind": "server", "grpc.service": "istio.mixer.v1.Mixer", "grpc.method": "Report", "peer.address": "[::1]:58083", "grpc.request.reports": 1, "grpc.request.words.global": 0, "grpc.request.words.default": 0, "grpc.code": "OK", "grpc.time_ms": 308}
```

DO NOT MERGE!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1405)
<!-- Reviewable:end -->
