### PR TITLE
bazel: adding a fedora image build

### DIFF
--- a/BUILD.fedora
+++ b/BUILD.fedora
@@ -1,0 +1,9 @@
+# build base docker ubuntu image
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+
+docker_build(
+    name = "f26",
+    tars = ["e5d3ad043980461b9cedbbcdbbf48ac6cec6045114c296fbc35fbfc2c894a491/layer.tar"],
+    visibility = ["//visibility:public"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,6 +114,14 @@ go_googleapis_repositories()
 go_istio_api_repositories(False)
 
 new_http_archive(
+    name = "docker_fedora",
+    build_file = "BUILD.fedora",
+    sha256 = "c8b427ead6823cd561ae7a875a852ceed75b900dbb56ca4253c52d83b1485fa6",
+    type = "tar.xz",
+    url = "https://mirrors.cat.pdx.edu/fedora/linux/releases/26/Docker/x86_64/images/Fedora-Container-Minimal-Base-26-1.5.x86_64.tar.xz",
+)
+
+new_http_archive(
     name = "docker_ubuntu",
     build_file = "BUILD.ubuntu",
     sha256 = "2c63dd81d714b825acd1cb3629c57d6ee733645479d0fcdf645203c2c35924c5",

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -2,7 +2,8 @@
 # gazelle:ignore
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("//docker:mixer_docker.bzl", "mixer_docker_build")
+load("//docker:mixer_docker.bzl", "mixer_docker_ubuntu_build")
+load("//docker:mixer_docker.bzl", "mixer_docker_fedora_build")
 load(":cacerts.bzl", "cacerts")
 
 # Use "manual" target tag to skip rules in the wildcard expansion
@@ -27,7 +28,7 @@ cacerts(
     name = "cacerts",
 )
 
-mixer_docker_build(
+mixer_docker_ubuntu_build(
     cmd = [
         "--configStoreURL=fs:///etc/opt/mixer/configroot",
         "--configStore2URL=k8s://",
@@ -51,6 +52,43 @@ mixer_docker_build(
         {
             "name": "mixer_debug",
             "base": "@ubuntu_xenial_debug//file",
+        },
+    ],
+    ports = [
+        "9091",
+        "9093",
+        "9094",
+        "42422",
+    ],
+    repository = "istio",
+    tags = ["manual"],
+    tars = [
+        ":mixer_tar",
+        "//testdata:configs_tar",
+        ":cacerts.tar",
+    ],
+)
+
+mixer_docker_fedora_build(
+    entrypoint = [
+        "/usr/local/bin/mixs",
+        "server",
+    ],
+    cmd = [
+        "--configStoreURL=fs:///etc/opt/mixer/configroot",
+        "--configStore2URL=k8s://",
+        "--logtostderr",
+        "--v=2",
+        "--traceOutput=http://zipkin:9411/api/v1/spans",
+    ],
+    images = [
+        {
+            "name": "mixer_fedora",
+            "base": "@docker_fedora//:f26",
+        },
+        {
+            "name": "mixer_fedora_debug",
+            "base": "@ubuntu_fedora_debug//file",
         },
     ],
     ports = [

--- a/docker/mixer_docker.bzl
+++ b/docker/mixer_docker.bzl
@@ -1,6 +1,14 @@
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
-def mixer_docker_build(images, **kwargs):
+def mixer_docker_ubuntu_build(images, **kwargs):
+    for image in images:
+        docker_build(
+            name = image['name'],
+            base = image['base'],
+            **kwargs
+        )
+
+def mixer_docker_fedora_build(images, **kwargs):
     for image in images:
         docker_build(
             name = image['name'],

--- a/example/servicegraph/docker/BUILD
+++ b/example/servicegraph/docker/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("//docker:mixer_docker.bzl", "mixer_docker_build")
+load("//docker:mixer_docker.bzl", "mixer_docker_ubuntu_build")
 
 # Use "manual" target tag to skip rules in the wildcard expansion
 
@@ -15,7 +15,7 @@ pkg_tar(
     tags = ["manual"],
 )
 
-mixer_docker_build(
+mixer_docker_ubuntu_build(
     entrypoint = [
         "/usr/local/bin/servicegraph",
         "--assetDir=/example/servicegraph",


### PR DESCRIPTION
As `bazel run //docker:mixer_fedora` produces a docker image of
`istio/docker:mixer_fedora`

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Including a build target to produce istio image based on a fedora 26.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1511)
<!-- Reviewable:end -->
