### PR TITLE
Add check_bazel_version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
 workspace(name = "com_github_istio_mixer")
 
+load(":check_bazel_version.bzl", "check_version")
+
+check_version()
+
 git_repository(
     name = "io_bazel_rules_go",
     commit = "7991b6353e468ba5e8403af382241d9ce031e571",  # Aug 1, 2017 (gazelle fixes)

--- a/check_bazel_version.bzl
+++ b/check_bazel_version.bzl
@@ -9,7 +9,7 @@ def _parse_bazel_version(bazel_version):
     # Turn "release" into a tuple of strings
     version_tuple = ()
     for number in parts[0].split("."):
-        version_tuple += (str(number),)
+        version_tuple += (int(number),)
     return version_tuple
 
 # acceptable min_version <= version <= max_version

--- a/check_bazel_version.bzl
+++ b/check_bazel_version.bzl
@@ -1,0 +1,39 @@
+def _parse_bazel_version(bazel_version):
+    # Remove commit from version.
+    version = bazel_version.split(" ", 1)[0]
+
+    # Split into (release, date) parts and only return the release
+    # as a tuple of integers.
+    parts = version.split("-", 1)
+
+    # Turn "release" into a tuple of strings
+    version_tuple = ()
+    for number in parts[0].split("."):
+        version_tuple += (str(number),)
+    return version_tuple
+
+# acceptable min_version <= version <= max_version
+def check_version():
+    check_bazel_version("0.5.3", "0.5.4")
+
+# acceptable min_version <= version <= max_version
+def check_bazel_version(min_version, max_version):
+    if "bazel_version" not in dir(native):
+        fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" %
+             min_version)
+    elif not native.bazel_version:
+        print("\nCurrent Bazel is not a release version, cannot check for " +
+              "compatibility.")
+        print("Make sure that you are running at least Bazel %s.\n" % min_version)
+    else:
+        _version = _parse_bazel_version(native.bazel_version)
+        _min_version = _parse_bazel_version(min_version)
+        _max_version = _parse_bazel_version(max_version)
+
+        if _version < _min_version:
+            fail("\nCurrent Bazel version {} is too old, expected at least {}\n".format(
+                native.bazel_version, min_version))
+
+        if _version > _max_version:
+            fail("\nCurrent Bazel version {} is too new, expected at most {}\n".format(
+                native.bazel_version, max_version))

--- a/check_bazel_version_test.py
+++ b/check_bazel_version_test.py
@@ -1,0 +1,64 @@
+# stub out the native object
+class Native(object):
+
+    def __init__(self, v):
+        self.bazel_version = v
+
+
+class Output(object):
+
+    def __init__(self):
+        self.output = ""
+
+
+class TestCase(object):
+
+    def __init__(self, min_ver, max_ver, ver, output):
+        self.min_ver = min_ver
+        self.max_ver = max_ver
+        self.ver = ver
+        self.output = output
+
+
+def test_check_version():
+    global native
+    global fail
+    ok = True
+    import shutil
+    import os
+
+    shutil.copyfile("check_bazel_version.bzl", "check_bazel_version.py")
+
+    import check_bazel_version as cv
+
+    ts = [TestCase("0.5.3", "0.5.4", "0.6.0", "too new"),
+          TestCase("0.5.3", "0.5.4", "0.5.1", "too old"),
+          TestCase("0.5.3", "0.5.4", "0.5.1", "")]
+    for tc in ts:
+        cv.native = Native(tc.ver)
+        op = Output()
+
+        def _fail(msg):
+            op.output = msg
+        cv.fail = _fail
+
+        cv.check_bazel_version(tc.min_ver, tc.max_ver)
+        if tc.output == op.output:
+            continue
+
+        if tc.output in op.output:
+            continue
+
+        print tc, "Got [ ", tc.output, "] want [", op.output
+        ok = False
+
+    os.remove("check_bazel_version.py")
+
+    if ok:
+        return 0
+
+    return -1
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(test_check_version())

--- a/check_bazel_version_test.py
+++ b/check_bazel_version_test.py
@@ -18,6 +18,8 @@ class TestCase(object):
         self.max_ver = max_ver
         self.ver = ver
         self.output = output
+    def __repr__(self):
+        return self.__dict__.__repr__()
 
 
 def test_check_version():
@@ -33,7 +35,8 @@ def test_check_version():
 
     ts = [TestCase("0.5.3", "0.5.4", "0.6.0", "too new"),
           TestCase("0.5.3", "0.5.4", "0.5.1", "too old"),
-          TestCase("0.5.3", "0.5.4", "0.5.1", "")]
+          TestCase("0.5.3", "0.5.4", "0.5.3", ""),
+          TestCase("0.5.3", "0.5.4", "0.5.4", "")]
     for tc in ts:
         cv.native = Native(tc.ver)
         op = Output()
@@ -43,13 +46,16 @@ def test_check_version():
         cv.fail = _fail
 
         cv.check_bazel_version(tc.min_ver, tc.max_ver)
-        if tc.output == op.output:
-            continue
+
+        if tc.output == "":
+            if op.output != "":
+                print "Test Failed", tc, "Want [ ", tc.output, "] Got [", op.output, "]"
+                ok = False
 
         if tc.output in op.output:
             continue
 
-        print tc, "Got [ ", tc.output, "] want [", op.output
+        print "Test Failed", tc, "Want [ ", tc.output, "] Got [", op.output, "]"
         ok = False
 
     os.remove("check_bazel_version.py")

--- a/check_bazel_version_test.py
+++ b/check_bazel_version_test.py
@@ -35,6 +35,7 @@ def test_check_version():
 
     ts = [TestCase("0.5.3", "0.5.4", "0.6.0", "too new"),
           TestCase("0.5.3", "0.5.4", "0.5.1", "too old"),
+          TestCase("0.5.3", "0.5.4", "0.11.0", "too new"),
           TestCase("0.5.3", "0.5.4", "0.5.3", ""),
           TestCase("0.5.3", "0.5.4", "0.5.4", "")]
     for tc in ts:


### PR DESCRIPTION
Ensures that bazel version is min <= version <= max.

If bazel version is not correct it produces output like
```
	File "/Users/mjog/GOHOME/src/istio.io/mixer/check_bazel_version.bzl", line 39, in check_version
		fail("\nCurrent Bazel version {} is t...))
Current Bazel version 0.6.0 is too new, expected at most 0.5.4
```
```
	File "/Users/mjog/GOHOME/src/istio.io/mixer/check_bazel_version.bzl", line 39, in check_version
		fail("\nCurrent Bazel version {} is t...))
Current Bazel version 0.5.2 is too old, expected at least 0.5.3
```
We would like to move this to a common repo so version can be checked uniformly.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1422)
<!-- Reviewable:end -->
