### PR TITLE
remove the check of max version of bazel

### DIFF
--- a/check_bazel_version.bzl
+++ b/check_bazel_version.bzl
@@ -14,9 +14,10 @@ def _parse_bazel_version(bazel_version):
 
 # acceptable min_version <= version <= max_version
 def check_version():
-    check_bazel_version("0.5.4", "0.6.1")
+    check_bazel_version("0.5.4", None)
 
-# acceptable min_version <= version <= max_version
+# acceptable min_version <= version <= max_version. max_version check will be omitted
+# when None is specified.
 def check_bazel_version(min_version, max_version):
     if "bazel_version" not in dir(native):
         fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" %
@@ -28,12 +29,12 @@ def check_bazel_version(min_version, max_version):
     else:
         _version = _parse_bazel_version(native.bazel_version)
         _min_version = _parse_bazel_version(min_version)
-        _max_version = _parse_bazel_version(max_version)
 
         if _version < _min_version:
             fail("\nCurrent Bazel version {} is too old, expected at least {}\n".format(
                 native.bazel_version, min_version))
-
-        if _version > _max_version:
-            fail("\nCurrent Bazel version {} is too new, expected at most {}\n".format(
-                native.bazel_version, max_version))
+        if max_version:
+            _max_version = _parse_bazel_version(max_version)
+            if _version > _max_version:
+                fail("\nCurrent Bazel version {} is too new, expected at most {}\n".format(
+                    native.bazel_version, max_version))


### PR DESCRIPTION
Currently there have been no reports for newer version of bazel which
can't build mixer since the check_bazel_version.bzl was created.

The max_version restriction is still helpful, but I think we should
allow no-limit for max_version, and that should be the default
currently.

The max_version can be easily added later again, when a new version
of bazel turned out not working with the current mixer code base.

fixes #1461

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1462)
<!-- Reviewable:end -->
