### PR TITLE
Make Result.Interface() return an empty string, as is.

### DIFF
--- a/pkg/il/compiler/compiler_test.go
+++ b/pkg/il/compiler/compiler_test.go
@@ -806,6 +806,13 @@ end`,
 	{
 		expr: `ar["c"] | "foo"`,
 		input: map[string]interface{}{
+			"ar": map[string]string{},
+		},
+		result: "foo",
+	},
+	{
+		expr: `ar["c"] | "foo"`,
+		input: map[string]interface{}{
 			"ar": map[string]string{"c": "b"},
 		},
 		result: "b",

--- a/pkg/il/compiler/compiler_test.go
+++ b/pkg/il/compiler/compiler_test.go
@@ -388,6 +388,20 @@ end
 `,
 	},
 	{
+		expr: `ar["b"]`,
+		input: map[string]interface{}{
+			"ar": map[string]string{},
+		},
+		result: "",
+		code: `
+fn eval() string
+  resolve_f "ar"
+  anlookup "b"
+  ret
+end
+`,
+	},
+	{
 		expr: `ai == 20 || ar["b"] == "c"`,
 		input: map[string]interface{}{
 			"ai": int64(19),

--- a/pkg/il/interpreter/interpreter_test.go
+++ b/pkg/il/interpreter/interpreter_test.go
@@ -1179,7 +1179,7 @@ func TestInterpreter_Eval(t *testing.T) {
 			input: map[string]interface{}{
 				"a": map[string]string{"b": "c"},
 			},
-			expected: nil,
+			expected: "",
 		},
 		"alookup/success": {
 			code: `
@@ -1227,7 +1227,7 @@ func TestInterpreter_Eval(t *testing.T) {
 			input: map[string]interface{}{
 				"a": map[string]string{"b": "c"},
 			},
-			expected: nil,
+			expected: "",
 		},
 		"tlookup/success": {
 			code: `

--- a/pkg/il/interpreter/result.go
+++ b/pkg/il/interpreter/result.go
@@ -99,12 +99,7 @@ func (r Result) AsInterface() interface{} {
 	case il.Bool:
 		return r.AsBool()
 	case il.String:
-		s := r.AsString()
-		// Align with the mechanics of the old expr evaluator.
-		if s == "" {
-			return nil
-		}
-		return s
+		return r.AsString()
 	case il.Integer:
 		return r.AsInteger()
 	case il.Double:

--- a/pkg/il/interpreter/result_test.go
+++ b/pkg/il/interpreter/result_test.go
@@ -96,17 +96,6 @@ func Test_String_WithNonString(t *testing.T) {
 	}
 }
 
-func Test_Interface_EmptyStringReturnsNull(t *testing.T) {
-	r := Result{
-		t:  il.String,
-		vs: "",
-	}
-
-	if r.AsInterface() != nil {
-		t.Fatalf("Expected empty string to be converted to nil.")
-	}
-}
-
 func Test_Interface(t *testing.T) {
 	r := Result{
 		t:  il.Interface,


### PR DESCRIPTION
+ Removing the old handling code that converts an empty string to
nil.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1523)
<!-- Reviewable:end -->
