### PR TITLE
Alter Preprocess bag handling to prevent attribute overriding

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,10 +11,13 @@ git_repository(
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
 go_rules_dependencies()
+
 go_register_toolchains()
 
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+
 proto_register_toolchains()
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
@@ -95,9 +98,9 @@ go_repository(
 
 go_repository(
     name = "com_github_opentracing_basictracer_go",
+    build_file_proto_mode = "legacy",
     commit = "1b32af207119a14b1b231d451df3ed04a72efebf",  # Sep 29, 2016 (no releases)
     importpath = "github.com/opentracing/basictracer-go",
-    build_file_proto_mode = "legacy",
 )
 
 load("//:x_tools_imports.bzl", "go_x_tools_imports_repositories")
@@ -268,9 +271,9 @@ go_repository(
 
 go_repository(
     name = "com_github_googleapis_gnostic",
+    build_file_proto_mode = "legacy",
     commit = "0c5108395e2debce0d731cf0287ddf7242066aba",  # Jul 29, 2017 (no releases)
     importpath = "github.com/googleapis/gnostic",
-    build_file_proto_mode = "legacy",
 )
 
 go_repository(
@@ -540,9 +543,9 @@ go_repository(
 
 go_repository(
     name = "com_github_openzipkin_zipkin_go_opentracing",
+    build_file_proto_mode = "legacy",
     commit = "90d57f421daae5e385ce2429580f0d695c41823b",  # Jul 5, 2017 (has releases but we need a newer commit)
     importpath = "github.com/openzipkin/zipkin-go-opentracing",
-    build_file_proto_mode = "legacy",
 )
 
 go_repository(

--- a/pkg/api/grpcServer.go
+++ b/pkg/api/grpcServer.go
@@ -132,12 +132,14 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 
 	// compatReqBag ensures that preprocessor input handles deprecated attributes gracefully.
 	compatReqBag := &compatBag{requestBag}
-	preprocResponseBag := attribute.GetMutableBag(requestBag)
-	// compatRespBag ensures that check input handles deprecated attributes gracefully.
-	compatRespBag := &compatBag{preprocResponseBag}
+	preprocResponseBag := attribute.GetMutableBag(nil)
 
 	glog.V(1).Info("Dispatching Preprocess Check")
 	out := s.aspectDispatcher.Preprocess(legacyCtx, compatReqBag, preprocResponseBag)
+
+	mutableBag := attribute.GetMutableBag(requestBag)
+	mutableBag.PreserveMerge(preprocResponseBag)
+	compatRespBag := &compatBag{mutableBag}
 
 	if !status.IsOK(out) {
 		glog.Error("Preprocess Check returned with: ", status.String(out))
@@ -149,7 +151,7 @@ func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRe
 
 	if glog.V(2) {
 		glog.Info("Dispatching to main adapters after running processors")
-		glog.Infof("Attribute Bag: \n%s", preprocResponseBag.DebugString())
+		glog.Infof("Attribute Bag: \n%s", mutableBag.DebugString())
 	}
 	dest, _ := compatRespBag.Get("destination.service")
 
@@ -278,11 +280,8 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 
 	protoBag := attribute.NewProtoBag(&req.Attributes[0], s.globalDict, s.globalWordList)
 	requestBag := attribute.GetMutableBag(protoBag)
-	// compatReqBag ensures that preprocessor input handles deprecated attributes gracefully.
 	compatReqBag := &compatBag{requestBag}
-	preprocResponseBag := attribute.GetMutableBag(requestBag)
-	// compatRespBag ensures that report input handles deprecated attributes gracefully.
-	compatRespBag := &compatBag{preprocResponseBag}
+	preprocResponseBag := attribute.GetMutableBag(nil)
 
 	var err error
 	for i := 0; i < len(req.Attributes); i++ {
@@ -312,9 +311,13 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 		}
 		glog.V(1).Info("Preprocess returned with: ", status.String(out))
 
+		mutableBag := attribute.GetMutableBag(requestBag)
+		mutableBag.PreserveMerge(preprocResponseBag)
+		compatRespBag := &compatBag{mutableBag}
+
 		if glog.V(2) {
 			glog.Info("Dispatching to main adapters after running processors")
-			glog.Infof("Attribute Bag: \n%s", preprocResponseBag.DebugString())
+			glog.Infof("Attribute Bag: \n%s", mutableBag.DebugString())
 		}
 
 		glog.V(1).Infof("Dispatching Report %d out of %d", i, len(req.Attributes))

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -239,7 +239,7 @@ func TestCheck(t *testing.T) {
 
 	ts.check = func(ctx context.Context, requestBag attribute.Bag) (*adapter.CheckResult, error) {
 		if val, _ := requestBag.Get("A1"); val == "override" {
-			return nil, errors.New("Attribute overriding allowed in Check()!")
+			return nil, errors.New("attribute overriding not allowed in Check")
 		}
 		return &adapter.CheckResult{
 			Status: status.WithPermissionDenied("Not Implemented"),
@@ -389,7 +389,7 @@ func TestReport(t *testing.T) {
 
 	ts.report = func(ctx context.Context, requestBag attribute.Bag) error {
 		if val, _ := requestBag.Get("A1"); val == "override" {
-			return errors.New("Attribute overriding allowed in Check()!")
+			return errors.New("attribute overriding NOT allowed in Check")
 		}
 		return nil
 	}

--- a/pkg/api/grpcServer_test.go
+++ b/pkg/api/grpcServer_test.go
@@ -231,6 +231,24 @@ func TestCheck(t *testing.T) {
 	if err != nil {
 		t.Errorf("Got %v, expected success", err)
 	}
+
+	ts.legacy.preproc = func(requestBag attribute.Bag, responseBag *attribute.MutableBag) rpc.Status {
+		responseBag.Set("A1", "override")
+		return status.OK
+	}
+
+	ts.check = func(ctx context.Context, requestBag attribute.Bag) (*adapter.CheckResult, error) {
+		if val, _ := requestBag.Get("A1"); val == "override" {
+			return nil, errors.New("Attribute overriding allowed in Check()!")
+		}
+		return &adapter.CheckResult{
+			Status: status.WithPermissionDenied("Not Implemented"),
+		}, nil
+	}
+
+	if _, err = ts.client.Check(context.Background(), &request); err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
 }
 
 func TestCheckQuota(t *testing.T) {
@@ -362,6 +380,22 @@ func TestReport(t *testing.T) {
 
 	if callCount == 0 {
 		t.Errorf("Got %d, expected call count of 2", callCount)
+	}
+
+	ts.legacy.preproc = func(requestBag attribute.Bag, responseBag *attribute.MutableBag) rpc.Status {
+		responseBag.Set("A1", "override")
+		return status.OK
+	}
+
+	ts.report = func(ctx context.Context, requestBag attribute.Bag) error {
+		if val, _ := requestBag.Get("A1"); val == "override" {
+			return errors.New("Attribute overriding allowed in Check()!")
+		}
+		return nil
+	}
+
+	if _, err = ts.client.Report(context.Background(), &request); err != nil {
+		t.Errorf("Got unexpected error: %v", err)
 	}
 }
 

--- a/pkg/attribute/bag_test.go
+++ b/pkg/attribute/bag_test.go
@@ -153,6 +153,21 @@ func TestMergeErrors(t *testing.T) {
 		t.Errorf("Expected error to contain the word FOO, got %s", err.Error())
 	}
 }
+func TestPreserveMerge(t *testing.T) {
+	mb := GetMutableBag(empty)
+
+	c1 := GetMutableBag(mb)
+	c2 := GetMutableBag(mb)
+
+	c1.Set("FOO", "X")
+	c2.Set("FOO", "Y")
+
+	if err := mb.PreserveMerge(c1, c2); err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	} else if val, _ := mb.Get("FOO"); val != "X" {
+		t.Errorf("Bad attribute value for FOO: got '%s', want '%s' ", val, "X")
+	}
+}
 
 func TestEmpty(t *testing.T) {
 	b := &emptyBag{}


### PR DESCRIPTION
Prevent APAs from overriding attributes sent in the original request.

This adds a new method to `MutableBag` named `PreserveMerge` which takes in bags that possibly contain conflicts and does a merge in which original values are maintained and conflicts are silently dropped on the floor.

This is in response to errors reported on the dev mailing list that stemmed from having *multiple* values for the attribute `destination.service` in the attribute bag that was used to create instances.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Prefer received attribute values to preprocess-derived attribute values.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1460)
<!-- Reviewable:end -->
