### PR TITLE
Test that we no more panic because of nil evaluation on empty string.

### DIFF
--- a/pkg/il/compiler/compiler_test.go
+++ b/pkg/il/compiler/compiler_test.go
@@ -388,6 +388,20 @@ end
 `,
 	},
 	{
+		expr: `ar["b"]`,
+		input: map[string]interface{}{
+			"ar": map[string]string{},
+		},
+		result: "",
+		code: `
+fn eval() string
+  resolve_f "ar"
+  anlookup "b"
+  ret
+end
+`,
+	},
+	{
 		expr: `ai == 20 || ar["b"] == "c"`,
 		input: map[string]interface{}{
 			"ai": int64(19),
@@ -788,6 +802,13 @@ L1:
 L2:
   ret
 end`,
+	},
+	{
+		expr: `ar["c"] | "foo"`,
+		input: map[string]interface{}{
+			"ar": map[string]string{},
+		},
+		result: "foo",
 	},
 	{
 		expr: `ar["c"] | "foo"`,

--- a/pkg/il/interpreter/interpreter_test.go
+++ b/pkg/il/interpreter/interpreter_test.go
@@ -1179,7 +1179,7 @@ func TestInterpreter_Eval(t *testing.T) {
 			input: map[string]interface{}{
 				"a": map[string]string{"b": "c"},
 			},
-			expected: nil,
+			expected: "",
 		},
 		"alookup/success": {
 			code: `
@@ -1227,7 +1227,7 @@ func TestInterpreter_Eval(t *testing.T) {
 			input: map[string]interface{}{
 				"a": map[string]string{"b": "c"},
 			},
-			expected: nil,
+			expected: "",
 		},
 		"tlookup/success": {
 			code: `

--- a/pkg/il/interpreter/result.go
+++ b/pkg/il/interpreter/result.go
@@ -99,12 +99,7 @@ func (r Result) AsInterface() interface{} {
 	case il.Bool:
 		return r.AsBool()
 	case il.String:
-		s := r.AsString()
-		// Align with the mechanics of the old expr evaluator.
-		if s == "" {
-			return nil
-		}
-		return s
+		return r.AsString()
 	case il.Integer:
 		return r.AsInteger()
 	case il.Double:

--- a/pkg/il/interpreter/result_test.go
+++ b/pkg/il/interpreter/result_test.go
@@ -96,17 +96,6 @@ func Test_String_WithNonString(t *testing.T) {
 	}
 }
 
-func Test_Interface_EmptyStringReturnsNull(t *testing.T) {
-	r := Result{
-		t:  il.String,
-		vs: "",
-	}
-
-	if r.AsInterface() != nil {
-		t.Fatalf("Expected empty string to be converted to nil.")
-	}
-}
-
 func Test_Interface(t *testing.T) {
 	r := Result{
 		t:  il.Interface,

--- a/template/sample/BUILD
+++ b/template/sample/BUILD
@@ -26,7 +26,10 @@ go_test(
     deps = [
         "//pkg/adapter:go_default_library",
         "//pkg/attribute:go_default_library",
+        "//pkg/config/descriptor:go_default_library",
+        "//pkg/config/proto:go_default_library",
         "//pkg/expr:go_default_library",
+        "//pkg/il/evaluator:go_default_library",
         "//template/sample/check:go_default_library",
         "//template/sample/quota:go_default_library",
         "//template/sample/report:go_default_library",

--- a/template/sample/template.gen_test.go
+++ b/template/sample/template.gen_test.go
@@ -33,7 +33,10 @@ import (
 	adpTmpl "istio.io/api/mixer/v1/template"
 	"istio.io/mixer/pkg/adapter"
 	"istio.io/mixer/pkg/attribute"
+	"istio.io/mixer/pkg/config/descriptor"
+	"istio.io/mixer/pkg/config/proto"
 	"istio.io/mixer/pkg/expr"
+	"istio.io/mixer/pkg/il/evaluator"
 	sample_check "istio.io/mixer/template/sample/check"
 	sample_quota "istio.io/mixer/template/sample/quota"
 	sample_report "istio.io/mixer/template/sample/report"
@@ -649,13 +652,37 @@ func (e *fakeExpr) Eval(mapExpression string, attrs attribute.Bag) (interface{},
 	if strings.HasSuffix(expr2, "timestamp") {
 		return time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC), nil
 	}
-	ev, _ := expr.NewCEXLEvaluator(expr.DefaultCacheSize)
+	ev, _ := evaluator.NewILEvaluator(1024, 1024)
+	ev.ChangeVocabulary(descriptor.NewFinder(&baseConfig))
 	return ev.Eval(expr2, attrs)
 }
 
+var baseConfig = istio_mixer_v1_config.GlobalConfig{
+	Manifests: []*istio_mixer_v1_config.AttributeManifest{
+		{
+			Attributes: map[string]*istio_mixer_v1_config.AttributeManifest_AttributeInfo{
+				"str.absent": {
+					ValueType: pb.STRING,
+				},
+				"bool.absent": {
+					ValueType: pb.BOOL,
+				},
+				"double.absent": {
+					ValueType: pb.DOUBLE,
+				},
+				"int64.absent": {
+					ValueType: pb.INT64,
+				},
+			},
+		},
+	},
+}
+
 // EvalString evaluates given expression using the attribute bag to a string
-func (e *fakeExpr) EvalString(mapExpression string, attrs attribute.Bag) (string, error) {
-	return "", nil
+func (e *fakeExpr) EvalString(ex string, attrs attribute.Bag) (string, error) {
+	ev, _ := evaluator.NewILEvaluator(1024, 1024)
+	ev.ChangeVocabulary(descriptor.NewFinder(&baseConfig))
+	return ev.EvalString(ex, attrs)
 }
 
 // EvalPredicate evaluates given predicate using the attribute bag
@@ -732,7 +759,6 @@ func TestProcessReport(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "EvalAllError",
 			insts: map[string]proto.Message{
@@ -749,7 +775,7 @@ func TestProcessReport(t *testing.T) {
 				},
 			},
 			hdlr:      &fakeReportHandler{},
-			wantError: "unresolved attribute bad.attribute",
+			wantError: "unknown attribute bad.attribute",
 		},
 		{
 			name: "EvalError",
@@ -767,7 +793,38 @@ func TestProcessReport(t *testing.T) {
 				},
 			},
 			hdlr:      &fakeReportHandler{},
-			wantError: "unresolved attribute bad.attribute",
+			wantError: "unknown attribute bad.attribute",
+		},
+		{
+			name: "AttributeAbsentAtRuntime",
+			insts: map[string]proto.Message{
+				"foo": &sample_report.InstanceParam{
+					Value:           "int64.absent | 2",
+					Dimensions:      map[string]string{"s": "str.absent | \"\""},
+					BoolPrimitive:   "bool.absent | true",
+					DoublePrimitive: "double.absent | 1.2",
+					Int64Primitive:  "int64.absent | 123",
+					StringPrimitive: "str.absent | \"\"",
+					Int64Map:        map[string]string{"a": "int64.absent | 123"},
+					TimeStamp:       "request.timestamp",
+					Duration:        "request.duration",
+				},
+			},
+			hdlr: &fakeReportHandler{},
+			wantInstance: []*sample_report.Instance{
+				{
+					Name:            "foo",
+					Value:           int64(2),
+					Dimensions:      map[string]interface{}{"s": ""},
+					BoolPrimitive:   true,
+					DoublePrimitive: 1.2,
+					Int64Primitive:  123,
+					StringPrimitive: "",
+					Int64Map:        map[string]int64{"a": int64(123)},
+					TimeStamp:       time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
+					Duration:        10 * time.Second,
+				},
+			},
 		},
 		{
 			name: "ProcessError",


### PR DESCRIPTION
Test the Mixer's behavior when attribute is absent at runtime and evaluated expr is empty string `""`.

Generated code was causing a panic because expression Eval was return nil in case of empty string.
This is now fixed with pending [pr/1523](https://github.com/istio/mixer/pull/1523/files), which I have applied to this PR). Therefore, please ignore all the changes under pkg/il as they are reviewed inside a separate [pr 1523](https://github.com/istio/mixer/pull/1523/files). In this PR I am just adding a test to ensuring we have a test for the panic reported by users.

**Release note**:
NONE
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/mixer/1541)
<!-- Reviewable:end -->
