### PR TITLE
Update bazel allowable version to 0.6.1

### DIFF
--- a/check_bazel_version.bzl
+++ b/check_bazel_version.bzl
@@ -14,7 +14,7 @@ def _parse_bazel_version(bazel_version):
 
 # acceptable min_version <= version <= max_version
 def check_version():
-    check_bazel_version("0.5.3", "0.5.4")
+    check_bazel_version("0.5.4", "0.6.1")
 
 # acceptable min_version <= version <= max_version
 def check_bazel_version(min_version, max_version):


### PR DESCRIPTION
Test infra bazel version has been updated to 0.6.1 now.
This PR allows that bazel version to run.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1429)
<!-- Reviewable:end -->
